### PR TITLE
fix: properly export types for Components

### DIFF
--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -1,3 +1,5 @@
+import { MaybeRefOrGetter } from 'vue';
+
 export type Numberish = number | `${number}`;
 
 export type AriaLabelProps = {
@@ -62,3 +64,7 @@ export type Getter<T> = () => T;
 export type Orientation = 'horizontal' | 'vertical';
 
 export type Direction = 'ltr' | 'rtl';
+
+export type Reactivify<TProps extends object, Exclude extends keyof TProps = never> = {
+  [TProp in keyof TProps]: TProp extends Exclude ? TProps[TProp] : MaybeRefOrGetter<TProps[TProp]>;
+};

--- a/packages/core/src/useCheckbox/useCheckbox.ts
+++ b/packages/core/src/useCheckbox/useCheckbox.ts
@@ -1,18 +1,19 @@
-import { MaybeRefOrGetter, Ref, computed, inject, ref, toValue } from 'vue';
+import { Ref, computed, inject, ref, toValue } from 'vue';
 import { uniqId, withRefCapture } from '../utils/common';
-import { AriaLabelableProps, InputBaseAttributes, RovingTabIndex } from '../types';
+import { AriaLabelableProps, Reactivify, InputBaseAttributes, RovingTabIndex } from '../types';
 import { useLabel } from '../composables/useLabel';
 import { CheckboxGroupContext, CheckboxGroupKey } from './useCheckboxGroup';
 import { useFieldValue } from '../composables/useFieldValue';
 import { useSyncModel } from '../composables/useModelSync';
 
 export interface CheckboxProps<TValue = string> {
-  name?: MaybeRefOrGetter<string>;
-  label?: MaybeRefOrGetter<string>;
-  disabled?: MaybeRefOrGetter<boolean>;
-  trueValue?: MaybeRefOrGetter<TValue>;
-  falseValue?: MaybeRefOrGetter<TValue>;
-  indeterminate?: MaybeRefOrGetter<boolean>;
+  name?: string;
+  label?: string;
+  modelValue?: TValue;
+  disabled?: boolean;
+  trueValue?: TValue;
+  falseValue?: TValue;
+  indeterminate?: boolean;
 }
 
 export interface CheckboxDomInputProps extends AriaLabelableProps, InputBaseAttributes {
@@ -29,7 +30,7 @@ export interface CheckboxDomProps extends AriaLabelableProps {
 }
 
 export function useCheckbox<TValue = string>(
-  props: CheckboxProps<TValue>,
+  props: Reactivify<CheckboxProps<TValue>>,
   elementRef?: Ref<HTMLInputElement | undefined>,
 ) {
   const inputId = uniqId();

--- a/packages/core/src/useCheckbox/useCheckboxGroup.ts
+++ b/packages/core/src/useCheckbox/useCheckboxGroup.ts
@@ -1,9 +1,16 @@
-import { InjectionKey, MaybeRefOrGetter, toValue, computed, onBeforeUnmount, reactive, provide } from 'vue';
+import { InjectionKey, toValue, computed, onBeforeUnmount, reactive, provide } from 'vue';
 import { useFieldValue } from '../composables/useFieldValue';
 import { useInputValidity } from '../composables/useInputValidity';
 import { useLabel } from '../composables/useLabel';
 import { useSyncModel } from '../composables/useModelSync';
-import { Orientation, AriaLabelableProps, AriaDescribableProps, AriaValidatableProps, Direction } from '../types';
+import {
+  Orientation,
+  AriaLabelableProps,
+  AriaDescribableProps,
+  AriaValidatableProps,
+  Direction,
+  Reactivify,
+} from '../types';
 import { uniqId, createDescribedByProps } from '../utils/common';
 
 export type CheckboxGroupValue<TCheckbox> = TCheckbox[];
@@ -35,17 +42,17 @@ export interface CheckboxContext {
 export const CheckboxGroupKey: InjectionKey<CheckboxGroupContext<any>> = Symbol('CheckboxGroupKey');
 
 export interface CheckboxGroupProps<TCheckbox = unknown> {
-  orientation?: MaybeRefOrGetter<Orientation>;
-  dir?: MaybeRefOrGetter<'ltr' | 'rtl'>;
-  label: MaybeRefOrGetter<string>;
-  description?: MaybeRefOrGetter<string>;
+  orientation?: Orientation;
+  dir?: 'ltr' | 'rtl';
+  label: string;
+  description?: string;
 
-  name?: MaybeRefOrGetter<string>;
-  modelValue?: MaybeRefOrGetter<CheckboxGroupValue<TCheckbox>>;
+  name?: string;
+  modelValue?: CheckboxGroupValue<TCheckbox>;
 
-  disabled?: MaybeRefOrGetter<boolean>;
-  readonly?: MaybeRefOrGetter<boolean>;
-  required?: MaybeRefOrGetter<boolean>;
+  disabled?: boolean;
+  readonly?: boolean;
+  required?: boolean;
 }
 
 interface CheckboxGroupDomProps extends AriaLabelableProps, AriaDescribableProps, AriaValidatableProps {
@@ -53,7 +60,7 @@ interface CheckboxGroupDomProps extends AriaLabelableProps, AriaDescribableProps
   dir: Direction;
 }
 
-export function useCheckboxGroup<TCheckbox>(props: CheckboxGroupProps<TCheckbox>) {
+export function useCheckboxGroup<TCheckbox>(props: Reactivify<CheckboxGroupProps<TCheckbox>>) {
   const groupId = uniqId();
   const checkboxes: CheckboxContext[] = [];
   const { labelProps, labelledByProps } = useLabel({

--- a/packages/core/src/useRadio/useRadio.ts
+++ b/packages/core/src/useRadio/useRadio.ts
@@ -1,14 +1,13 @@
-import { MaybeRefOrGetter, Ref, computed, inject, nextTick, ref, toValue } from 'vue';
+import { Ref, computed, inject, nextTick, ref, toValue } from 'vue';
 import { uniqId, withRefCapture } from '../utils/common';
-import { AriaLabelableProps, InputBaseAttributes, RovingTabIndex } from '../types';
+import { AriaLabelableProps, InputBaseAttributes, Reactivify, RovingTabIndex } from '../types';
 import { useLabel } from '../composables/useLabel';
 import { RadioGroupContext, RadioGroupKey } from './useRadioGroup';
 
 export interface RadioProps<TValue = string> {
   value: TValue;
-
-  label?: MaybeRefOrGetter<string>;
-  disabled?: MaybeRefOrGetter<boolean>;
+  label?: string;
+  disabled?: boolean;
 }
 
 export interface RadioDomInputProps extends AriaLabelableProps, InputBaseAttributes {
@@ -24,7 +23,10 @@ export interface RadioDomProps extends AriaLabelableProps {
   'aria-required'?: boolean;
 }
 
-export function useRadio<TValue = string>(props: RadioProps<TValue>, elementRef?: Ref<HTMLInputElement | undefined>) {
+export function useRadio<TValue = string>(
+  props: Reactivify<RadioProps<TValue>>,
+  elementRef?: Ref<HTMLInputElement | undefined>,
+) {
   const inputId = uniqId();
   const group: RadioGroupContext<TValue> | null = inject(RadioGroupKey, null);
   const inputRef = elementRef || ref<HTMLInputElement>();
@@ -38,12 +40,12 @@ export function useRadio<TValue = string>(props: RadioProps<TValue>, elementRef?
   function createHandlers(isInput: boolean) {
     const baseHandlers = {
       onClick() {
-        group?.setValue(props.value);
+        group?.setValue(toValue(props.value));
       },
       onKeydown(e: KeyboardEvent) {
         if (e.code === 'Space') {
           e.preventDefault();
-          group?.setValue(props.value);
+          group?.setValue(toValue(props.value));
         }
       },
     };
@@ -86,7 +88,7 @@ export function useRadio<TValue = string>(props: RadioProps<TValue>, elementRef?
     isChecked: () => checked.value,
     isDisabled,
     setChecked: () => {
-      group?.setValue(props.value);
+      group?.setValue(toValue(props.value));
       focus();
       nextTick(() => {
         group?.setValidity(inputRef.value?.validationMessage ?? '');

--- a/packages/core/src/useRadio/useRadioGroup.ts
+++ b/packages/core/src/useRadio/useRadioGroup.ts
@@ -1,9 +1,16 @@
-import { InjectionKey, MaybeRefOrGetter, toValue, computed, onBeforeUnmount, reactive, provide } from 'vue';
+import { InjectionKey, toValue, computed, onBeforeUnmount, reactive, provide } from 'vue';
 import { useFieldValue } from '../composables/useFieldValue';
 import { useInputValidity } from '../composables/useInputValidity';
 import { useLabel } from '../composables/useLabel';
 import { useSyncModel } from '../composables/useModelSync';
-import { Orientation, AriaLabelableProps, AriaDescribableProps, AriaValidatableProps, Direction } from '../types';
+import {
+  Orientation,
+  AriaLabelableProps,
+  AriaDescribableProps,
+  AriaValidatableProps,
+  Direction,
+  Reactivify,
+} from '../types';
 import { uniqId, createDescribedByProps, getNextCycleArrIdx } from '../utils/common';
 
 export interface RadioGroupContext<TValue> {
@@ -28,17 +35,17 @@ export interface RadioItemContext {
 export const RadioGroupKey: InjectionKey<RadioGroupContext<any>> = Symbol('RadioGroupKey');
 
 export interface RadioGroupProps<TValue = string> {
-  orientation?: MaybeRefOrGetter<Orientation>;
-  dir?: MaybeRefOrGetter<'ltr' | 'rtl'>;
-  label: MaybeRefOrGetter<string>;
-  description?: MaybeRefOrGetter<string>;
+  orientation?: Orientation;
+  dir?: 'ltr' | 'rtl';
+  label: string;
+  description?: string;
 
-  name?: MaybeRefOrGetter<string>;
-  modelValue?: MaybeRefOrGetter<TValue>;
+  name?: string;
+  modelValue?: TValue;
 
-  disabled?: MaybeRefOrGetter<boolean>;
-  readonly?: MaybeRefOrGetter<boolean>;
-  required?: MaybeRefOrGetter<boolean>;
+  disabled?: boolean;
+  readonly?: boolean;
+  required?: boolean;
 }
 
 interface RadioGroupDomProps extends AriaLabelableProps, AriaDescribableProps, AriaValidatableProps {
@@ -52,7 +59,7 @@ const ORIENTATION_ARROWS: Record<Orientation, Record<Direction, string[]>> = {
   vertical: { ltr: ['ArrowUp', 'ArrowDown'], rtl: ['ArrowUp', 'ArrowDown'] },
 };
 
-export function useRadioGroup<TValue = string>(props: RadioGroupProps<TValue>) {
+export function useRadioGroup<TValue = string>(props: Reactivify<RadioGroupProps<TValue>>) {
   const groupId = uniqId();
   const getOrientationArrows = () =>
     ORIENTATION_ARROWS[toValue(props.orientation) ?? 'vertical'][toValue(props.dir) || 'ltr'];

--- a/packages/core/src/useSearchField/index.ts
+++ b/packages/core/src/useSearchField/index.ts
@@ -1,10 +1,11 @@
-import { MaybeRefOrGetter, Ref, computed, ref, toValue } from 'vue';
+import { Ref, computed, ref, toValue } from 'vue';
 import {
   AriaDescribableProps,
   AriaLabelableProps,
   AriaValidatableProps,
   InputEvents,
   Numberish,
+  Reactivify,
   TextInputBaseAttributes,
 } from '../types';
 import { createDescribedByProps, propsToValues, uniqId, withRefCapture } from '../utils/common';
@@ -27,26 +28,25 @@ export interface SearchInputDOMProps
 }
 
 export interface SearchFieldProps {
-  label: MaybeRefOrGetter<string>;
-  modelValue?: MaybeRefOrGetter<string>;
-  description?: MaybeRefOrGetter<string>;
+  label: string;
+  modelValue?: string;
+  description?: string;
+  // TODO: Vue cannot resolve these types if they are mapped from up there
+  name?: string;
+  value?: string;
+  maxLength?: Numberish;
+  minLength?: Numberish;
+  pattern?: string | undefined;
+  placeholder?: string | undefined;
+
+  required?: boolean;
+  readonly?: boolean;
+  disabled?: boolean;
 
   onSubmit?: (value: string) => void;
-
-  // TODO: Vue cannot resolve these types if they are mapped from up there
-  name?: MaybeRefOrGetter<string>;
-  value?: MaybeRefOrGetter<string>;
-  maxLength?: MaybeRefOrGetter<Numberish>;
-  minLength?: MaybeRefOrGetter<Numberish>;
-  pattern?: MaybeRefOrGetter<string | undefined>;
-  placeholder?: MaybeRefOrGetter<string | undefined>;
-
-  required?: MaybeRefOrGetter<boolean>;
-  readonly?: MaybeRefOrGetter<boolean>;
-  disabled?: MaybeRefOrGetter<boolean>;
 }
 
-export function useSearchField(props: SearchFieldProps, elementRef?: Ref<HTMLInputElement>) {
+export function useSearchField(props: Reactivify<SearchFieldProps, 'onSubmit'>, elementRef?: Ref<HTMLInputElement>) {
   const inputId = uniqId();
   const inputRef = elementRef || ref<HTMLInputElement>();
 

--- a/packages/core/src/useSlider/slider.ts
+++ b/packages/core/src/useSlider/slider.ts
@@ -1,20 +1,20 @@
-import { InjectionKey, MaybeRefOrGetter, computed, onBeforeUnmount, provide, ref, toValue } from 'vue';
+import { InjectionKey, computed, onBeforeUnmount, provide, ref, toValue } from 'vue';
 import { useLabel } from '../composables/useLabel';
-import { AriaLabelableProps, Orientation } from '../types';
+import { AriaLabelableProps, Orientation, Reactivify } from '../types';
 import { uniqId, withRefCapture } from '../utils/common';
 import { toNearestMultipleOf } from '../utils/math';
 import { useSyncModel } from '../composables/useModelSync';
 
 export interface SliderProps {
-  label?: MaybeRefOrGetter<string>;
+  label?: string;
 
-  orientation?: MaybeRefOrGetter<Orientation>;
-  dir?: MaybeRefOrGetter<'ltr' | 'rtl'>;
-  modelValue?: MaybeRefOrGetter<number | number[]>;
-  min?: MaybeRefOrGetter<number>;
-  max?: MaybeRefOrGetter<number>;
+  orientation?: Orientation;
+  dir?: 'ltr' | 'rtl';
+  modelValue?: number | number[];
+  min?: number;
+  max?: number;
 
-  step?: MaybeRefOrGetter<number>;
+  step?: number;
 }
 
 export type Coordinate = { x: number; y: number };
@@ -73,7 +73,7 @@ export interface SliderContext {
 
 export const SliderInjectionKey: InjectionKey<SliderContext> = Symbol('Slider');
 
-export function useSlider(props: SliderProps) {
+export function useSlider(props: Reactivify<SliderProps>) {
   const inputId = uniqId();
   const trackRef = ref<HTMLElement>();
   const thumbs = ref<ThumbContext[]>([]);

--- a/packages/core/src/useSlider/thumb.ts
+++ b/packages/core/src/useSlider/thumb.ts
@@ -1,12 +1,12 @@
-import { MaybeRefOrGetter, Ref, computed, inject, ref, toValue } from 'vue';
+import { Ref, computed, inject, ref, toValue } from 'vue';
 import { SliderContext, SliderInjectionKey, ThumbContext } from './slider';
 import { withRefCapture } from '../utils/common';
 import { useFieldValue } from '../composables/useFieldValue';
-import { Direction } from '../types';
+import { Direction, Reactivify } from '../types';
 
 export interface SliderThumbProps {
-  label?: MaybeRefOrGetter<string>;
-  modelValue?: MaybeRefOrGetter<number>;
+  label?: string;
+  modelValue?: number;
 }
 
 const mockSlider: () => SliderContext = () => ({
@@ -23,7 +23,7 @@ const mockSlider: () => SliderContext = () => ({
 
 const PAGE_KEY_MULTIPLIER = 10;
 
-export function useSliderThumb(props: SliderThumbProps, elementRef?: Ref<HTMLElement>) {
+export function useSliderThumb(props: Reactivify<SliderThumbProps>, elementRef?: Ref<HTMLElement>) {
   const thumbRef = elementRef || ref<HTMLElement>();
   const isDragging = ref(false);
   const { fieldValue } = useFieldValue(toValue(props.modelValue) ?? 0);

--- a/packages/core/src/useSwitch/index.ts
+++ b/packages/core/src/useSwitch/index.ts
@@ -1,5 +1,5 @@
-import { MaybeRefOrGetter, Ref, computed, shallowRef, toValue } from 'vue';
-import { AriaDescribableProps, AriaLabelableProps, InputBaseAttributes, InputEvents } from '../types';
+import { Ref, computed, shallowRef, toValue } from 'vue';
+import { AriaDescribableProps, AriaLabelableProps, InputBaseAttributes, InputEvents, Reactivify } from '../types';
 import { uniqId, withRefCapture } from '../utils/common';
 import { useFieldValue } from '../composables/useFieldValue';
 import { useLabel } from '../composables/useLabel';
@@ -13,18 +13,18 @@ export interface SwitchDOMProps extends InputBaseAttributes, AriaLabelableProps,
 }
 
 export type SwitchProps = {
-  label?: MaybeRefOrGetter<string>;
-  name?: MaybeRefOrGetter<string>;
-  modelValue?: MaybeRefOrGetter<boolean>;
+  label?: string;
+  name?: string;
+  modelValue?: boolean;
 
-  readonly?: MaybeRefOrGetter<boolean>;
-  disabled?: MaybeRefOrGetter<boolean>;
+  readonly?: boolean;
+  disabled?: boolean;
 
-  trueValue?: MaybeRefOrGetter<unknown>;
-  falseValue?: MaybeRefOrGetter<unknown>;
+  trueValue?: unknown;
+  falseValue?: unknown;
 };
 
-export function useSwitch(props: SwitchProps, elementRef?: Ref<HTMLInputElement>) {
+export function useSwitch(props: Reactivify<SwitchProps>, elementRef?: Ref<HTMLInputElement>) {
   const id = uniqId();
   const inputRef = elementRef || shallowRef<HTMLInputElement>();
   const { labelProps, labelledByProps } = useLabel({

--- a/packages/core/src/useTextField/index.ts
+++ b/packages/core/src/useTextField/index.ts
@@ -1,4 +1,4 @@
-import { MaybeRefOrGetter, Ref, computed, shallowRef, toValue } from 'vue';
+import { Ref, computed, shallowRef, toValue } from 'vue';
 import { createDescribedByProps, propsToValues, uniqId, withRefCapture } from '../utils/common';
 import {
   AriaDescribableProps,
@@ -7,6 +7,7 @@ import {
   InputEvents,
   AriaValidatableProps,
   Numberish,
+  Reactivify,
 } from '../types/common';
 import { useSyncModel } from '../composables/useModelSync';
 import { useInputValidity } from '../composables/useInputValidity';
@@ -29,25 +30,28 @@ export interface TextInputDOMProps
 }
 
 export interface TextFieldProps {
-  label: MaybeRefOrGetter<string>;
-  modelValue?: MaybeRefOrGetter<string>;
-  description?: MaybeRefOrGetter<string>;
+  label: string;
+  modelValue?: string;
+  description?: string;
 
   // TODO: Vue cannot resolve these types if they are mapped from up there
-  name?: MaybeRefOrGetter<string>;
-  value?: MaybeRefOrGetter<string>;
-  type?: MaybeRefOrGetter<TextInputDOMType>;
-  maxLength?: MaybeRefOrGetter<Numberish>;
-  minLength?: MaybeRefOrGetter<Numberish>;
-  pattern?: MaybeRefOrGetter<string | undefined>;
-  placeholder?: MaybeRefOrGetter<string | undefined>;
+  name?: string;
+  value?: string;
+  type?: TextInputDOMType;
+  maxLength?: Numberish;
+  minLength?: Numberish;
+  pattern?: string | undefined;
+  placeholder?: string | undefined;
 
-  required?: MaybeRefOrGetter<boolean>;
-  readonly?: MaybeRefOrGetter<boolean>;
-  disabled?: MaybeRefOrGetter<boolean>;
+  required?: boolean;
+  readonly?: boolean;
+  disabled?: boolean;
 }
 
-export function useTextField(props: TextFieldProps, elementRef?: Ref<HTMLInputElement | HTMLTextAreaElement>) {
+export function useTextField(
+  props: Reactivify<TextFieldProps>,
+  elementRef?: Ref<HTMLInputElement | HTMLTextAreaElement>,
+) {
   const inputId = uniqId();
   const inputRef = elementRef || shallowRef<HTMLInputElement>();
   const { fieldValue } = useFieldValue<string>(toValue(props.modelValue));


### PR DESCRIPTION
# What

To make Vue compiler pick up the component types correctly and at the same time expose them as composable options, I considered the following solutions:

1. **Manually duplicate props and composable options**: Too manual.
2. **Use a mapped type `Propify` to convert `MaybeRefOrGetter` to their underlying types:** Doesn't work because Vue compiler won't process mapped type resulting in the same issue.

However doing the inverse of `#2` will work, we can expose the basic interface prop types and make its properties `MaybeRefOrGetter` using a mapped type `Reactivify`:

```ts
export type Reactivify<TProps extends object, Exclude extends keyof TProps = never> = {
  [TProp in keyof TProps]: TProp extends Exclude ? TProps[TProp] : MaybeRefOrGetter<TProps[TProp]>;
};
```

By adding the `Exclude` option it also allows us to maintain certain options like functions/callbacks without wrapping them. This solution became obvious once I noticed all our composables exclusively use `MaybeRefOrGetter` for all their properties save for two cases which are easily handled by the `Exclude` generic arg.

Testing this against our playground it works well and we maintain full typing information in props and in the script section as well.

closes #22