### PR TITLE
feat: mask away the field errors if it is disabled

### DIFF
--- a/.changeset/metal-suits-wonder.md
+++ b/.changeset/metal-suits-wonder.md
@@ -1,0 +1,5 @@
+---
+'@formwerk/core': minor
+---
+
+feat!: disabled fields no longer particpate in form validation state

--- a/packages/core/src/useForm/useForm.ts
+++ b/packages/core/src/useForm/useForm.ts
@@ -101,7 +101,7 @@ export function useForm<
   const isHtmlValidationDisabled = () => props?.disableHtmlValidation ?? getConfig().disableHtmlValidation;
   const values = reactive(cloneDeep(valuesSnapshot.originals.value)) as PartialDeep<TInput>;
   const touched = reactive(cloneDeep(touchedSnapshot.originals.value)) as TouchedSchema<TInput>;
-  const disabled = {} as DisabledSchema<TInput>;
+  const disabled = reactive({}) as DisabledSchema<TInput>;
   const errors = ref({}) as Ref<ErrorsSchema<TInput>>;
 
   const ctx = createFormContext<TInput, TOutput>({
@@ -145,11 +145,11 @@ export function useForm<
   }
 
   function getError<TPath extends Path<TInput>>(path: TPath): string | undefined {
-    return ctx.getFieldErrors(path)[0];
+    return ctx.isPathDisabled(path) ? undefined : ctx.getFieldErrors(path)[0];
   }
 
   function displayError(path: Path<TInput>) {
-    return ctx.isFieldTouched(path) ? getError(path) : undefined;
+    return ctx.isFieldTouched(path) && !ctx.isPathDisabled(path) ? getError(path) : undefined;
   }
 
   provide(FormKey, {

--- a/packages/core/src/useFormField/useFormField.spec.ts
+++ b/packages/core/src/useFormField/useFormField.spec.ts
@@ -1,6 +1,7 @@
 import { renderSetup, defineStandardSchema } from '@test-utils/index';
-import { useFormField } from './useFormField';
+import { exposeField, useFormField } from './useFormField';
 import { useForm } from '../useForm/useForm';
+import { ref } from 'vue';
 
 test('it initializes the field value', async () => {
   const { fieldValue } = await renderSetup(() => {
@@ -130,20 +131,68 @@ test('can have a typed schema for validation', async () => {
   expect(errors.value).toEqual(['error']);
 });
 
-// test('can have a typed schema for initial value', async () => {
-//   const { fieldValue } = await renderSetup(() => {
-//     return useFormField({
-//       schema: {
-//         parse: async () => {
-//           return { errors: [] };
-//         },
-//         defaults(value) {
-//           return value || 'default';
-//         },
-//       },
-//     });
-//   });
+test('disabled fields report isValid as true and errors as empty after being invalid', async () => {
+  const disabled = ref(false);
+  const { validate, isValid, errors, errorMessage } = await renderSetup(() => {
+    return useFormField({
+      initialValue: 'bar',
+      disabled,
+      schema: defineStandardSchema(async () => {
+        return { issues: [{ message: 'error', path: ['field'] }] };
+      }),
+    });
+  });
 
-//   await nextTick();
-//   expect(fieldValue.value).toEqual('default');
-// });
+  // Initially validate to make the field invalid
+  await validate(true);
+  expect(isValid.value).toBe(false);
+  expect(errors.value).toEqual(['error']);
+  expect(errorMessage.value).toBe('error');
+
+  // Disable the field
+  disabled.value = true;
+
+  // Check the state after disabling
+  expect(isValid.value).toBe(true);
+  expect(errors.value).toEqual([]);
+  expect(errorMessage.value).toBe('');
+});
+
+test('setErrors warns when trying to set errors on a disabled field', async () => {
+  const disabled = ref(true);
+  const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const { isValid, errors, errorMessage, setErrors } = await renderSetup(() => {
+    return exposeField(
+      {},
+      useFormField({
+        initialValue: 'bar',
+        disabled,
+        schema: defineStandardSchema(async () => {
+          return { issues: [{ message: 'error', path: ['field'] }] };
+        }),
+      }),
+    );
+  });
+
+  // Attempt to set errors on a disabled field
+  setErrors('error');
+
+  // Check that a warning was logged
+  expect(consoleWarnSpy).toHaveBeenCalledOnce();
+
+  // Check the state, errors should not be set
+  expect(isValid.value).toBe(true);
+  expect(errors.value).toEqual([]);
+  expect(errorMessage.value).toBe('');
+
+  // Enable the field
+  disabled.value = false;
+
+  // Check the state, errors should be set
+  expect(isValid.value).toBe(false);
+  expect(errors.value).toEqual(['error']);
+  expect(errorMessage.value).toBe('error');
+
+  // Clean up the mock
+  consoleWarnSpy.mockRestore();
+});

--- a/packages/core/src/useFormField/useFormField.spec.ts
+++ b/packages/core/src/useFormField/useFormField.spec.ts
@@ -196,3 +196,33 @@ test('setErrors warns when trying to set errors on a disabled field', async () =
   // Clean up the mock
   consoleWarnSpy.mockRestore();
 });
+
+test('validate warns and skips validation on a disabled field', async () => {
+  const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  const schemaSpy = vi.fn(async () => {
+    return { issues: [{ message: 'error', path: ['field'] }] };
+  });
+
+  const { validate, errors } = await renderSetup(() => {
+    return useFormField({
+      initialValue: 'bar',
+      disabled: true,
+      schema: defineStandardSchema(schemaSpy),
+    });
+  });
+
+  // Attempt to validate the disabled field
+  await validate(true);
+
+  // Check that a warning was logged
+  expect(consoleWarnSpy).toHaveBeenCalledOnce();
+
+  // Ensure no errors were set
+  expect(errors.value).toEqual([]);
+
+  // Ensure the schema function was not called
+  expect(schemaSpy).not.toHaveBeenCalled();
+
+  // Clean up the mocks
+  consoleWarnSpy.mockRestore();
+});

--- a/packages/core/src/useFormField/useFormField.spec.ts
+++ b/packages/core/src/useFormField/useFormField.spec.ts
@@ -220,8 +220,8 @@ test('validate warns and skips validation on a disabled field', async () => {
   // Ensure no errors were set
   expect(errors.value).toEqual([]);
 
-  // Ensure the schema function was not called
-  expect(schemaSpy).not.toHaveBeenCalled();
+  // Ensure the schema function was called because we don't want the integrity of the schema to be compromised
+  expect(schemaSpy).toHaveBeenCalled();
 
   // Clean up the mocks
   consoleWarnSpy.mockRestore();

--- a/packages/core/src/useFormField/useFormField.ts
+++ b/packages/core/src/useFormField/useFormField.ts
@@ -83,16 +83,16 @@ export function useFormField<TValue = unknown>(opts?: Partial<FormFieldOptions<T
 
   async function validate(mutate?: boolean): Promise<ValidationResult> {
     const schema = opts?.schema;
-    if (!schema || isDisabled.value) {
-      if (__DEV__) {
-        if (isDisabled.value) {
-          warn('Field is disabled, skipping validation call');
-        }
-      }
-
+    if (!schema) {
       return Promise.resolve(
         createValidationResult({ isValid: true, errors: [], output: cloneDeep(fieldValue.value) }),
       );
+    }
+
+    if (__DEV__) {
+      if (isDisabled.value) {
+        warn('Field is disabled, the validation call will not have an immediate effect.');
+      }
     }
 
     const result = await schema['~standard']['validate'](fieldValue.value);

--- a/packages/core/src/useFormField/useFormField.ts
+++ b/packages/core/src/useFormField/useFormField.ts
@@ -83,7 +83,13 @@ export function useFormField<TValue = unknown>(opts?: Partial<FormFieldOptions<T
 
   async function validate(mutate?: boolean): Promise<ValidationResult> {
     const schema = opts?.schema;
-    if (!schema) {
+    if (!schema || isDisabled.value) {
+      if (__DEV__) {
+        if (isDisabled.value) {
+          warn('Field is disabled, skipping validation call');
+        }
+      }
+
       return Promise.resolve(
         createValidationResult({ isValid: true, errors: [], output: cloneDeep(fieldValue.value) }),
       );

--- a/packages/core/src/useFormField/useFormField.ts
+++ b/packages/core/src/useFormField/useFormField.ts
@@ -2,7 +2,7 @@ import { computed, inject, MaybeRefOrGetter, nextTick, readonly, Ref, shallowRef
 import { FormContext, FormKey } from '../useForm/useForm';
 import { Arrayable, Getter, StandardSchema, ValidationResult } from '../types';
 import { useSyncModel } from '../reactivity/useModelSync';
-import { cloneDeep, isEqual, normalizeArrayable, combineIssues, tryOnScopeDispose } from '../utils/common';
+import { cloneDeep, isEqual, normalizeArrayable, combineIssues, tryOnScopeDispose, warn } from '../utils/common';
 import { FormGroupKey } from '../useFormGroup';
 import { useErrorDisplay } from './useErrorDisplay';
 import { usePathPrefixer } from '../helpers/usePathPrefixer';
@@ -49,7 +49,7 @@ export function useFormField<TValue = unknown>(opts?: Partial<FormFieldOptions<T
   const initialValue = opts?.initialValue;
   const { fieldValue, pathlessValue, setValue } = useFieldValue(getPath, form, initialValue);
   const { isTouched, pathlessTouched, setTouched } = useFieldTouched(getPath, form);
-  const { errors, setErrors, isValid, errorMessage, pathlessValidity } = useFieldValidity(getPath, form);
+  const { errors, setErrors, isValid, errorMessage, pathlessValidity } = useFieldValidity(getPath, isDisabled, form);
   const { displayError } = useErrorDisplay(errorMessage, isTouched);
 
   const isDirty = computed(() => {
@@ -182,13 +182,14 @@ export function useFormField<TValue = unknown>(opts?: Partial<FormFieldOptions<T
   return field;
 }
 
-function useFieldValidity(getPath: Getter<string | undefined>, form?: FormContext | null) {
+function useFieldValidity(getPath: Getter<string | undefined>, isDisabled: Ref<boolean>, form?: FormContext | null) {
   const validity = form ? createFormValidityRef(getPath, form) : createLocalValidity();
-  const errorMessage = computed(() => validity.errors.value[0] ?? '');
-  const isValid = computed(() => validity.errors.value.length === 0);
+  const errorMessage = computed(() => (isDisabled.value ? '' : (validity.errors.value[0] ?? '')));
+  const isValid = computed(() => (isDisabled.value ? true : validity.errors.value.length === 0));
 
   return {
     ...validity,
+    errors: computed(() => (isDisabled.value ? [] : validity.errors.value)),
     isValid,
     errorMessage,
   };
@@ -420,7 +421,15 @@ export function exposeField<TReturns extends object, TValue>(
     isTouched: field.isTouched,
     isValid: field.isValid,
     isDisabled: field.isDisabled,
-    setErrors: field.setErrors,
+    setErrors: __DEV__
+      ? (messages: Arrayable<string>) => {
+          if (field.isDisabled.value) {
+            warn('This field is disabled, setting errors will not take effect until the field is enabled.');
+          }
+
+          field.setErrors(messages);
+        }
+      : field.setErrors,
     setTouched: field.setTouched,
     setValue: field.setValue,
   } satisfies ExposedField<TValue>;

--- a/packages/core/src/validation/useInputValidity.ts
+++ b/packages/core/src/validation/useInputValidity.ts
@@ -106,11 +106,9 @@ export function useInputValidity(opts: InputValidityOptions) {
 
   useEventListener(opts.inputEl, opts?.events || ['change', 'blur'], updateValidity);
 
-  watch(opts.field.isDisabled, async state => {
-    if (!state) {
-      await nextTick();
-      validateNative(true);
-    }
+  watch(opts.field.isDisabled, async () => {
+    await nextTick();
+    validateNative(true);
   });
 
   // It shouldn't mutate the field if the validation is sourced by the form.

--- a/packages/core/src/validation/useInputValidity.ts
+++ b/packages/core/src/validation/useInputValidity.ts
@@ -106,6 +106,13 @@ export function useInputValidity(opts: InputValidityOptions) {
 
   useEventListener(opts.inputEl, opts?.events || ['change', 'blur'], updateValidity);
 
+  watch(opts.field.isDisabled, async state => {
+    if (!state) {
+      await nextTick();
+      validateNative(true);
+    }
+  });
+
   // It shouldn't mutate the field if the validation is sourced by the form.
   // The form will handle the mutation later once it aggregates all the results.
   (formGroup || form)?.onValidationDispatch(enqueue => {

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -15,8 +15,10 @@ import {
   CheckboxGroup,
   Radio,
 } from '@starter/minimal/index';
+import { ref } from 'vue';
 
-const { handleSubmit } = useForm({
+const disabled = ref(false);
+const { handleSubmit, isValid, getError, getErrors } = useForm({
   scrollToInvalidFieldOnSubmit: {
     behavior: 'instant',
     block: 'center',
@@ -27,12 +29,22 @@ const { handleSubmit } = useForm({
 const onSubmit = handleSubmit(data => {
   console.log(data);
 });
+
+const toggleDisabled = () => {
+  disabled.value = !disabled.value;
+};
 </script>
 
 <template>
   <div class="flex flex-col">
-    <TextField name="text" label="Text" required />
-    <SearchField name="search" label="Search" required />
+    <button type="button" @click="toggleDisabled">Toggle Disabled</button>
+    <TextField name="text" label="Text" required :disabled="disabled" />
+
+    {{ isValid }}
+    {{ getError('text') }}
+    {{ getErrors() }}
+
+    <!-- <SearchField name="search" label="Search" required />
 
     <Checkbox name="checkbox" label="Checkbox" required />
 
@@ -63,7 +75,7 @@ const onSubmit = handleSubmit(data => {
 
     <FormRepeater name="formRepeater" label="Form Repeater" required>
       <TextField name="formRepeater" label="Text" required />
-    </FormRepeater>
+    </FormRepeater> -->
 
     <button class="bg-blue-500 text-white p-2 rounded-md" @click="onSubmit">Submit</button>
   </div>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -73,8 +73,8 @@ const toggleDisabled = () => {
       <TextField name="formRepeater" label="Text" required />
     </FormRepeater> -->
 
-    <FormGroup name="formGroup" label="Form Group" required>
-      <TextField name="formGroup" label="Text" required :disabled="disabled" />
+    <FormGroup name="formGroup" label="Form Group" :disabled="disabled">
+      <TextField name="formGroup" label="Text" required />
     </FormGroup>
 
     <button class="bg-blue-500 text-white p-2 rounded-md" @click="onSubmit">Submit</button>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -38,7 +38,7 @@ const toggleDisabled = () => {
 <template>
   <div class="flex flex-col">
     <button type="button" @click="toggleDisabled">Toggle Disabled</button>
-    <TextField name="text" label="Text" required :disabled="disabled" />
+    <TextField name="text" label="Text" required />
 
     {{ isValid }}
     {{ getError('text') }}
@@ -69,13 +69,13 @@ const toggleDisabled = () => {
 
     <Slider name="slider" label="Slider" required />
 
-    <FormGroup name="formGroup" label="Form Group" required>
-      <TextField name="formGroup" label="Text" required />
-    </FormGroup>
-
     <FormRepeater name="formRepeater" label="Form Repeater" required>
       <TextField name="formRepeater" label="Text" required />
     </FormRepeater> -->
+
+    <FormGroup name="formGroup" label="Form Group" required>
+      <TextField name="formGroup" label="Text" required :disabled="disabled" />
+    </FormGroup>
 
     <button class="bg-blue-500 text-white p-2 rounded-md" @click="onSubmit">Submit</button>
   </div>

--- a/packages/playground/tailwind.config.js
+++ b/packages/playground/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ['./src/**/*.html', './src/**/*.vue', './src/**/*.ts', './index.html'],
+  content: ['./src/**/*.html', './src/App.vue', './src/**/*.vue', './src/**/*.ts', './index.html'],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## What
When using default HTML validation, disabled fields are not validated and they do not contribute to the form's validation state.

We should do the same and extend that to standard schema as well, however the approach is tricky since we have a lot of getters/setters for the form/field validity.

## How

I have decided to go with masking validation state with computed properties, this has the benefit when a field is un-disabled, the error state will become available without having to re-validate. Also it allows fields. This will need to be tested thoroughly as Form/Group/Field validity states all need to match and sync with the disabled state.

## Caveats

- How can the user query the current errors, even if a field is disabled?
- Should the form `getErrors` return the disabled errors as well?