### PR TITLE
feat: Expose the `validate` function on custom fields

### DIFF
--- a/.changeset/silver-berries-taste.md
+++ b/.changeset/silver-berries-taste.md
@@ -1,0 +1,5 @@
+---
+'@formwerk/core': patch
+---
+
+feat: Expose the validate function on custom fields

--- a/packages/core/src/useCustomField/useCustomField.spec.ts
+++ b/packages/core/src/useCustomField/useCustomField.spec.ts
@@ -174,26 +174,26 @@ describe('useCustomField', () => {
   });
 
   describe('validation', () => {
-    test('validates the field', async () => {
-      const schema: StandardSchema<string, string> = {
-        '~standard': {
-          vendor: 'formwerk',
-          version: 1,
-          validate: value => {
-            const strValue = value ? String(value) : undefined;
-            if (!strValue || strValue.length < 0) {
-              return {
-                issues: [{ path: [], message: 'Value is required' }],
-              };
-            }
-
+    const schema: StandardSchema<string, string> = {
+      '~standard': {
+        vendor: 'formwerk',
+        version: 1,
+        validate: value => {
+          const strValue = value ? String(value) : undefined;
+          if (!strValue || strValue.length < 0) {
             return {
-              value: strValue,
+              issues: [{ path: [], message: 'Value is required' }],
             };
-          },
-        },
-      };
+          }
 
+          return {
+            value: strValue,
+          };
+        },
+      },
+    };
+
+    test('validates the field and updates the error message', async () => {
       const { validate, errorMessage } = await renderSetup(() => {
         const { validate, errorMessage } = useCustomField({ label: 'Custom Field', schema });
 
@@ -202,8 +202,19 @@ describe('useCustomField', () => {
 
       expect(errorMessage.value).toBe('');
       await validate();
-      await flush();
       expect(errorMessage.value).toBe('Value is required');
+    });
+
+    test('does not mutate the field errors when validate is called with false', async () => {
+      const { validate, errorMessage } = await renderSetup(() => {
+        const { validate, errorMessage } = useCustomField({ label: 'Custom Field', schema });
+
+        return { validate, errorMessage };
+      });
+
+      expect(errorMessage.value).toBe('');
+      await validate(false);
+      expect(errorMessage.value).toBe('');
     });
   });
 });

--- a/packages/core/src/useCustomField/useCustomField.ts
+++ b/packages/core/src/useCustomField/useCustomField.ts
@@ -113,6 +113,10 @@ export function useCustomField<TValue = unknown>(
        * Props for the control element/group.
        */
       controlProps,
+      /**
+       * Validates the field, pass `false` to not mutate the field errors.
+       */
+      validate: (mutate = true) => field.validate(mutate),
     },
     field,
   );

--- a/packages/core/src/useFormField/useFormField.ts
+++ b/packages/core/src/useFormField/useFormField.ts
@@ -436,11 +436,6 @@ export type ExposedField<TValue> = {
    * Sets the value for the field.
    */
   setValue: (value: TValue) => void;
-
-  /**
-   * Validates the field.
-   */
-  validate: () => Promise<ValidationResult>;
 };
 
 export function exposeField<TReturns extends object, TValue>(
@@ -458,7 +453,6 @@ export function exposeField<TReturns extends object, TValue>(
     isTouched: field.isTouched,
     isValid: field.isValid,
     isDisabled: field.isDisabled,
-    validate: () => field.validate(true),
     setErrors: __DEV__
       ? (messages: Arrayable<string>) => {
           if (field.isDisabled.value) {

--- a/packages/core/src/useFormField/useFormField.ts
+++ b/packages/core/src/useFormField/useFormField.ts
@@ -436,6 +436,11 @@ export type ExposedField<TValue> = {
    * Sets the value for the field.
    */
   setValue: (value: TValue) => void;
+
+  /**
+   * Validates the field.
+   */
+  validate: () => Promise<ValidationResult>;
 };
 
 export function exposeField<TReturns extends object, TValue>(
@@ -453,6 +458,7 @@ export function exposeField<TReturns extends object, TValue>(
     isTouched: field.isTouched,
     isValid: field.isValid,
     isDisabled: field.isDisabled,
+    validate: () => field.validate(true),
     setErrors: __DEV__
       ? (messages: Arrayable<string>) => {
           if (field.isDisabled.value) {


### PR DESCRIPTION
Exposes the validate function on the `useCustomField` to allow for custom validation triggers.