### PR TITLE
fix: allow nesting form groups

### DIFF
--- a/.changeset/perfect-colts-bathe.md
+++ b/.changeset/perfect-colts-bathe.md
@@ -1,0 +1,5 @@
+---
+'@formwerk/core': patch
+---
+
+allow nesting form groups

--- a/packages/core/src/useFormGroup/useFormGroup.spec.ts
+++ b/packages/core/src/useFormGroup/useFormGroup.spec.ts
@@ -86,6 +86,47 @@ test('prefixes path values with its name', async () => {
   expect(form.values).toEqual({ groupTest: { field1: 'test 1' }, nestedGroup: { deep: { field2: 'test 2' } } });
 });
 
+test('nested groups', async () => {
+  let form!: ReturnType<typeof useForm>;
+  await render({
+    components: { TInput: createInputComponent(), TGroup: createGroupComponent() },
+    setup() {
+      form = useForm();
+
+      return {};
+    },
+    template: `      
+      <TGroup name="group_a">
+        <TInput name="input_a" />
+        <TGroup name="group_a_b">
+          <TInput name="input_a_b" />
+          <TGroup name="group_a_b_c">
+            <TInput name="input_a_b_c" />
+          </TGroup>
+        </TGroup>
+      </TGroup>
+    `,
+  });
+
+  await flush();
+  await fireEvent.update(screen.getByTestId('input_a'), 'input_a');
+  await fireEvent.update(screen.getByTestId('input_a_b'), 'input_a_b');
+  await fireEvent.update(screen.getByTestId('input_a_b_c'), 'input_a_b_c');
+  await flush();
+
+  expect(form.values).toEqual({
+    group_a: {
+      input_a: 'input_a',
+      group_a_b: {
+        input_a_b: 'input_a_b',
+        group_a_b_c: {
+          input_a_b_c: 'input_a_b_c',
+        },
+      },
+    },
+  });
+});
+
 test('tracks its dirty state', async () => {
   const groups: ReturnType<typeof useFormGroup>[] = [];
   await render({

--- a/packages/core/src/useFormGroup/useFormGroup.ts
+++ b/packages/core/src/useFormGroup/useFormGroup.ts
@@ -73,7 +73,9 @@ export function useFormGroup<TInput extends FormObject = FormObject, TOutput ext
 
     const prefixPath = pathPrefixer ? pathPrefixer.prefixPath(path) : path;
 
-    if (!prefixPath) return path;
+    if (!prefixPath) {
+      return path;
+    }
 
     return prefixPath;
   };

--- a/packages/core/src/useFormGroup/useFormGroup.ts
+++ b/packages/core/src/useFormGroup/useFormGroup.ts
@@ -15,7 +15,7 @@ import { useValidationProvider } from '../validation/useValidationProvider';
 import { FormValidationMode } from '../useForm/formContext';
 import { prefixPath as _prefixPath } from '../utils/path';
 import { getConfig } from '../config';
-import { createPathPrefixer } from '../helpers/usePathPrefixer';
+import { createPathPrefixer, usePathPrefixer } from '../helpers/usePathPrefixer';
 import { createDisabledContext } from '../helpers/createDisabledContext';
 
 export interface FormGroupProps<TInput extends FormObject = FormObject, TOutput extends FormObject = TInput> {
@@ -66,7 +66,17 @@ export function useFormGroup<TInput extends FormObject = FormObject, TOutput ext
 ) {
   const id = useUniqId(FieldTypePrefixes.FormGroup);
   const props = normalizeProps(_props, ['schema']);
-  const getPath = () => toValue(props.name);
+  const pathPrefixer = usePathPrefixer();
+
+  const getPath = () => {
+    const path = toValue(_props.name);
+
+    const prefixPath = pathPrefixer ? pathPrefixer.prefixPath(path) : path;
+
+    if (!prefixPath) return path;
+
+    return prefixPath;
+  };
   const groupEl = elementRef || shallowRef<HTMLInputElement>();
   const form = inject(FormKey, null);
   const isDisabled = createDisabledContext(props.disabled);


### PR DESCRIPTION
Fixes #110 

This PR allows creating nested form groups like so:

```html
<FormGroup name="account" label="Account">
      <InputText name="name" label="Account Name" />
      <FormGroup name="company" label="Company">
        <InputText name="name" label="Company Name" />
        <FormGroup name="address" label="Address">
          <InputText name="name" label="Street Name" />
        </FormGroup>
      </FormGroup>
    </FormGroup>
```