### PR TITLE
feat: Implement `useDateField` with Temporals API

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,7 @@
     "dist/*.d.ts"
   ],
   "dependencies": {
+    "@js-temporal/polyfill": "^0.4.4",
     "@standard-schema/spec": "1.0.0",
     "@standard-schema/utils": "^0.3.0",
     "klona": "^2.0.6",

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -18,6 +18,8 @@ export const FieldTypePrefixes = {
   CustomField: 'cf',
   ComboBox: 'cbx',
   ListBox: 'lb',
+  DateTimeField: 'dtf',
+  DateTimeSegment: 'dts',
 } as const;
 
 export const NOOP = () => {};

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -20,6 +20,7 @@ export const FieldTypePrefixes = {
   ListBox: 'lb',
   DateTimeField: 'dtf',
   DateTimeSegment: 'dts',
+  Calendar: 'cal',
 } as const;
 
 export const NOOP = () => {};

--- a/packages/core/src/helpers/useControlButtonProps/index.ts
+++ b/packages/core/src/helpers/useControlButtonProps/index.ts
@@ -1,0 +1,1 @@
+export * from './useControlButtonProps';

--- a/packages/core/src/helpers/useControlButtonProps/useControlButtonProps.ts
+++ b/packages/core/src/helpers/useControlButtonProps/useControlButtonProps.ts
@@ -6,12 +6,12 @@ interface ControlButtonProps {
   disabled?: boolean;
 }
 
-export function useControlButtonProps(props: ControlButtonProps) {
+export function useControlButtonProps(props: () => ControlButtonProps) {
   const buttonEl = shallowRef<HTMLElement>();
 
   const buttonProps = computed(() => {
     const isBtn = isButtonElement(buttonEl.value);
-    const { disabled, ...rest } = props;
+    const { disabled, ...rest } = props();
 
     return withRefCapture(
       {

--- a/packages/core/src/helpers/useControlButtonProps/useControlButtonProps.ts
+++ b/packages/core/src/helpers/useControlButtonProps/useControlButtonProps.ts
@@ -1,0 +1,29 @@
+import { computed, shallowRef } from 'vue';
+import { isButtonElement, withRefCapture } from '../../utils/common';
+
+interface ControlButtonProps {
+  [key: string]: unknown;
+  disabled?: boolean;
+}
+
+export function useControlButtonProps(props: ControlButtonProps) {
+  const buttonEl = shallowRef<HTMLElement>();
+
+  const buttonProps = computed(() => {
+    const isBtn = isButtonElement(buttonEl.value);
+    const { disabled, ...rest } = props;
+
+    return withRefCapture(
+      {
+        type: isBtn ? ('button' as const) : undefined,
+        role: isBtn ? undefined : 'button',
+        [isBtn ? 'disabled' : 'aria-disabled']: disabled || undefined,
+        tabindex: '-1',
+        ...rest,
+      },
+      buttonEl,
+    );
+  });
+
+  return buttonProps;
+}

--- a/packages/core/src/i18n/getCalendar.ts
+++ b/packages/core/src/i18n/getCalendar.ts
@@ -1,0 +1,13 @@
+import { CalendarIdentifier } from '../useDateTimeField';
+
+export function getCalendar(locale: Intl.Locale): CalendarIdentifier {
+  if (locale.calendar) {
+    return locale.calendar as CalendarIdentifier;
+  }
+
+  if ('calendars' in locale) {
+    return (locale.calendars as string[])[0] as CalendarIdentifier;
+  }
+
+  return 'gregory';
+}

--- a/packages/core/src/i18n/getCalendar.ts
+++ b/packages/core/src/i18n/getCalendar.ts
@@ -1,4 +1,4 @@
-import { CalendarIdentifier } from '../useDateTimeField';
+import { CalendarIdentifier } from '../useCalendar';
 
 export function getCalendar(locale: Intl.Locale): CalendarIdentifier {
   if (locale.calendar) {

--- a/packages/core/src/i18n/getDirection.spec.ts
+++ b/packages/core/src/i18n/getDirection.spec.ts
@@ -2,8 +2,8 @@ import { configure } from '../config';
 import { getDirection } from './getDirection';
 
 test('gets the direction of a locale', () => {
-  expect(getDirection('ar-EG')).toBe('rtl');
-  expect(getDirection('en-US')).toBe('ltr');
+  expect(getDirection(new Intl.Locale('ar-EG'))).toBe('rtl');
+  expect(getDirection(new Intl.Locale('en-US'))).toBe('ltr');
 });
 
 test('warns if the direction was not recognized', () => {
@@ -15,6 +15,6 @@ test('warns if the direction was not recognized', () => {
 
 test('returns ltr if detectDirection is false', () => {
   configure({ detectDirection: false });
-  expect(getDirection('ar-EG')).toBe('ltr');
+  expect(getDirection(new Intl.Locale('ar-EG'))).toBe('ltr');
   configure({ detectDirection: true });
 });

--- a/packages/core/src/i18n/getDirection.ts
+++ b/packages/core/src/i18n/getDirection.ts
@@ -2,19 +2,18 @@ import { Direction } from '../types';
 import { isCallable, warn } from '../utils/common';
 import { getConfig } from '../config';
 
-export function getDirection(locale: string): Direction {
+export function getDirection(locale: Intl.Locale): Direction {
   if (!getConfig().detectDirection) {
     return 'ltr';
   }
 
   try {
-    const instance = new Intl.Locale(locale);
-    if ('textInfo' in instance) {
-      return ((instance.textInfo as { direction: Direction }).direction as Direction) || 'ltr';
+    if ('textInfo' in locale) {
+      return ((locale.textInfo as { direction: Direction }).direction as Direction) || 'ltr';
     }
 
-    if ('getTextInfo' in instance && isCallable(instance.getTextInfo)) {
-      return (instance.getTextInfo().direction as Direction) || 'ltr';
+    if ('getTextInfo' in locale && isCallable(locale.getTextInfo)) {
+      return (locale.getTextInfo().direction as Direction) || 'ltr';
     }
 
     throw new Error(`Cannot determine direction for locale ${locale}`);

--- a/packages/core/src/i18n/getTimezone.ts
+++ b/packages/core/src/i18n/getTimezone.ts
@@ -1,0 +1,3 @@
+export function getTimeZone(locale: Intl.Locale) {
+  return new Intl.DateTimeFormat(locale).resolvedOptions().timeZone;
+}

--- a/packages/core/src/i18n/getWeekInfo.ts
+++ b/packages/core/src/i18n/getWeekInfo.ts
@@ -1,0 +1,26 @@
+import { isCallable, warn } from '../utils/common';
+
+export interface WeekInfo {
+  firstDay: number;
+  weekend: number[];
+}
+
+export function getWeekInfo(locale: Intl.Locale): WeekInfo {
+  const fallbackInfo: WeekInfo = { firstDay: 7, weekend: [6, 7] };
+
+  try {
+    if ('weekInfo' in locale) {
+      return (locale.weekInfo as WeekInfo) || fallbackInfo;
+    }
+
+    if ('getWeekInfo' in locale && isCallable(locale.getWeekInfo)) {
+      return (locale.getWeekInfo() as WeekInfo) || fallbackInfo;
+    }
+
+    throw new Error(`Cannot determine week info for locale ${locale}`);
+  } catch {
+    warn(`Cannot determine week info for locale ${locale}`);
+
+    return fallbackInfo;
+  }
+}

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -4,3 +4,4 @@ export * from './getSiteLocale';
 export * from './useLocale';
 export * from './useNumberParser';
 export * from './checkLocaleMismatch';
+export * from './useDateFormatter';

--- a/packages/core/src/i18n/useDateFormatter/index.ts
+++ b/packages/core/src/i18n/useDateFormatter/index.ts
@@ -3,6 +3,7 @@ import { Intl as TemporalIntl } from '@js-temporal/polyfill';
 import { getUserLocale } from '../getUserLocale';
 import { isEqual } from '../../utils/common';
 
+// TODO: May memory leak in SSR
 const dateFormatterCache = new Map<string, TemporalIntl.DateTimeFormat>();
 
 function getFormatter(locale: string, options: Intl.DateTimeFormatOptions = {}) {

--- a/packages/core/src/i18n/useDateFormatter/index.ts
+++ b/packages/core/src/i18n/useDateFormatter/index.ts
@@ -1,0 +1,25 @@
+import { MaybeRefOrGetter, shallowRef, toValue, watch } from 'vue';
+import { getUserLocale } from '../getUserLocale';
+import { isEqual } from '../../utils/common';
+
+export function useDateFormatter(
+  locale: MaybeRefOrGetter<string | undefined>,
+  opts?: MaybeRefOrGetter<Intl.DateTimeFormatOptions | undefined>,
+) {
+  const resolvedLocale = getUserLocale();
+  const formatter = shallowRef(new Intl.DateTimeFormat(toValue(locale) || resolvedLocale, toValue(opts)));
+
+  watch(
+    () => ({
+      locale: toValue(locale) || resolvedLocale,
+      opts: toValue(opts),
+    }),
+    (config, oldConfig) => {
+      if (!isEqual(config, oldConfig)) {
+        formatter.value = new Intl.DateTimeFormat(config.locale, config.opts);
+      }
+    },
+  );
+
+  return formatter;
+}

--- a/packages/core/src/i18n/useDateFormatter/index.ts
+++ b/packages/core/src/i18n/useDateFormatter/index.ts
@@ -1,4 +1,5 @@
 import { MaybeRefOrGetter, shallowRef, toValue, watch } from 'vue';
+import { Intl as TemporalIntl } from '@js-temporal/polyfill';
 import { getUserLocale } from '../getUserLocale';
 import { isEqual } from '../../utils/common';
 
@@ -7,7 +8,7 @@ export function useDateFormatter(
   opts?: MaybeRefOrGetter<Intl.DateTimeFormatOptions | undefined>,
 ) {
   const resolvedLocale = getUserLocale();
-  const formatter = shallowRef(new Intl.DateTimeFormat(toValue(locale) || resolvedLocale, toValue(opts)));
+  const formatter = shallowRef(new TemporalIntl.DateTimeFormat(toValue(locale) || resolvedLocale, toValue(opts)));
 
   watch(
     () => ({
@@ -16,7 +17,7 @@ export function useDateFormatter(
     }),
     (config, oldConfig) => {
       if (!isEqual(config, oldConfig)) {
-        formatter.value = new Intl.DateTimeFormat(config.locale, config.opts);
+        formatter.value = new TemporalIntl.DateTimeFormat(config.locale, config.opts);
       }
     },
   );

--- a/packages/core/src/i18n/useLocale.ts
+++ b/packages/core/src/i18n/useLocale.ts
@@ -4,8 +4,8 @@ import { getDirection } from './getDirection';
 import { getWeekInfo } from './getWeekInfo';
 import { Maybe, Reactivify } from '../types';
 import { getCalendar } from './getCalendar';
-import { Temporal } from '@js-temporal/polyfill';
 import { CalendarIdentifier } from '../useCalendar';
+import { getTimeZone } from './getTimezone';
 
 export type NumberLocaleExtension = `nu-${string}`;
 
@@ -49,8 +49,9 @@ export function useLocale(
   const localeInstance = computed(() => new Intl.Locale(localeString.value));
   const direction = computed(() => getDirection(localeInstance.value));
   const weekInfo = computed(() => getWeekInfo(localeInstance.value));
-  const calendar = computed(() => new Temporal.Calendar(getCalendar(localeInstance.value)));
+  const calendar = computed(() => getCalendar(localeInstance.value));
+  const timeZone = computed(() => getTimeZone(localeInstance.value));
   const locale = computed(() => localeInstance.value.toString());
 
-  return { locale, direction, weekInfo, calendar };
+  return { locale, direction, weekInfo, calendar, timeZone };
 }

--- a/packages/core/src/i18n/useLocale.ts
+++ b/packages/core/src/i18n/useLocale.ts
@@ -3,6 +3,8 @@ import { getConfig } from '../config';
 import { getDirection } from './getDirection';
 import { getWeekInfo } from './getWeekInfo';
 import { Maybe } from '../types';
+import { getCalendar } from './getCalendar';
+import { Temporal } from '@js-temporal/polyfill';
 
 /**
  * Composable that resolves the currently configured locale and direction.
@@ -11,8 +13,9 @@ export function useLocale(localeCode?: MaybeRefOrGetter<Maybe<string>>) {
   const localeInstance = computed(() => new Intl.Locale(toValue(localeCode) || getConfig().locale));
   const direction = computed(() => getDirection(localeInstance.value));
   const weekInfo = computed(() => getWeekInfo(localeInstance.value));
+  const calendar = computed(() => new Temporal.Calendar(getCalendar(localeInstance.value)));
 
   const locale = computed(() => localeInstance.value.toString());
 
-  return { locale, direction, weekInfo };
+  return { locale, direction, weekInfo, calendar };
 }

--- a/packages/core/src/i18n/useLocale.ts
+++ b/packages/core/src/i18n/useLocale.ts
@@ -1,13 +1,18 @@
-import { computed } from 'vue';
+import { computed, MaybeRefOrGetter, toValue } from 'vue';
 import { getConfig } from '../config';
 import { getDirection } from './getDirection';
+import { getWeekInfo } from './getWeekInfo';
+import { Maybe } from '../types';
 
 /**
  * Composable that resolves the currently configured locale and direction.
  */
-export function useLocale() {
-  const locale = computed(() => getConfig().locale);
-  const direction = computed(() => getDirection(locale.value));
+export function useLocale(localeCode?: MaybeRefOrGetter<Maybe<string>>) {
+  const localeInstance = computed(() => new Intl.Locale(toValue(localeCode) || getConfig().locale));
+  const direction = computed(() => getDirection(localeInstance.value));
+  const weekInfo = computed(() => getWeekInfo(localeInstance.value));
 
-  return { locale, direction };
+  const locale = computed(() => localeInstance.value.baseName);
+
+  return { locale, direction, weekInfo };
 }

--- a/packages/core/src/i18n/useLocale.ts
+++ b/packages/core/src/i18n/useLocale.ts
@@ -12,7 +12,7 @@ export function useLocale(localeCode?: MaybeRefOrGetter<Maybe<string>>) {
   const direction = computed(() => getDirection(localeInstance.value));
   const weekInfo = computed(() => getWeekInfo(localeInstance.value));
 
-  const locale = computed(() => localeInstance.value.baseName);
+  const locale = computed(() => localeInstance.value.toString());
 
   return { locale, direction, weekInfo };
 }

--- a/packages/core/src/i18n/useLocale.ts
+++ b/packages/core/src/i18n/useLocale.ts
@@ -2,19 +2,54 @@ import { computed, MaybeRefOrGetter, toValue } from 'vue';
 import { getConfig } from '../config';
 import { getDirection } from './getDirection';
 import { getWeekInfo } from './getWeekInfo';
-import { Maybe } from '../types';
+import { Maybe, Reactivify } from '../types';
 import { getCalendar } from './getCalendar';
 import { Temporal } from '@js-temporal/polyfill';
+import { CalendarIdentifier } from '../useCalendar';
+
+export type NumberLocaleExtension = `nu-${string}`;
+
+export interface LocaleExtension {
+  number: Maybe<NumberLocaleExtension>;
+  calendar: Maybe<CalendarIdentifier>;
+}
 
 /**
  * Composable that resolves the currently configured locale and direction.
  */
-export function useLocale(localeCode?: MaybeRefOrGetter<Maybe<string>>) {
-  const localeInstance = computed(() => new Intl.Locale(toValue(localeCode) || getConfig().locale));
+export function useLocale(
+  localeCode?: MaybeRefOrGetter<Maybe<string>>,
+  extensions: Partial<Reactivify<LocaleExtension>> = {},
+) {
+  const localeString = computed(() => {
+    let code = toValue(localeCode) || getConfig().locale;
+    const calExt = toValue(extensions.calendar);
+    const numExt = toValue(extensions.number);
+
+    // Add the base locale extension if it's not already present
+    if (!code.includes('-u-') && (numExt || calExt)) {
+      code += '-u-';
+    }
+
+    // Add the number locale extension if it's not already present
+    if (!code.includes('-nu-') && numExt) {
+      code += `-nu-${numExt}`;
+    }
+
+    // Add the calendar locale extension if it's not already present
+    if (!code.includes('-ca-') && calExt) {
+      code += `-ca-${calExt}`;
+    }
+
+    code = code.replaceAll('--', '-');
+
+    return code;
+  });
+
+  const localeInstance = computed(() => new Intl.Locale(localeString.value));
   const direction = computed(() => getDirection(localeInstance.value));
   const weekInfo = computed(() => getWeekInfo(localeInstance.value));
   const calendar = computed(() => new Temporal.Calendar(getCalendar(localeInstance.value)));
-
   const locale = computed(() => localeInstance.value.toString());
 
   return { locale, direction, weekInfo, calendar };

--- a/packages/core/src/i18n/useNumberParser/index.ts
+++ b/packages/core/src/i18n/useNumberParser/index.ts
@@ -67,6 +67,7 @@ interface NumberParser {
   isValidNumberPart(value: string): boolean;
 }
 
+// TODO: May memory leak in SSR
 const numberParserCache = new Map<string, NumberParser>();
 
 function getParser(locale: string, options: Intl.NumberFormatOptions) {

--- a/packages/core/src/i18n/useNumberParser/index.ts
+++ b/packages/core/src/i18n/useNumberParser/index.ts
@@ -57,7 +57,7 @@ interface NumberSymbols {
   resolveNumber: (number: string) => string;
 }
 
-interface NumberParser {
+export interface NumberParser {
   formatter: Intl.NumberFormat;
   options: Intl.ResolvedNumberFormatOptions;
   locale: string;
@@ -206,6 +206,8 @@ export function defineNumberParser(locale: string, options: Intl.NumberFormatOpt
     isValidNumberPart,
   };
 }
+
+export type NumberParserContext = Pick<NumberParser, 'parse' | 'isValidNumberPart'>;
 
 export function useNumberParser(
   locale: MaybeRefOrGetter<string | undefined>,

--- a/packages/core/src/i18n/useNumberParser/index.ts
+++ b/packages/core/src/i18n/useNumberParser/index.ts
@@ -1,4 +1,4 @@
-import { MaybeRefOrGetter, toValue } from 'vue';
+import { MaybeRefOrGetter, toValue, watch } from 'vue';
 import { getUserLocale } from '../getUserLocale';
 
 /**
@@ -276,11 +276,17 @@ export function useNumberParser(
     return resolveParser(value).isValidNumberPart(value);
   }
 
-  function format(value: number): string {
-    const defaultParser = getParser(toValue(locale) ?? toValue(resolvedLocale), toValue(opts) || {});
-
-    return (lastResolvedParser ?? defaultParser).format(value);
+  function getDefaultParser() {
+    return getParser(toValue(locale) ?? toValue(resolvedLocale), toValue(opts) || {});
   }
+
+  function format(value: number): string {
+    return (lastResolvedParser ?? getDefaultParser()).format(value);
+  }
+
+  watch([() => toValue(locale), () => toValue(opts)], () => {
+    lastResolvedParser = getDefaultParser();
+  });
 
   return {
     parse,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from './useSelect';
 export * from './useComboBox';
 export * from './useHiddenField';
 export * from './useCustomField';
+export * from './useDateTimeField';
 export * from './types';
 export * from './config';
 export * from './useForm';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './useComboBox';
 export * from './useHiddenField';
 export * from './useCustomField';
 export * from './useDateTimeField';
+export * from './useCalendar';
 export * from './types';
 export * from './config';
 export * from './useForm';

--- a/packages/core/src/useCalendar/constants.ts
+++ b/packages/core/src/useCalendar/constants.ts
@@ -1,0 +1,4 @@
+import { InjectionKey } from 'vue';
+import { CalendarContext } from './types';
+
+export const CalendarContextKey: InjectionKey<CalendarContext> = Symbol('CalendarContext');

--- a/packages/core/src/useCalendar/constants.ts
+++ b/packages/core/src/useCalendar/constants.ts
@@ -2,3 +2,9 @@ import { InjectionKey } from 'vue';
 import { CalendarContext } from './types';
 
 export const CalendarContextKey: InjectionKey<CalendarContext> = Symbol('CalendarContext');
+
+export const YEAR_CELLS_COUNT = 9;
+
+export const MONTHS_COLUMNS_COUNT = 3;
+
+export const YEARS_COLUMNS_COUNT = 3;

--- a/packages/core/src/useCalendar/index.ts
+++ b/packages/core/src/useCalendar/index.ts
@@ -1,0 +1,3 @@
+export * from './useCalendar';
+export * from './types';
+export * from './useCalendarCell';

--- a/packages/core/src/useCalendar/types.ts
+++ b/packages/core/src/useCalendar/types.ts
@@ -1,4 +1,8 @@
 import { Temporal } from '@js-temporal/polyfill';
+import { MaybeRefOrGetter } from 'vue';
+import { WeekInfo } from '../i18n/getWeekInfo';
+import { Ref } from 'vue';
+import { Maybe } from '../types';
 
 export type CalendarIdentifier =
   | 'buddhist'
@@ -20,18 +24,50 @@ export type CalendarIdentifier =
   | 'persian'
   | 'roc';
 
-export interface CalendarDay {
+export interface CalendarDayCell {
+  type: 'day';
   value: Temporal.ZonedDateTime;
-
   dayOfMonth: number;
-
+  label: string;
   isToday: boolean;
-
   isOutsideMonth: boolean;
-
   selected: boolean;
-
   disabled: boolean;
-
   focused: boolean;
+}
+
+export interface CalendarMonthCell {
+  type: 'month';
+  label: string;
+  value: Temporal.ZonedDateTime;
+  monthOfYear: number;
+  selected: boolean;
+  disabled: boolean;
+  focused: boolean;
+}
+
+export interface CalendarYearCell {
+  type: 'year';
+  label: string;
+  value: Temporal.ZonedDateTime;
+  year: number;
+  selected: boolean;
+  disabled: boolean;
+  focused: boolean;
+}
+
+export type CalendarCellProps = CalendarDayCell | CalendarMonthCell | CalendarYearCell;
+
+export type CalendarPanelType = 'day' | 'month' | 'year';
+
+export interface CalendarContext {
+  locale: Ref<string>;
+  weekInfo: Ref<WeekInfo>;
+  calendar: Ref<CalendarIdentifier>;
+  selectedDate: MaybeRefOrGetter<Temporal.ZonedDateTime>;
+  getMinDate: () => Maybe<Temporal.ZonedDateTime>;
+  getMaxDate: () => Maybe<Temporal.ZonedDateTime>;
+  getFocusedDate: () => Temporal.ZonedDateTime;
+  setFocusedDate: (date: Temporal.ZonedDateTime) => void;
+  setDate: (date: Temporal.ZonedDateTime, panel?: CalendarPanelType) => void;
 }

--- a/packages/core/src/useCalendar/types.ts
+++ b/packages/core/src/useCalendar/types.ts
@@ -22,8 +22,16 @@ export type CalendarIdentifier =
 
 export interface CalendarDay {
   value: Temporal.ZonedDateTime;
+
   dayOfMonth: number;
+
   isToday: boolean;
-  isSelected: boolean;
+
   isOutsideMonth: boolean;
+
+  selected: boolean;
+
+  disabled: boolean;
+
+  focused: boolean;
 }

--- a/packages/core/src/useCalendar/types.ts
+++ b/packages/core/src/useCalendar/types.ts
@@ -1,5 +1,4 @@
 import { Temporal } from '@js-temporal/polyfill';
-import { MaybeRefOrGetter } from 'vue';
 import { WeekInfo } from '../i18n/getWeekInfo';
 import { Ref } from 'vue';
 import { Maybe } from '../types';
@@ -64,7 +63,7 @@ export interface CalendarContext {
   locale: Ref<string>;
   weekInfo: Ref<WeekInfo>;
   calendar: Ref<CalendarIdentifier>;
-  selectedDate: MaybeRefOrGetter<Temporal.ZonedDateTime>;
+  getSelectedDate: () => Temporal.ZonedDateTime;
   getMinDate: () => Maybe<Temporal.ZonedDateTime>;
   getMaxDate: () => Maybe<Temporal.ZonedDateTime>;
   getFocusedDate: () => Temporal.ZonedDateTime;

--- a/packages/core/src/useCalendar/types.ts
+++ b/packages/core/src/useCalendar/types.ts
@@ -21,7 +21,7 @@ export type CalendarIdentifier =
   | 'roc';
 
 export interface CalendarDay {
-  value: Temporal.PlainDate;
+  value: Temporal.ZonedDateTime;
   dayOfMonth: number;
   isToday: boolean;
   isSelected: boolean;

--- a/packages/core/src/useCalendar/types.ts
+++ b/packages/core/src/useCalendar/types.ts
@@ -1,0 +1,29 @@
+import { Temporal } from '@js-temporal/polyfill';
+
+export type CalendarIdentifier =
+  | 'buddhist'
+  | 'chinese'
+  | 'coptic'
+  | 'dangi'
+  | 'ethioaa'
+  | 'ethiopic'
+  | 'gregory'
+  | 'hebrew'
+  | 'indian'
+  | 'islamic'
+  | 'islamic-umalqura'
+  | 'islamic-tbla'
+  | 'islamic-civil'
+  | 'islamic-rgsa'
+  | 'iso8601'
+  | 'japanese'
+  | 'persian'
+  | 'roc';
+
+export interface CalendarDay {
+  value: Temporal.PlainDate;
+  dayOfMonth: number;
+  isToday: boolean;
+  isSelected: boolean;
+  isOutsideMonth: boolean;
+}

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -31,7 +31,7 @@ export interface CalendarProps {
 interface CalendarContext {
   locale: Ref<string>;
   weekInfo: Ref<WeekInfo>;
-  calendar: Ref<Temporal.Calendar>;
+  calendar: Ref<CalendarIdentifier>;
   currentDate: MaybeRefOrGetter<Temporal.PlainDate | Temporal.PlainDateTime>;
   setDay: (date: Temporal.PlainDate) => void;
 }

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -15,12 +15,12 @@ export interface CalendarProps {
   /**
    * The current date to use for the calendar.
    */
-  currentDate?: Temporal.PlainDate | Temporal.PlainDateTime;
+  currentDate?: Temporal.ZonedDateTime;
 
   /**
    * The callback to call when a day is selected.
    */
-  onDaySelected?: (day: Temporal.PlainDate) => void;
+  onDaySelected?: (day: Temporal.ZonedDateTime) => void;
 
   /**
    * The calendar type to use for the calendar, e.g. `gregory`, `islamic-umalqura`, etc.
@@ -32,8 +32,8 @@ interface CalendarContext {
   locale: Ref<string>;
   weekInfo: Ref<WeekInfo>;
   calendar: Ref<CalendarIdentifier>;
-  currentDate: MaybeRefOrGetter<Temporal.PlainDate | Temporal.PlainDateTime>;
-  setDay: (date: Temporal.PlainDate) => void;
+  currentDate: MaybeRefOrGetter<Temporal.ZonedDateTime>;
+  setDay: (date: Temporal.ZonedDateTime) => void;
 }
 
 export const CalendarContextKey: InjectionKey<CalendarContext> = Symbol('CalendarContext');
@@ -44,14 +44,14 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     calendar: () => toValue(props.calendar),
   });
 
-  const currentDate = computed(() => toValue(props.currentDate) ?? Temporal.Now.plainDate(calendar.value));
+  const currentDate = computed(() => toValue(props.currentDate) ?? Temporal.Now.zonedDateTime(calendar.value));
 
   const context: CalendarContext = {
     weekInfo,
     locale,
     calendar,
     currentDate,
-    setDay: (date: Temporal.PlainDate) => {
+    setDay: (date: Temporal.ZonedDateTime) => {
       props.onDaySelected?.(date);
     },
   };
@@ -93,9 +93,9 @@ function useDaysOfTheWeek({ weekInfo, locale, currentDate }: CalendarContext) {
     }[] = [];
     for (let i = 0; i < daysPerWeek; i++) {
       days.push({
-        long: longFormatter.value.format(current.add({ days: i })),
-        short: shortFormatter.value.format(current.add({ days: i })),
-        narrow: narrowFormatter.value.format(current.add({ days: i })),
+        long: longFormatter.value.format(current.add({ days: i }).toPlainDateTime()),
+        short: shortFormatter.value.format(current.add({ days: i }).toPlainDateTime()),
+        narrow: narrowFormatter.value.format(current.add({ days: i }).toPlainDateTime()),
       });
     }
 
@@ -122,7 +122,7 @@ function useCalendarDays({ weekInfo, currentDate, calendar }: CalendarContext) {
     const totalDays = daysInMonth + daysToSubtract;
     const remainingDays = 7 - (totalDays % 7);
     const gridDays = totalDays + (remainingDays === 7 ? 0 : remainingDays);
-    const now = Temporal.Now.plainDate(calendar.value);
+    const now = Temporal.Now.zonedDateTime(calendar.value);
 
     return Array.from({ length: gridDays }, (_, i) => {
       const dayOfMonth = firstDay.add({ days: i });

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -112,11 +112,11 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
   const { daysOfTheWeek } = useDaysOfTheWeek(context);
   const { days } = useCalendarDays(context);
 
-  const buttonProps = useControlButtonProps({
+  const buttonProps = useControlButtonProps(() => ({
     onClick: () => {
       isOpen.value = true;
     },
-  });
+  }));
 
   const pickerHandlers = {
     onKeydown(e: KeyboardEvent) {
@@ -170,19 +170,19 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     );
   });
 
-  const nextMonthButtonProps = useControlButtonProps({
+  const nextMonthButtonProps = useControlButtonProps(() => ({
     id: `${calendarId}-next-month`,
     onClick: () => {
       context.setFocusedDay(context.getFocusedDate().add({ months: 1 }));
     },
-  });
+  }));
 
-  const previousMonthButtonProps = useControlButtonProps({
+  const previousMonthButtonProps = useControlButtonProps(() => ({
     id: `${calendarId}-previous-month`,
     onClick: () => {
       context.setFocusedDay(context.getFocusedDate().subtract({ months: 1 }));
     },
-  });
+  }));
 
   const monthYearLabel = computed(() => {
     return formatter.value.format(context.getFocusedDate().toPlainDateTime());

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -192,17 +192,37 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     );
   });
 
-  const nextMonthButtonProps = useControlButtonProps(() => ({
-    id: `${calendarId}-next-month`,
+  const nextPanelButtonProps = useControlButtonProps(() => ({
+    id: `${calendarId}-next`,
     onClick: () => {
-      context.setFocusedDate(context.getFocusedDate().add({ months: 1 }));
+      if (currentPanel.value.type === 'day') {
+        context.setFocusedDate(context.getFocusedDate().add({ months: 1 }));
+        return;
+      }
+
+      if (currentPanel.value.type === 'month') {
+        context.setFocusedDate(context.getFocusedDate().add({ years: 1 }));
+        return;
+      }
+
+      context.setFocusedDate(currentPanel.value.years[currentPanel.value.years.length - 1].value.add({ years: 1 }));
     },
   }));
 
-  const previousMonthButtonProps = useControlButtonProps(() => ({
-    id: `${calendarId}-previous-month`,
+  const previousPanelButtonProps = useControlButtonProps(() => ({
+    id: `${calendarId}-previous`,
     onClick: () => {
-      context.setFocusedDate(context.getFocusedDate().subtract({ months: 1 }));
+      if (currentPanel.value.type === 'day') {
+        context.setFocusedDate(context.getFocusedDate().subtract({ months: 1 }));
+        return;
+      }
+
+      if (currentPanel.value.type === 'month') {
+        context.setFocusedDate(context.getFocusedDate().subtract({ years: 1 }));
+        return;
+      }
+
+      context.setFocusedDate(currentPanel.value.years[0].value.subtract({ years: 1 }));
     },
   }));
 
@@ -212,7 +232,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     label: panelLabel,
   });
 
-  const monthYearLabelProps = computed(() => {
+  const panelLabelProps = computed(() => {
     return withRefCapture(
       {
         ...monthYearLabelBaseProps.value,
@@ -235,7 +255,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     );
   });
 
-  const gridProps = computed(() => {
+  const panelGridProps = computed(() => {
     return withRefCapture(
       {
         id: `${calendarId}-g`,
@@ -259,9 +279,9 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
      */
     pickerProps,
     /**
-     * The props for the grid element.
+     * The props for the grid element that displays the panel values.
      */
-    gridProps,
+    panelGridProps,
     /**
      * The props for the button element.
      */
@@ -271,10 +291,6 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
      */
     selectedDate,
     /**
-     * The grid element.
-     */
-    gridEl,
-    /**
      * The current panel.
      */
     currentPanel,
@@ -283,21 +299,21 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
      */
     switchPanel,
     /**
-     * The props for the month and year label element.
+     * The props for the panel label element.
      */
-    monthYearLabelProps,
+    panelLabelProps,
     /**
-     * The props for the next month button.
+     * The props for the next panel values button. if it is a day panel, the button will move the panel to the next month. If it is a month panel, the button will move the panel to the next year. If it is a year panel, the button will move the panel to the next set of years.
      */
-    nextMonthButtonProps,
+    nextPanelButtonProps,
     /**
-     * The props for the previous month button.
+     * The props for the previous panel values button. If it is a day panel, the button will move the panel to the previous month. If it is a month panel, the button will move the panel to the previous year. If it is a year panel, the button will move the panel to the previous set of years.
      */
-    previousMonthButtonProps,
+    previousPanelButtonProps,
     /**
-     * The month and year label.
+     * The label for the current panel. If it is a day panel, the label will be the month and year. If it is a month panel, the label will be the year. If it is a year panel, the label will be the range of years currently being displayed.
      */
-    monthYearLabel: panelLabel,
+    panelLabel,
   };
 }
 

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -1,6 +1,6 @@
 import { computed, InjectionKey, MaybeRefOrGetter, provide, Ref, toValue } from 'vue';
 import { Temporal } from '@js-temporal/polyfill';
-import { CalendarDay } from './types';
+import { CalendarDay, CalendarIdentifier } from './types';
 import { normalizeProps } from '../utils/common';
 import { Reactivify } from '../types';
 import { useDateFormatter, useLocale } from '../i18n';
@@ -21,6 +21,11 @@ export interface CalendarProps {
    * The callback to call when a day is selected.
    */
   onDaySelected?: (day: Temporal.PlainDate) => void;
+
+  /**
+   * The calendar type to use for the calendar, e.g. `gregory`, `islamic-umalqura`, etc.
+   */
+  calendar?: CalendarIdentifier;
 }
 
 interface CalendarContext {
@@ -35,7 +40,10 @@ export const CalendarContextKey: InjectionKey<CalendarContext> = Symbol('Calenda
 
 export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> = {}) {
   const props = normalizeProps(_props, ['onDaySelected']);
-  const { weekInfo, locale, calendar } = useLocale(props.locale);
+  const { weekInfo, locale, calendar } = useLocale(props.locale, {
+    calendar: () => toValue(props.calendar),
+  });
+
   const currentDate = computed(() => toValue(props.currentDate) ?? Temporal.Now.plainDate(calendar.value));
 
   const context: CalendarContext = {

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -2,7 +2,7 @@ import { computed, InjectionKey, MaybeRefOrGetter, nextTick, provide, ref, Ref, 
 import { Temporal } from '@js-temporal/polyfill';
 import { CalendarDay, CalendarIdentifier } from './types';
 import { hasKeyCode, normalizeProps, useUniqId, withRefCapture } from '../utils/common';
-import { Reactivify } from '../types';
+import { Maybe, Reactivify } from '../types';
 import { useDateFormatter, useLocale } from '../i18n';
 import { WeekInfo } from '../i18n/getWeekInfo';
 import { FieldTypePrefixes } from '../constants';
@@ -55,12 +55,12 @@ export interface CalendarProps {
   /**
    * The minimum date to use for the calendar.
    */
-  minDate?: Temporal.ZonedDateTime;
+  minDate?: Maybe<Temporal.ZonedDateTime>;
 
   /**
    * The maximum date to use for the calendar.
    */
-  maxDate?: Temporal.ZonedDateTime;
+  maxDate?: Maybe<Temporal.ZonedDateTime>;
 }
 
 interface CalendarContext {
@@ -68,8 +68,8 @@ interface CalendarContext {
   weekInfo: Ref<WeekInfo>;
   calendar: Ref<CalendarIdentifier>;
   selectedDate: MaybeRefOrGetter<Temporal.ZonedDateTime>;
-  getMinDate: () => Temporal.ZonedDateTime | undefined;
-  getMaxDate: () => Temporal.ZonedDateTime | undefined;
+  getMinDate: () => Maybe<Temporal.ZonedDateTime>;
+  getMaxDate: () => Maybe<Temporal.ZonedDateTime>;
   getFocusedDate: () => Temporal.ZonedDateTime;
   setDay: (date: Temporal.ZonedDateTime) => void;
   setFocusedDay: (date: Temporal.ZonedDateTime) => void;

--- a/packages/core/src/useCalendar/useCalendarCell.ts
+++ b/packages/core/src/useCalendar/useCalendarCell.ts
@@ -10,17 +10,24 @@ export function useCalendarCell(_props: Reactivify<CalendarDay>) {
   const calendarCtx = inject(CalendarContextKey, null);
 
   function handleClick() {
+    if (toValue(props.disabled)) {
+      return;
+    }
+
     calendarCtx?.setDay(toValue(props.value));
   }
 
   const cellProps = computed(() => {
+    const isDisabled = toValue(props.disabled);
+    const isFocused = toValue(props.focused);
+
     return withRefCapture(
       {
         key: toValue(props.value).toString(),
-        onClick: handleClick,
+        onClick: isDisabled ? undefined : handleClick,
         'aria-selected': toValue(props.selected),
-        'aria-disabled': toValue(props.disabled),
-        tabindex: toValue(props.disabled) || !toValue(props.focused) ? '-1' : '0',
+        'aria-disabled': isDisabled,
+        tabindex: isDisabled || !isFocused ? '-1' : '0',
       },
       cellEl,
     );
@@ -32,6 +39,7 @@ export function useCalendarCell(_props: Reactivify<CalendarDay>) {
 }
 
 export const CalendarCell = defineComponent({
+  name: 'CalendarCell',
   props: ['value', 'dayOfMonth', 'isToday', 'selected', 'isOutsideMonth', 'disabled', 'focused'],
   setup(props) {
     const { cellProps } = useCalendarCell(props);

--- a/packages/core/src/useCalendar/useCalendarCell.ts
+++ b/packages/core/src/useCalendar/useCalendarCell.ts
@@ -1,10 +1,10 @@
 import { Reactivify } from '../types';
 import { normalizeProps, withRefCapture } from '../utils/common';
-import { CalendarContextKey } from './useCalendar';
 import { computed, defineComponent, h, inject, shallowRef, toValue } from 'vue';
-import { CalendarDay } from './types';
+import { CalendarCellProps, CalendarPanelType } from './types';
+import { CalendarContextKey } from './constants';
 
-export function useCalendarCell(_props: Reactivify<CalendarDay>) {
+export function useCalendarCell(_props: Reactivify<CalendarCellProps>) {
   const props = normalizeProps(_props);
   const cellEl = shallowRef<HTMLElement>();
   const calendarCtx = inject(CalendarContextKey, null);
@@ -14,7 +14,9 @@ export function useCalendarCell(_props: Reactivify<CalendarDay>) {
       return;
     }
 
-    calendarCtx?.setDay(toValue(props.value));
+    const type = toValue(props.type);
+    const nextPanel: CalendarPanelType | undefined = type === 'month' ? 'day' : type === 'year' ? 'month' : undefined;
+    calendarCtx?.setDate(toValue(props.value), nextPanel);
   }
 
   const cellProps = computed(() => {
@@ -33,17 +35,21 @@ export function useCalendarCell(_props: Reactivify<CalendarDay>) {
     );
   });
 
+  const label = computed(() => toValue(props.label));
+
   return {
     cellProps,
+    label,
   };
 }
 
 export const CalendarCell = defineComponent({
   name: 'CalendarCell',
-  props: ['value', 'dayOfMonth', 'isToday', 'selected', 'isOutsideMonth', 'disabled', 'focused'],
+  inheritAttrs: true,
+  props: ['value', 'selected', 'disabled', 'focused', 'label', 'type', 'monthOfYear', 'year'],
   setup(props) {
-    const { cellProps } = useCalendarCell(props);
+    const { cellProps, label } = useCalendarCell(props);
 
-    return () => h('span', cellProps.value, String(props.dayOfMonth));
+    return () => h('span', cellProps.value, label.value);
   },
 });

--- a/packages/core/src/useCalendar/useCalendarCell.ts
+++ b/packages/core/src/useCalendar/useCalendarCell.ts
@@ -1,0 +1,33 @@
+import { Reactivify } from '../types';
+import { normalizeProps } from '../utils/common';
+import { CalendarContextKey } from './useCalendar';
+import { computed, defineComponent, h, inject, toValue } from 'vue';
+import { CalendarDay } from './types';
+
+export function useCalendarCell(_props: Reactivify<CalendarDay>) {
+  const props = normalizeProps(_props);
+  const calendarCtx = inject(CalendarContextKey, null);
+  if (!calendarCtx) {
+    throw new Error('Calendar context not found');
+  }
+
+  const cellProps = computed(() => ({
+    key: toValue(props.value).toString(),
+    onClick() {
+      calendarCtx.setDay(toValue(props.value));
+    },
+  }));
+
+  return {
+    cellProps,
+  };
+}
+
+export const CalendarCell = defineComponent({
+  props: ['value', 'dayOfMonth', 'isToday', 'isSelected', 'isOutsideMonth'],
+  setup(props) {
+    const { cellProps } = useCalendarCell(props);
+
+    return () => h('span', cellProps.value, String(props.dayOfMonth));
+  },
+});

--- a/packages/core/src/useCalendar/useCalendarPanel.ts
+++ b/packages/core/src/useCalendar/useCalendarPanel.ts
@@ -1,0 +1,235 @@
+import { computed, MaybeRefOrGetter, shallowRef, toValue } from 'vue';
+import { CalendarContext, CalendarDayCell, CalendarMonthCell, CalendarPanelType, CalendarYearCell } from './types';
+import { useDateFormatter } from '../i18n';
+import { Temporal } from '@js-temporal/polyfill';
+import { Reactivify } from '../types';
+import { normalizeProps } from '../utils/common';
+
+export interface CalendarDayPanel {
+  type: 'day';
+  days: CalendarDayCell[];
+  daysOfTheWeek: string[];
+}
+
+export interface CalendarMonthPanel {
+  type: 'month';
+  months: CalendarMonthCell[];
+}
+
+export interface CalendarYearPanel {
+  type: 'year';
+  years: CalendarYearCell[];
+}
+
+export type CalendarPanel = CalendarDayPanel | CalendarMonthPanel | CalendarYearPanel;
+
+export interface CalendarPanelProps {
+  daysOfWeekFormat?: Intl.DateTimeFormatOptions['weekday'];
+  monthFormat?: Intl.DateTimeFormatOptions['month'];
+  yearFormat?: Intl.DateTimeFormatOptions['year'];
+}
+
+export function useCalendarPanel(_props: Reactivify<CalendarPanelProps>, context: CalendarContext) {
+  const props = normalizeProps(_props);
+  const panelType = shallowRef<CalendarPanelType>('day');
+  const { days, daysOfTheWeek } = useCalendarDaysPanel(context, props.daysOfWeekFormat);
+  const { months, monthFormatter } = useCalendarMonthsPanel(context, props.monthFormat);
+  const { years, yearFormatter } = useCalendarYearsPanel(context, props.yearFormat);
+
+  const currentPanel = computed(() => {
+    if (panelType.value === 'day') {
+      return {
+        type: 'day',
+        days: days.value,
+        daysOfTheWeek: daysOfTheWeek.value,
+      } as CalendarDayPanel;
+    }
+
+    if (panelType.value === 'month') {
+      return {
+        type: 'month',
+        months: months.value,
+      } as CalendarMonthPanel;
+    }
+
+    return {
+      type: 'year',
+      years: years.value,
+    } as CalendarYearPanel;
+  });
+
+  function switchPanel(type: CalendarPanelType) {
+    panelType.value = type;
+  }
+
+  const panelLabel = computed(() => {
+    if (panelType.value === 'day') {
+      return monthFormatter.value.format(context.getFocusedDate().toPlainDateTime());
+    }
+
+    if (panelType.value === 'month') {
+      return yearFormatter.value.format(context.getFocusedDate().toPlainDateTime());
+    }
+
+    return `${yearFormatter.value.format(context.getFocusedDate().subtract({ years: 4 }).toPlainDateTime())} - ${yearFormatter.value.format(context.getFocusedDate().add({ years: 4 }).toPlainDateTime())}`;
+  });
+
+  return { currentPanel, switchPanel, panelLabel };
+}
+
+function useCalendarDaysPanel(
+  { weekInfo, getFocusedDate, calendar, selectedDate, locale, getMinDate, getMaxDate }: CalendarContext,
+  daysOfWeekFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['weekday']>,
+) {
+  const dayFormatter = useDateFormatter(locale, () => ({ weekday: toValue(daysOfWeekFormat) ?? 'short' }));
+
+  const days = computed<CalendarDayCell[]>(() => {
+    const current = toValue(selectedDate);
+    const focused = getFocusedDate();
+    const startOfMonth = focused.with({ day: 1 });
+
+    const firstDayOfWeek = weekInfo.value.firstDay;
+    const startDayOfWeek = startOfMonth.dayOfWeek;
+    const daysToSubtract = (startDayOfWeek - firstDayOfWeek + 7) % 7;
+
+    // Move to first day of week
+    const firstDay = startOfMonth.subtract({ days: daysToSubtract });
+
+    // Always use 6 weeks (42 days) for consistent layout
+    const gridDays = 42;
+    const now = Temporal.Now.zonedDateTime(calendar.value);
+    const minDate = getMinDate();
+    const maxDate = getMaxDate();
+
+    return Array.from({ length: gridDays }, (_, i) => {
+      const dayOfMonth = firstDay.add({ days: i });
+      let disabled = false;
+
+      if (minDate && Temporal.ZonedDateTime.compare(dayOfMonth, minDate) < 0) {
+        disabled = true;
+      }
+
+      if (maxDate && Temporal.ZonedDateTime.compare(dayOfMonth, maxDate) > 0) {
+        disabled = true;
+      }
+
+      return {
+        value: dayOfMonth,
+        label: String(dayOfMonth.day),
+        dayOfMonth: dayOfMonth.day,
+        isToday: dayOfMonth.equals(now),
+        selected: current.equals(dayOfMonth),
+        isOutsideMonth: dayOfMonth.monthCode !== focused.monthCode,
+        focused: focused.equals(dayOfMonth),
+        disabled,
+        type: 'day',
+      } as CalendarDayCell;
+    });
+  });
+
+  const daysOfTheWeek = computed(() => {
+    let focused = getFocusedDate();
+    const daysPerWeek = focused.daysInWeek;
+    const firstDayOfWeek = weekInfo.value.firstDay;
+    // Get the current date's day of week (0-6)
+    const currentDayOfWeek = focused.dayOfWeek;
+
+    // Calculate how many days to go back to reach first day of week
+    const daysToSubtract = (currentDayOfWeek - firstDayOfWeek + 7) % 7;
+
+    // Move current date back to first day of week
+    focused = focused.subtract({ days: daysToSubtract });
+
+    const days: string[] = [];
+    for (let i = 0; i < daysPerWeek; i++) {
+      days.push(dayFormatter.value.format(focused.add({ days: i }).toPlainDateTime()));
+    }
+
+    return days;
+  });
+
+  return { days, daysOfTheWeek, dayFormatter };
+}
+
+function useCalendarMonthsPanel(
+  { getFocusedDate, locale, selectedDate, getMinDate, getMaxDate }: CalendarContext,
+  monthFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['month']>,
+) {
+  const monthFormatter = useDateFormatter(locale, () => ({ month: toValue(monthFormat) ?? 'long' }));
+
+  const months = computed<CalendarMonthCell[]>(() => {
+    const focused = getFocusedDate();
+    const current = toValue(selectedDate);
+    const minDate = getMinDate();
+    const maxDate = getMaxDate();
+
+    return Array.from({ length: focused.monthsInYear }, (_, i) => {
+      const date = focused.with({ month: i + 1, day: 1 });
+      let disabled = false;
+
+      if (minDate && minDate.month < date.month) {
+        disabled = true;
+      }
+
+      if (maxDate && maxDate.month > date.month) {
+        disabled = true;
+      }
+
+      const cell: CalendarMonthCell = {
+        type: 'month',
+        label: monthFormatter.value.format(date.toPlainDateTime()),
+        value: date,
+        monthOfYear: date.month,
+        selected: date.month === current.month && date.year === current.year,
+        focused: focused.monthCode === date.monthCode && focused.year === date.year,
+        disabled,
+      };
+
+      return cell;
+    });
+  });
+
+  return { months, monthFormatter };
+}
+
+function useCalendarYearsPanel(
+  { getFocusedDate, locale, selectedDate, getMinDate, getMaxDate }: CalendarContext,
+  yearFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['year']>,
+) {
+  const yearFormatter = useDateFormatter(locale, () => ({ year: toValue(yearFormat) ?? 'numeric' }));
+
+  const years = computed<CalendarYearCell[]>(() => {
+    const focused = getFocusedDate();
+    const current = toValue(selectedDate);
+    const minDate = getMinDate();
+    const maxDate = getMaxDate();
+
+    return Array.from({ length: 9 }, (_, i) => {
+      const startYear = Math.floor(focused.year / 9) * 9;
+      const date = focused.with({ year: startYear + i, month: 1, day: 1 });
+      let disabled = false;
+
+      if (minDate && minDate.year < date.year) {
+        disabled = true;
+      }
+
+      if (maxDate && maxDate.year > date.year) {
+        disabled = true;
+      }
+
+      const cell: CalendarYearCell = {
+        type: 'year',
+        label: yearFormatter.value.format(date.toPlainDateTime()),
+        value: date,
+        year: date.year,
+        selected: date.year === current.year,
+        focused: focused.year === date.year,
+        disabled,
+      };
+
+      return cell;
+    });
+  });
+
+  return { years, yearFormatter };
+}

--- a/packages/core/src/useCalendar/useCalendarPanel.ts
+++ b/packages/core/src/useCalendar/useCalendarPanel.ts
@@ -71,7 +71,7 @@ export function useCalendarPanel(_props: Reactivify<CalendarPanelProps>, context
       return yearFormatter.value.format(context.getFocusedDate().toPlainDateTime());
     }
 
-    return `${yearFormatter.value.format(context.getFocusedDate().subtract({ years: 4 }).toPlainDateTime())} - ${yearFormatter.value.format(context.getFocusedDate().add({ years: 4 }).toPlainDateTime())}`;
+    return `${yearFormatter.value.format(years.value[0].value.toPlainDateTime())} - ${yearFormatter.value.format(years.value[years.value.length - 1].value.toPlainDateTime())}`;
   });
 
   return { currentPanel, switchPanel, panelLabel };

--- a/packages/core/src/useCalendar/useCalendarPanel.ts
+++ b/packages/core/src/useCalendar/useCalendarPanel.ts
@@ -4,6 +4,7 @@ import { useDateFormatter } from '../i18n';
 import { Temporal } from '@js-temporal/polyfill';
 import { Reactivify } from '../types';
 import { normalizeProps } from '../utils/common';
+import { YEAR_CELLS_COUNT } from './constants';
 
 export interface CalendarDayPanel {
   type: 'day';
@@ -64,7 +65,7 @@ export function useCalendarPanel(_props: Reactivify<CalendarPanelProps>, context
 
   const panelLabel = computed(() => {
     if (panelType.value === 'day') {
-      return monthFormatter.value.format(context.getFocusedDate().toPlainDateTime());
+      return `${monthFormatter.value.format(context.getFocusedDate().toPlainDateTime())} ${yearFormatter.value.format(context.getFocusedDate().toPlainDateTime())}`;
     }
 
     if (panelType.value === 'month') {
@@ -78,13 +79,13 @@ export function useCalendarPanel(_props: Reactivify<CalendarPanelProps>, context
 }
 
 function useCalendarDaysPanel(
-  { weekInfo, getFocusedDate, calendar, selectedDate, locale, getMinDate, getMaxDate }: CalendarContext,
+  { weekInfo, getFocusedDate, calendar, getSelectedDate, locale, getMinDate, getMaxDate }: CalendarContext,
   daysOfWeekFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['weekday']>,
 ) {
   const dayFormatter = useDateFormatter(locale, () => ({ weekday: toValue(daysOfWeekFormat) ?? 'short' }));
 
   const days = computed<CalendarDayCell[]>(() => {
-    const current = toValue(selectedDate);
+    const current = getSelectedDate();
     const focused = getFocusedDate();
     const startOfMonth = focused.with({ day: 1 });
 
@@ -152,14 +153,14 @@ function useCalendarDaysPanel(
 }
 
 function useCalendarMonthsPanel(
-  { getFocusedDate, locale, selectedDate, getMinDate, getMaxDate }: CalendarContext,
+  { getFocusedDate, locale, getSelectedDate, getMinDate, getMaxDate }: CalendarContext,
   monthFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['month']>,
 ) {
   const monthFormatter = useDateFormatter(locale, () => ({ month: toValue(monthFormat) ?? 'long' }));
 
   const months = computed<CalendarMonthCell[]>(() => {
     const focused = getFocusedDate();
-    const current = toValue(selectedDate);
+    const current = getSelectedDate();
     const minDate = getMinDate();
     const maxDate = getMaxDate();
 
@@ -193,19 +194,19 @@ function useCalendarMonthsPanel(
 }
 
 function useCalendarYearsPanel(
-  { getFocusedDate, locale, selectedDate, getMinDate, getMaxDate }: CalendarContext,
+  { getFocusedDate, locale, getSelectedDate, getMinDate, getMaxDate }: CalendarContext,
   yearFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['year']>,
 ) {
   const yearFormatter = useDateFormatter(locale, () => ({ year: toValue(yearFormat) ?? 'numeric' }));
 
   const years = computed<CalendarYearCell[]>(() => {
     const focused = getFocusedDate();
-    const current = toValue(selectedDate);
+    const current = getSelectedDate();
     const minDate = getMinDate();
     const maxDate = getMaxDate();
 
-    return Array.from({ length: 9 }, (_, i) => {
-      const startYear = Math.floor(focused.year / 9) * 9;
+    return Array.from({ length: YEAR_CELLS_COUNT }, (_, i) => {
+      const startYear = Math.floor(focused.year / YEAR_CELLS_COUNT) * YEAR_CELLS_COUNT;
       const date = focused.with({ year: startYear + i, month: 1, day: 1 });
       let disabled = false;
 

--- a/packages/core/src/useComboBox/useComboBox.ts
+++ b/packages/core/src/useComboBox/useComboBox.ts
@@ -316,7 +316,7 @@ export function useComboBox<TOption, TValue = TOption>(
     isPopupOpen.value = !isPopupOpen.value;
   }
 
-  const buttonProps = useControlButtonProps({
+  const buttonProps = useControlButtonProps(() => ({
     id: `${inputId}-btn`,
     disabled: isDisabled.value,
     type: 'button' as const,
@@ -325,7 +325,7 @@ export function useComboBox<TOption, TValue = TOption>(
     'aria-activedescendant': findFocusedOption()?.id ?? undefined,
     'aria-controls': listBoxId,
     onClick: onButtonClick,
-  });
+  }));
 
   // https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/#rps_label_textbox
   const inputProps = computed(() => {

--- a/packages/core/src/useComboBox/useComboBox.ts
+++ b/packages/core/src/useComboBox/useComboBox.ts
@@ -18,6 +18,7 @@ import { useListBox } from '../useListBox';
 import { useErrorMessage } from '../a11y/useErrorMessage';
 import { useInputValidity } from '../validation';
 import { FilterFn } from '../collections';
+import { useControlButtonProps } from '../helpers/useControlButtonProps';
 
 export interface ComboBoxProps<TOption, TValue = TOption> {
   /**
@@ -315,24 +316,15 @@ export function useComboBox<TOption, TValue = TOption>(
     isPopupOpen.value = !isPopupOpen.value;
   }
 
-  const buttonProps = computed(() => {
-    const isButton = buttonEl.value?.tagName === 'BUTTON';
-
-    return withRefCapture(
-      {
-        id: inputId,
-        role: isButton ? undefined : 'button',
-        [isButton ? 'disabled' : 'aria-disabled']: isDisabled.value || undefined,
-        tabindex: '-1',
-        type: 'button' as const,
-        'aria-haspopup': 'listbox' as const,
-        'aria-expanded': isPopupOpen.value,
-        'aria-activedescendant': findFocusedOption()?.id ?? undefined,
-        'aria-controls': listBoxId,
-        onClick: onButtonClick,
-      },
-      buttonEl,
-    );
+  const buttonProps = useControlButtonProps({
+    id: `${inputId}-btn`,
+    disabled: isDisabled.value,
+    type: 'button' as const,
+    'aria-haspopup': 'listbox' as const,
+    'aria-expanded': isPopupOpen.value,
+    'aria-activedescendant': findFocusedOption()?.id ?? undefined,
+    'aria-controls': listBoxId,
+    onClick: onButtonClick,
   });
 
   // https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/#rps_label_textbox

--- a/packages/core/src/useDateTimeField/constants.ts
+++ b/packages/core/src/useDateTimeField/constants.ts
@@ -1,0 +1,3 @@
+import { DateTimeSegmentType } from './types';
+
+export const NON_EDITABLE_SEGMENT_TYPES: DateTimeSegmentType[] = ['era', 'timeZoneName', 'literal'];

--- a/packages/core/src/useDateTimeField/constants.ts
+++ b/packages/core/src/useDateTimeField/constants.ts
@@ -14,6 +14,7 @@ export function segmentTypeToDurationLike(type: DateTimeSegmentType): keyof Temp
     minute: 'minutes',
     second: 'seconds',
     dayPeriod: 'hours',
+    weekday: 'days',
   };
 
   return map[type];

--- a/packages/core/src/useDateTimeField/constants.ts
+++ b/packages/core/src/useDateTimeField/constants.ts
@@ -5,6 +5,12 @@ export function isEditableSegmentType(type: DateTimeSegmentType) {
   return !['era', 'timeZoneName', 'literal'].includes(type);
 }
 
+export function isOptionalSegmentType(type: DateTimeSegmentType) {
+  const optionalTypes: DateTimeSegmentType[] = ['dayPeriod', 'weekday', 'era'];
+
+  return optionalTypes.includes(type);
+}
+
 export function segmentTypeToDurationLike(type: DateTimeSegmentType): keyof Temporal.DurationLike | undefined {
   const map: Partial<Record<DateTimeSegmentType, keyof Temporal.DurationLike>> = {
     year: 'years',
@@ -15,6 +21,21 @@ export function segmentTypeToDurationLike(type: DateTimeSegmentType): keyof Temp
     second: 'seconds',
     dayPeriod: 'hours',
     weekday: 'days',
+  };
+
+  return map[type];
+}
+
+export function getSegmentTypePlaceholder(type: DateTimeSegmentType) {
+  const map: Partial<Record<DateTimeSegmentType, string>> = {
+    year: 'YYYY',
+    month: 'MM',
+    day: 'DD',
+    hour: 'HH',
+    minute: 'mm',
+    second: 'ss',
+    dayPeriod: 'AM',
+    weekday: 'ddd',
   };
 
   return map[type];

--- a/packages/core/src/useDateTimeField/constants.ts
+++ b/packages/core/src/useDateTimeField/constants.ts
@@ -1,3 +1,20 @@
+import { Temporal } from '@js-temporal/polyfill';
 import { DateTimeSegmentType } from './types';
 
-export const NON_EDITABLE_SEGMENT_TYPES: DateTimeSegmentType[] = ['era', 'timeZoneName', 'literal'];
+export function isEditableSegmentType(type: DateTimeSegmentType) {
+  return !['era', 'timeZoneName', 'literal'].includes(type);
+}
+
+export function segmentTypeToDurationLike(type: DateTimeSegmentType): keyof Temporal.DurationLike | undefined {
+  const map: Partial<Record<DateTimeSegmentType, keyof Temporal.DurationLike>> = {
+    year: 'years',
+    month: 'months',
+    day: 'days',
+    hour: 'hours',
+    minute: 'minutes',
+    second: 'seconds',
+    dayPeriod: 'hours',
+  };
+
+  return map[type];
+}

--- a/packages/core/src/useDateTimeField/index.ts
+++ b/packages/core/src/useDateTimeField/index.ts
@@ -1,3 +1,4 @@
 export * from './useDateTimeField';
 export * from './useDateTimeSegment';
 export * from './useCalendar';
+export * from './types';

--- a/packages/core/src/useDateTimeField/index.ts
+++ b/packages/core/src/useDateTimeField/index.ts
@@ -1,2 +1,3 @@
 export * from './useDateTimeField';
 export * from './useDateTimeSegment';
+export * from './useCalendar';

--- a/packages/core/src/useDateTimeField/index.ts
+++ b/packages/core/src/useDateTimeField/index.ts
@@ -1,4 +1,4 @@
 export * from './useDateTimeField';
 export * from './useDateTimeSegment';
-export * from './useCalendar';
+export * from '../useCalendar/useCalendar';
 export * from './types';

--- a/packages/core/src/useDateTimeField/index.ts
+++ b/packages/core/src/useDateTimeField/index.ts
@@ -1,0 +1,2 @@
+export * from './useDateTimeField';
+export * from './useDateTimeSegment';

--- a/packages/core/src/useDateTimeField/temporalPartial.ts
+++ b/packages/core/src/useDateTimeField/temporalPartial.ts
@@ -1,0 +1,34 @@
+import { Temporal } from '@js-temporal/polyfill';
+import { DateTimeSegmentType, TemporalPartial } from './types';
+import { CalendarIdentifier } from '../useCalendar';
+import { isObject } from '../../../shared/src';
+
+export function createTemporalPartial(calendar: CalendarIdentifier, timeZone: string) {
+  const zonedDateTime = Temporal.Now.zonedDateTime(calendar, timeZone);
+  zonedDateTime['~fw_temporal_partial'] = {};
+
+  return zonedDateTime as TemporalPartial;
+}
+
+export function toTemporalPartial(
+  value: Temporal.ZonedDateTime | TemporalPartial,
+  setParts?: DateTimeSegmentType[],
+): TemporalPartial {
+  const clone = Temporal.ZonedDateTime.from(value);
+  clone['~fw_temporal_partial'] = isTemporalPartial(value) ? value['~fw_temporal_partial'] : {};
+  if (setParts) {
+    setParts.forEach(part => {
+      clone['~fw_temporal_partial'][part] = true;
+    });
+  }
+
+  return clone as TemporalPartial;
+}
+
+export function isTemporalPartial(value: Temporal.ZonedDateTime): value is TemporalPartial {
+  return isObject(value['~fw_temporal_partial']);
+}
+
+export function isTemporalPartSet(value: TemporalPartial, part: DateTimeSegmentType): boolean {
+  return part in value['~fw_temporal_partial'] && value['~fw_temporal_partial'][part] === true;
+}

--- a/packages/core/src/useDateTimeField/temporalPartial.ts
+++ b/packages/core/src/useDateTimeField/temporalPartial.ts
@@ -4,17 +4,17 @@ import { CalendarIdentifier } from '../useCalendar';
 import { isObject } from '../../../shared/src';
 
 export function createTemporalPartial(calendar: CalendarIdentifier, timeZone: string) {
-  const zonedDateTime = Temporal.Now.zonedDateTime(calendar, timeZone);
+  const zonedDateTime = Temporal.Now.zonedDateTime(calendar, timeZone) as TemporalPartial;
   zonedDateTime['~fw_temporal_partial'] = {};
 
-  return zonedDateTime as TemporalPartial;
+  return zonedDateTime;
 }
 
 export function toTemporalPartial(
   value: Temporal.ZonedDateTime | TemporalPartial,
   setParts?: DateTimeSegmentType[],
 ): TemporalPartial {
-  const clone = Temporal.ZonedDateTime.from(value);
+  const clone = Temporal.ZonedDateTime.from(value) as TemporalPartial;
   clone['~fw_temporal_partial'] = isTemporalPartial(value) ? value['~fw_temporal_partial'] : {};
   if (setParts) {
     setParts.forEach(part => {
@@ -22,11 +22,11 @@ export function toTemporalPartial(
     });
   }
 
-  return clone as TemporalPartial;
+  return clone;
 }
 
 export function isTemporalPartial(value: Temporal.ZonedDateTime): value is TemporalPartial {
-  return isObject(value['~fw_temporal_partial']);
+  return isObject((value as TemporalPartial)['~fw_temporal_partial']);
 }
 
 export function isTemporalPartSet(value: TemporalPartial, part: DateTimeSegmentType): boolean {

--- a/packages/core/src/useDateTimeField/types.ts
+++ b/packages/core/src/useDateTimeField/types.ts
@@ -25,3 +25,23 @@ export type TemporalDate =
   | Temporal.ZonedDateTime;
 
 export type DateValue = Date | TemporalDate;
+
+export type CalendarIdentifier =
+  | 'buddhist'
+  | 'chinese'
+  | 'coptic'
+  | 'dangi'
+  | 'ethioaa'
+  | 'ethiopic'
+  | 'gregory'
+  | 'hebrew'
+  | 'indian'
+  | 'islamic'
+  | 'islamic-umalqura'
+  | 'islamic-tbla'
+  | 'islamic-civil'
+  | 'islamic-rgsa'
+  | 'iso8601'
+  | 'japanese'
+  | 'persian'
+  | 'roc';

--- a/packages/core/src/useDateTimeField/types.ts
+++ b/packages/core/src/useDateTimeField/types.ts
@@ -1,0 +1,15 @@
+/**
+ * lib.es2017.intl.d.ts
+ */
+export type DateTimeSegmentType =
+  | 'day'
+  | 'dayPeriod'
+  | 'era'
+  | 'hour'
+  | 'literal'
+  | 'minute'
+  | 'month'
+  | 'second'
+  | 'timeZoneName'
+  | 'weekday'
+  | 'year';

--- a/packages/core/src/useDateTimeField/types.ts
+++ b/packages/core/src/useDateTimeField/types.ts
@@ -30,5 +30,4 @@ export type TemporalPartial = Temporal.ZonedDateTime & {
   [`~fw_temporal_partial`]: {
     [key: string]: boolean | undefined;
   };
-  [`~fw_temporal_full_partial`]?: true;
 };

--- a/packages/core/src/useDateTimeField/types.ts
+++ b/packages/core/src/useDateTimeField/types.ts
@@ -16,7 +16,7 @@ export type DateTimeSegmentType =
   | 'weekday'
   | 'year';
 
-export type TemporalDate =
+export type TemporalValue =
   | Temporal.Instant
   | Temporal.PlainDate
   | Temporal.PlainDateTime
@@ -24,24 +24,4 @@ export type TemporalDate =
   | Temporal.PlainYearMonth
   | Temporal.ZonedDateTime;
 
-export type DateValue = Date | TemporalDate;
-
-export type CalendarIdentifier =
-  | 'buddhist'
-  | 'chinese'
-  | 'coptic'
-  | 'dangi'
-  | 'ethioaa'
-  | 'ethiopic'
-  | 'gregory'
-  | 'hebrew'
-  | 'indian'
-  | 'islamic'
-  | 'islamic-umalqura'
-  | 'islamic-tbla'
-  | 'islamic-civil'
-  | 'islamic-rgsa'
-  | 'iso8601'
-  | 'japanese'
-  | 'persian'
-  | 'roc';
+export type DateValue = Date | TemporalValue;

--- a/packages/core/src/useDateTimeField/types.ts
+++ b/packages/core/src/useDateTimeField/types.ts
@@ -25,3 +25,10 @@ export type TemporalValue =
   | Temporal.ZonedDateTime;
 
 export type DateValue = Date | TemporalValue;
+
+export type TemporalPartial = Temporal.ZonedDateTime & {
+  [`~fw_temporal_partial`]: {
+    [key: string]: boolean | undefined;
+  };
+  [`~fw_temporal_full_partial`]?: true;
+};

--- a/packages/core/src/useDateTimeField/types.ts
+++ b/packages/core/src/useDateTimeField/types.ts
@@ -1,3 +1,5 @@
+import type { Temporal } from '@js-temporal/polyfill';
+
 /**
  * lib.es2017.intl.d.ts
  */
@@ -13,3 +15,13 @@ export type DateTimeSegmentType =
   | 'timeZoneName'
   | 'weekday'
   | 'year';
+
+export type TemporalDate =
+  | Temporal.Instant
+  | Temporal.PlainDate
+  | Temporal.PlainDateTime
+  | Temporal.PlainTime
+  | Temporal.PlainYearMonth
+  | Temporal.ZonedDateTime;
+
+export type DateValue = Date | TemporalDate;

--- a/packages/core/src/useDateTimeField/useCalendar.ts
+++ b/packages/core/src/useDateTimeField/useCalendar.ts
@@ -1,0 +1,124 @@
+import { computed, MaybeRefOrGetter, Ref, toValue } from 'vue';
+import { Temporal } from '@js-temporal/polyfill';
+import { CalendarIdentifier } from './types';
+import { normalizeProps } from '../utils/common';
+import { Reactivify } from '../types';
+import { useDateFormatter, useLocale } from '../i18n';
+import { WeekInfo } from '../i18n/getWeekInfo';
+
+interface CalendarProps {
+  locale: string;
+
+  calendar: CalendarIdentifier;
+
+  currentDate: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime;
+}
+
+export interface CalendarDay {
+  value: Temporal.PlainMonthDay;
+  dayOfMonth: number;
+  isToday: boolean;
+  isSelected: boolean;
+  isOutsideMonth: boolean;
+}
+
+interface CalendarContext {
+  locale: Ref<string>;
+  weekInfo: Ref<WeekInfo>;
+  calendar: Ref<Temporal.Calendar>;
+  currentDate: MaybeRefOrGetter<Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime>;
+}
+
+export function useCalendar(_props: Reactivify<CalendarProps>) {
+  const props = normalizeProps(_props);
+  const { weekInfo, locale } = useLocale(props.locale);
+  const calendar = computed(() => new Temporal.Calendar(toValue(props.calendar)));
+  const context: CalendarContext = {
+    weekInfo,
+    locale,
+    calendar,
+    currentDate: props.currentDate,
+  };
+
+  const { daysOfTheWeek } = useDaysOfTheWeek(context);
+  const { days } = useCalendarDays(context);
+
+  return {
+    calendar,
+    days,
+    daysOfTheWeek,
+  };
+}
+
+function useDaysOfTheWeek({ weekInfo, locale, currentDate }: CalendarContext) {
+  const longFormatter = useDateFormatter(locale, { weekday: 'long' });
+  const shortFormatter = useDateFormatter(locale, { weekday: 'short' });
+  const narrowFormatter = useDateFormatter(locale, { weekday: 'narrow' });
+
+  const daysOfTheWeek = computed(() => {
+    let current = toValue(currentDate);
+    const daysPerWeek = current.daysInWeek;
+    const firstDayOfWeek = weekInfo.value.firstDay;
+    // Get the current date's day of week (0-6)
+    const currentDayOfWeek = current.dayOfWeek;
+
+    // Calculate how many days to go back to reach first day of week
+    const daysToSubtract = (currentDayOfWeek - firstDayOfWeek + 7) % 7;
+
+    // Move current date back to first day of week
+    current = current.subtract({ days: daysToSubtract });
+
+    const days: {
+      long: string;
+      short: string;
+      narrow: string;
+    }[] = [];
+    for (let i = 0; i < daysPerWeek; i++) {
+      days.push({
+        long: longFormatter.value.format(current.add({ days: i })),
+        short: shortFormatter.value.format(current.add({ days: i })),
+        narrow: narrowFormatter.value.format(current.add({ days: i })),
+      });
+    }
+
+    return days;
+  });
+
+  return { daysOfTheWeek };
+}
+
+function useCalendarDays({ weekInfo, currentDate, calendar }: CalendarContext) {
+  const days = computed<CalendarDay[]>(() => {
+    const current = toValue(currentDate);
+    const plainCurrent = current.toPlainMonthDay();
+    const startOfMonth = current.with({ day: 1 });
+
+    const firstDayOfWeek = weekInfo.value.firstDay;
+    const startDayOfWeek = startOfMonth.dayOfWeek;
+    const daysToSubtract = (startDayOfWeek - firstDayOfWeek + 7) % 7;
+
+    // Move to first day of week
+    const firstDay = startOfMonth.subtract({ days: daysToSubtract });
+
+    // Calculate total days needed to fill grid
+    const daysInMonth = startOfMonth.daysInMonth;
+    const totalDays = daysInMonth + daysToSubtract;
+    const remainingDays = 7 - (totalDays % 7);
+    const gridDays = totalDays + (remainingDays === 7 ? 0 : remainingDays);
+    const now = Temporal.Now.plainDate(calendar.value);
+
+    return Array.from({ length: gridDays }, (_, i) => {
+      const dayOfMonth = firstDay.add({ days: i }).toPlainMonthDay();
+
+      return {
+        value: dayOfMonth,
+        dayOfMonth: dayOfMonth.day,
+        isToday: dayOfMonth.equals(now),
+        isSelected: plainCurrent.equals(dayOfMonth),
+        isOutsideMonth: dayOfMonth.monthCode !== plainCurrent.monthCode,
+      } as CalendarDay;
+    });
+  });
+
+  return { days };
+}

--- a/packages/core/src/useDateTimeField/useCalendar.ts
+++ b/packages/core/src/useDateTimeField/useCalendar.ts
@@ -7,11 +7,11 @@ import { useDateFormatter, useLocale } from '../i18n';
 import { WeekInfo } from '../i18n/getWeekInfo';
 
 interface CalendarProps {
-  locale: string;
+  locale?: string;
 
-  calendar: CalendarIdentifier;
+  calendar?: CalendarIdentifier;
 
-  currentDate: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime;
+  currentDate?: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime;
 }
 
 export interface CalendarDay {
@@ -29,15 +29,16 @@ interface CalendarContext {
   currentDate: MaybeRefOrGetter<Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime>;
 }
 
-export function useCalendar(_props: Reactivify<CalendarProps>) {
+export function useCalendar(_props: Reactivify<CalendarProps> = {}) {
   const props = normalizeProps(_props);
-  const { weekInfo, locale } = useLocale(props.locale);
-  const calendar = computed(() => new Temporal.Calendar(toValue(props.calendar)));
+  const { weekInfo, locale, calendar } = useLocale(props.locale);
+  const currentDate = computed(() => toValue(props.currentDate) ?? Temporal.Now.plainDate(calendar.value));
+
   const context: CalendarContext = {
     weekInfo,
     locale,
     calendar,
-    currentDate: props.currentDate,
+    currentDate,
   };
 
   const { daysOfTheWeek } = useDaysOfTheWeek(context);

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -31,15 +31,16 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
   const field = useFormField<Date>({
     path: props.name,
     disabled: props.disabled,
-    initialValue: toValue(props.modelValue) ?? toValue(props.value),
+    initialValue: toValue(props.modelValue) ?? toValue(props.value) ?? new Date(),
     schema: props.schema,
   });
 
   const { fieldValue } = field;
   const { segments } = useDateTimeSegmentGroup({
-    dateValue: fieldValue,
+    dateValue: () => fieldValue.value ?? new Date(),
     formatter,
     controlEl,
+    onValueChange: field.setValue,
   });
 
   const { labelProps, labelledByProps } = useLabel({

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -95,7 +95,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
   const field = useFormField<Maybe<Date>>({
     path: props.name,
     disabled: props.disabled,
-    initialValue: toValue(props.modelValue) ?? toValue(props.value) ?? new Date(),
+    initialValue: toValue(props.modelValue) ?? toValue(props.value),
     schema: props.schema,
   });
 

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -1,5 +1,5 @@
 import { Maybe, Reactivify } from '../types';
-import { CalendarProps } from '../useCalendar';
+import { CalendarIdentifier, CalendarProps } from '../useCalendar';
 import { createDescribedByProps, isNullOrUndefined, normalizeProps, useUniqId, withRefCapture } from '../utils/common';
 import { computed, shallowRef, toValue } from 'vue';
 import { exposeField, useFormField } from '../useFormField';
@@ -29,7 +29,10 @@ export interface DateTimeFieldProps {
 export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'>) {
   const props = normalizeProps(_props, ['schema']);
   const controlEl = shallowRef<HTMLInputElement>();
-  const { locale } = useLocale(props.locale);
+  const { locale, direction } = useLocale(props.locale, {
+    calendar: () => toValue(props.formatOptions)?.calendar as CalendarIdentifier,
+  });
+
   const formatter = useDateFormatter(locale, props.formatOptions);
   const controlId = useUniqId(FieldTypePrefixes.DateTimeField);
 
@@ -101,6 +104,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
       segments,
       errorMessageProps,
       calendarProps,
+      direction,
     },
     field,
   );

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -1,4 +1,4 @@
-import { Maybe, Reactivify } from '../types';
+import { Maybe, Reactivify, StandardSchema } from '../types';
 import { CalendarIdentifier, CalendarProps } from '../useCalendar';
 import { createDescribedByProps, isNullOrUndefined, normalizeProps, useUniqId, withRefCapture } from '../utils/common';
 import { computed, shallowRef, toValue } from 'vue';
@@ -12,25 +12,72 @@ import { DateValue } from './types';
 import { Temporal, toTemporalInstant } from '@js-temporal/polyfill';
 
 export interface DateTimeFieldProps {
+  /**
+   * The label to use for the field.
+   */
   label: string;
-  locale?: string;
+
+  /**
+   * The name to use for the field.
+   */
   name: string;
+
+  /**
+   * The locale to use for the field.
+   */
+  locale?: string;
+
+  /**
+   * The calendar type to use for the field, e.g. `gregory`, `islamic-umalqura`, etc.
+   */
+  calendar?: CalendarIdentifier;
+
+  /**
+   * The Intl.DateTimeFormatOptions to use for the field, used to format the date value.
+   */
   formatOptions?: Intl.DateTimeFormatOptions;
+
+  /**
+   * The description to use for the field.
+   */
   description?: string;
+
+  /**
+   * The placeholder to use for the field.
+   */
   placeholder?: string;
+
+  /**
+   * Whether the field is readonly.
+   */
   readonly?: boolean;
+
+  /**
+   * Whether the field is disabled.
+   */
   disabled?: boolean;
+
+  /**
+   * The value to use for the field.
+   */
   value?: DateValue;
+
+  /**
+   * The model value to use for the field.
+   */
   modelValue?: DateValue;
 
-  schema?: any;
+  /**
+   * The schema to use for the field.
+   */
+  schema?: StandardSchema<DateValue>;
 }
 
 export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'>) {
   const props = normalizeProps(_props, ['schema']);
   const controlEl = shallowRef<HTMLInputElement>();
   const { locale, direction } = useLocale(props.locale, {
-    calendar: () => toValue(props.formatOptions)?.calendar as CalendarIdentifier,
+    calendar: () => toValue(props.calendar) ?? (toValue(props.formatOptions)?.calendar as CalendarIdentifier),
   });
 
   const formatter = useDateFormatter(locale, props.formatOptions);

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -99,6 +99,24 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     schema: props.schema,
   });
 
+  const minDate = useTemporalStore({
+    calendar: calendar,
+    timeZone: timeZone,
+    locale: locale,
+    model: {
+      get: () => toValue(props.minDate),
+    },
+  });
+
+  const maxDate = useTemporalStore({
+    calendar: calendar,
+    timeZone: timeZone,
+    locale: locale,
+    model: {
+      get: () => toValue(props.maxDate),
+    },
+  });
+
   const temporalValue = useTemporalStore({
     calendar: calendar,
     timeZone: timeZone,
@@ -142,6 +160,8 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     locale: () => locale.value,
     currentDate: temporalValue,
     onDaySelected: onValueChange,
+    minDate,
+    maxDate,
   };
 
   const controlProps = computed(() => {

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -9,6 +9,7 @@ import { useDateFormatter, useLocale } from '../i18n';
 import { useErrorMessage, useLabel } from '../a11y';
 import { useTemporalStore } from './useTemporalStore';
 import { Temporal } from '@js-temporal/polyfill';
+import { isTemporalPartial } from './temporalPartial';
 
 export interface DateTimeFieldProps {
   /**
@@ -160,8 +161,8 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     locale: () => locale.value,
     currentDate: temporalValue,
     onDaySelected: onValueChange,
-    minDate,
-    maxDate,
+    minDate: () => (isTemporalPartial(minDate.value) ? undefined : minDate.value),
+    maxDate: () => (isTemporalPartial(maxDate.value) ? undefined : maxDate.value),
   };
 
   const controlProps = computed(() => {

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -28,9 +28,8 @@ export interface DateTimeFieldProps {
 export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'>) {
   const props = normalizeProps(_props, ['schema']);
   const controlEl = shallowRef<HTMLInputElement>();
-  const { locale } = useLocale();
-  const fieldLocale = computed(() => toValue(props.locale) ?? locale.value);
-  const formatter = useDateFormatter(fieldLocale, props.formatOptions);
+  const { locale } = useLocale(props.locale);
+  const formatter = useDateFormatter(locale, props.formatOptions);
   const controlId = useUniqId(FieldTypePrefixes.DateTimeField);
 
   const field = useFormField<DateValue>({
@@ -42,7 +41,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
 
   const { fieldValue } = field;
   const { segments } = useDateTimeSegmentGroup({
-    dateValue: () => normalizeDateValue(fieldValue.value, fieldLocale.value),
+    dateValue: () => normalizeDateValue(fieldValue.value, locale.value),
     formatter,
     controlEl,
     onValueChange: field.setValue,

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -1,0 +1,83 @@
+import { Reactivify } from '../types';
+import { createDescribedByProps, normalizeProps, useUniqId, withRefCapture } from '../utils/common';
+import { computed, shallowRef, toValue } from 'vue';
+import { exposeField, useFormField } from '../useFormField';
+import { useDateTimeSegmentGroup } from './useDateTimeSegmentGroup';
+import { FieldTypePrefixes } from '../constants';
+import { useDateFormatter, useLocale } from '../i18n';
+import { useErrorMessage, useLabel } from '../a11y';
+
+export interface DateTimeFieldProps {
+  label: string;
+  locale?: string;
+  name: string;
+  formatOptions?: Intl.DateTimeFormatOptions;
+  description?: string;
+  placeholder?: string;
+  readonly?: boolean;
+  disabled?: boolean;
+  value?: Date;
+  modelValue?: Date;
+
+  schema?: any;
+}
+
+export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'>) {
+  const props = normalizeProps(_props, ['schema']);
+  const controlEl = shallowRef<HTMLInputElement>();
+  const { locale } = useLocale();
+  const formatter = useDateFormatter(() => toValue(props.locale) ?? locale.value, props.formatOptions);
+  const controlId = useUniqId(FieldTypePrefixes.DateTimeField);
+  const field = useFormField<Date>({
+    path: props.name,
+    disabled: props.disabled,
+    initialValue: toValue(props.modelValue) ?? toValue(props.value),
+    schema: props.schema,
+  });
+
+  const { fieldValue } = field;
+  const { segments } = useDateTimeSegmentGroup({
+    dateValue: fieldValue,
+    formatter,
+  });
+
+  const { labelProps, labelledByProps } = useLabel({
+    for: controlId,
+    label: props.label,
+    targetRef: controlEl,
+  });
+
+  const { descriptionProps, describedByProps } = createDescribedByProps({
+    inputId: controlId,
+    description: props.description,
+  });
+
+  const { errorMessageProps, accessibleErrorProps } = useErrorMessage({
+    inputId: controlId,
+    errorMessage: field.errorMessage,
+  });
+
+  const controlProps = computed(() => {
+    return withRefCapture(
+      {
+        id: controlId,
+        ...labelledByProps.value,
+        ...describedByProps.value,
+        ...accessibleErrorProps.value,
+      },
+      controlEl,
+    );
+  });
+
+  return exposeField(
+    {
+      controlEl,
+      controlProps,
+      descriptionProps,
+      labelProps,
+      segments,
+      errorMessageProps,
+    },
+    field,
+  );
+}

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -39,6 +39,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
   const { segments } = useDateTimeSegmentGroup({
     dateValue: fieldValue,
     formatter,
+    controlEl,
   });
 
   const { labelProps, labelledByProps } = useLabel({

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -102,6 +102,8 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
 
   const { segments } = useDateTimeSegmentGroup({
     formatter,
+    locale,
+    formatOptions: props.formatOptions,
     controlEl,
     temporalValue,
     onValueChange,

--- a/packages/core/src/useDateTimeField/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegment.ts
@@ -1,6 +1,6 @@
 import { computed, defineComponent, h, inject, shallowRef, toValue } from 'vue';
 import { Reactivify } from '../types';
-import { normalizeProps, useUniqId, withRefCapture } from '../utils/common';
+import { hasKeyCode, normalizeProps, useUniqId, withRefCapture } from '../utils/common';
 import { DateTimeSegmentGroupKey } from './useDateTimeSegmentGroup';
 import { FieldTypePrefixes } from '../constants';
 
@@ -49,12 +49,33 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
     getType: () => toValue(props.type),
   });
 
+  const handlers = {
+    onKeydown(evt: KeyboardEvent) {
+      if (isLiteral()) {
+        evt.preventDefault();
+        return;
+      }
+
+      if (hasKeyCode(evt, 'ArrowUp')) {
+        evt.preventDefault();
+        evt.stopPropagation();
+      }
+
+      if (hasKeyCode(evt, 'ArrowDown')) {
+        evt.preventDefault();
+        evt.stopPropagation();
+      }
+    },
+  };
+
   const segmentProps = computed(() => {
     return withRefCapture(
       {
         id,
         tabindex: isLiteral() ? '-1' : '0',
         contenteditable: isLiteral() ? undefined : 'plaintext-only',
+        'data-segment-type': toValue(props.type),
+        ...handlers,
       },
       segmentEl,
     );

--- a/packages/core/src/useDateTimeField/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegment.ts
@@ -17,6 +17,11 @@ export interface DateTimeSegmentProps {
    * The text value of the segment.
    */
   value: string;
+
+  /**
+   * Whether the segment is disabled.
+   */
+  disabled?: boolean;
 }
 
 export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
@@ -24,7 +29,7 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
   const id = useUniqId(FieldTypePrefixes.DateTimeSegment);
   const segmentEl = shallowRef<HTMLSpanElement>();
   const segmentGroup = inject(DateTimeSegmentGroupKey, null);
-  const isNonEditable = () => NON_EDITABLE_SEGMENT_TYPES.includes(toValue(props.type));
+  const isNonEditable = () => toValue(props.disabled) || NON_EDITABLE_SEGMENT_TYPES.includes(toValue(props.type));
 
   if (!segmentGroup) {
     throw new Error('DateTimeSegmentGroup is not provided');
@@ -38,20 +43,19 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
 
   const handlers = {
     onKeydown(evt: KeyboardEvent) {
-      if (isNonEditable()) {
-        blockEvent(evt);
-        return;
-      }
-
       if (hasKeyCode(evt, 'ArrowUp')) {
         blockEvent(evt);
-        increment();
+        if (!isNonEditable()) {
+          increment();
+        }
         return;
       }
 
       if (hasKeyCode(evt, 'ArrowDown')) {
         blockEvent(evt);
-        decrement();
+        if (!isNonEditable()) {
+          decrement();
+        }
         return;
       }
     },
@@ -63,6 +67,7 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
         id,
         tabindex: isNonEditable() ? '-1' : '0',
         contenteditable: isNonEditable() ? undefined : 'plaintext-only',
+        'aria-disabled': toValue(props.disabled),
         'data-segment-type': toValue(props.type),
         ...handlers,
       },
@@ -77,7 +82,7 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
 
 export const DateTimeSegment = defineComponent<DateTimeSegmentProps>({
   name: 'DateTimeSegment',
-  props: ['type', 'value'],
+  props: ['type', 'value', 'disabled'],
   setup(props) {
     const { segmentProps } = useDateTimeSegment(props);
 

--- a/packages/core/src/useDateTimeField/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegment.ts
@@ -50,6 +50,8 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
     getType: () => toValue(props.type),
   });
 
+  const isNumeric = computed(() => parser.isValidNumberPart(toValue(props.value)));
+
   let currentInput = '';
 
   const handlers = {
@@ -64,6 +66,10 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
       }
 
       blockEvent(evt);
+      if (!isNumeric.value) {
+        return;
+      }
+
       const nextValue = currentInput + evt.data;
       currentInput = nextValue;
 

--- a/packages/core/src/useDateTimeField/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegment.ts
@@ -4,22 +4,8 @@ import { hasKeyCode, normalizeProps, useUniqId, withRefCapture } from '../utils/
 import { DateTimeSegmentGroupKey } from './useDateTimeSegmentGroup';
 import { FieldTypePrefixes } from '../constants';
 import { blockEvent } from '../utils/events';
-
-/**
- * lib.es2017.intl.d.ts
- */
-export type DateTimeSegmentType =
-  | 'day'
-  | 'dayPeriod'
-  | 'era'
-  | 'hour'
-  | 'literal'
-  | 'minute'
-  | 'month'
-  | 'second'
-  | 'timeZoneName'
-  | 'weekday'
-  | 'year';
+import { DateTimeSegmentType } from './types';
+import { NON_EDITABLE_SEGMENT_TYPES } from './constants';
 
 export interface DateTimeSegmentProps {
   /**
@@ -38,7 +24,7 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
   const id = useUniqId(FieldTypePrefixes.DateTimeSegment);
   const segmentEl = shallowRef<HTMLSpanElement>();
   const segmentGroup = inject(DateTimeSegmentGroupKey, null);
-  const isLiteral = () => toValue(props.type) === 'literal';
+  const isNonEditable = () => NON_EDITABLE_SEGMENT_TYPES.includes(toValue(props.type));
 
   if (!segmentGroup) {
     throw new Error('DateTimeSegmentGroup is not provided');
@@ -52,7 +38,7 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
 
   const handlers = {
     onKeydown(evt: KeyboardEvent) {
-      if (isLiteral()) {
+      if (isNonEditable()) {
         blockEvent(evt);
         return;
       }
@@ -75,8 +61,8 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
     return withRefCapture(
       {
         id,
-        tabindex: isLiteral() ? '-1' : '0',
-        contenteditable: isLiteral() ? undefined : 'plaintext-only',
+        tabindex: isNonEditable() ? '-1' : '0',
+        contenteditable: isNonEditable() ? undefined : 'plaintext-only',
         'data-segment-type': toValue(props.type),
         ...handlers,
       },

--- a/packages/core/src/useDateTimeField/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegment.ts
@@ -5,7 +5,7 @@ import { DateTimeSegmentGroupKey } from './useDateTimeSegmentGroup';
 import { FieldTypePrefixes } from '../constants';
 import { blockEvent } from '../utils/events';
 import { DateTimeSegmentType } from './types';
-import { NON_EDITABLE_SEGMENT_TYPES } from './constants';
+import { isEditableSegmentType } from './constants';
 
 export interface DateTimeSegmentProps {
   /**
@@ -29,7 +29,7 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
   const id = useUniqId(FieldTypePrefixes.DateTimeSegment);
   const segmentEl = shallowRef<HTMLSpanElement>();
   const segmentGroup = inject(DateTimeSegmentGroupKey, null);
-  const isNonEditable = () => toValue(props.disabled) || NON_EDITABLE_SEGMENT_TYPES.includes(toValue(props.type));
+  const isNonEditable = () => toValue(props.disabled) || !isEditableSegmentType(toValue(props.type));
 
   if (!segmentGroup) {
     throw new Error('DateTimeSegmentGroup is not provided');

--- a/packages/core/src/useDateTimeField/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegment.ts
@@ -1,4 +1,4 @@
-import { computed, defineComponent, h, inject, shallowRef, toValue } from 'vue';
+import { computed, CSSProperties, defineComponent, h, inject, shallowRef, toValue } from 'vue';
 import { Reactivify } from '../types';
 import { hasKeyCode, normalizeProps, useUniqId, withRefCapture } from '../utils/common';
 import { DateTimeSegmentGroupKey } from './useDateTimeSegmentGroup';
@@ -24,6 +24,15 @@ export interface DateTimeSegmentProps {
   disabled?: boolean;
 }
 
+interface DateTimeSegmentDomProps {
+  id: string;
+  tabindex: number;
+  contenteditable: string | undefined;
+  'aria-disabled': boolean | undefined;
+  'data-segment-type': DateTimeSegmentType;
+  style?: CSSProperties;
+}
+
 export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
   const props = normalizeProps(_props);
   const id = useUniqId(FieldTypePrefixes.DateTimeSegment);
@@ -42,6 +51,7 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
   });
 
   const handlers = {
+    onFocus() {},
     onKeydown(evt: KeyboardEvent) {
       if (hasKeyCode(evt, 'ArrowUp')) {
         blockEvent(evt);
@@ -62,17 +72,20 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
   };
 
   const segmentProps = computed(() => {
-    return withRefCapture(
-      {
-        id,
-        tabindex: isNonEditable() ? '-1' : '0',
-        contenteditable: isNonEditable() ? undefined : 'plaintext-only',
-        'aria-disabled': toValue(props.disabled),
-        'data-segment-type': toValue(props.type),
-        ...handlers,
-      },
-      segmentEl,
-    );
+    const domProps: DateTimeSegmentDomProps = {
+      id,
+      tabindex: isNonEditable() ? -1 : 0,
+      contenteditable: isNonEditable() ? undefined : 'plaintext-only',
+      'aria-disabled': toValue(props.disabled),
+      'data-segment-type': toValue(props.type),
+      ...handlers,
+    };
+
+    if (isNonEditable()) {
+      domProps.style = { pointerEvents: 'none' };
+    }
+
+    return withRefCapture(domProps, segmentEl);
   });
 
   return {

--- a/packages/core/src/useDateTimeField/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegment.ts
@@ -1,0 +1,76 @@
+import { computed, defineComponent, h, inject, shallowRef, toValue } from 'vue';
+import { Reactivify } from '../types';
+import { normalizeProps, useUniqId, withRefCapture } from '../utils/common';
+import { DateTimeSegmentGroupKey } from './useDateTimeSegmentGroup';
+import { FieldTypePrefixes } from '../constants';
+
+/**
+ * lib.es2017.intl.d.ts
+ */
+export type DateTimeSegmentType =
+  | 'day'
+  | 'dayPeriod'
+  | 'era'
+  | 'hour'
+  | 'literal'
+  | 'minute'
+  | 'month'
+  | 'second'
+  | 'timeZoneName'
+  | 'weekday'
+  | 'year';
+
+export interface DateTimeSegmentProps {
+  /**
+   * The type of the segment.
+   */
+  type: DateTimeSegmentType;
+
+  /**
+   * The text value of the segment.
+   */
+  value: string;
+}
+
+export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
+  const props = normalizeProps(_props);
+  const id = useUniqId(FieldTypePrefixes.DateTimeSegment);
+  const segmentEl = shallowRef<HTMLSpanElement>();
+  const segmentGroup = inject(DateTimeSegmentGroupKey, null);
+  const isLiteral = () => toValue(props.type) === 'literal';
+
+  if (!segmentGroup) {
+    throw new Error('DateTimeSegmentGroup is not provided');
+  }
+
+  segmentGroup.useDateSegmentRegistration({
+    id,
+    getElem: () => segmentEl.value,
+    getType: () => toValue(props.type),
+  });
+
+  const segmentProps = computed(() => {
+    return withRefCapture(
+      {
+        id,
+        tabindex: isLiteral() ? '-1' : '0',
+        contenteditable: isLiteral() ? undefined : 'plaintext-only',
+      },
+      segmentEl,
+    );
+  });
+
+  return {
+    segmentProps,
+  };
+}
+
+export const DateTimeSegment = defineComponent<DateTimeSegmentProps>({
+  name: 'DateTimeSegment',
+  props: ['type', 'value'],
+  setup(props) {
+    const { segmentProps } = useDateTimeSegment(props);
+
+    return () => h('span', segmentProps.value, props.value);
+  },
+});

--- a/packages/core/src/useDateTimeField/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegment.ts
@@ -44,11 +44,12 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
     throw new Error('DateTimeSegmentGroup is not provided');
   }
 
-  const { increment, decrement, setValue, getMetadata, onDone, parser } = segmentGroup.useDateSegmentRegistration({
-    id,
-    getElem: () => segmentEl.value,
-    getType: () => toValue(props.type),
-  });
+  const { increment, decrement, setValue, getMetadata, onDone, parser, clear } =
+    segmentGroup.useDateSegmentRegistration({
+      id,
+      getElem: () => segmentEl.value,
+      getType: () => toValue(props.type),
+    });
 
   const isNumeric = computed(() => parser.isValidNumberPart(toValue(props.value)));
 
@@ -123,6 +124,13 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
           decrement();
         }
         return;
+      }
+
+      if (hasKeyCode(evt, 'Backspace') || hasKeyCode(evt, 'Delete')) {
+        blockEvent(evt);
+        if (!isNonEditable()) {
+          clear();
+        }
       }
     },
   };

--- a/packages/core/src/useDateTimeField/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegment.ts
@@ -3,6 +3,7 @@ import { Reactivify } from '../types';
 import { hasKeyCode, normalizeProps, useUniqId, withRefCapture } from '../utils/common';
 import { DateTimeSegmentGroupKey } from './useDateTimeSegmentGroup';
 import { FieldTypePrefixes } from '../constants';
+import { blockEvent } from '../utils/events';
 
 /**
  * lib.es2017.intl.d.ts
@@ -43,7 +44,7 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
     throw new Error('DateTimeSegmentGroup is not provided');
   }
 
-  segmentGroup.useDateSegmentRegistration({
+  const { increment, decrement } = segmentGroup.useDateSegmentRegistration({
     id,
     getElem: () => segmentEl.value,
     getType: () => toValue(props.type),
@@ -52,18 +53,20 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
   const handlers = {
     onKeydown(evt: KeyboardEvent) {
       if (isLiteral()) {
-        evt.preventDefault();
+        blockEvent(evt);
         return;
       }
 
       if (hasKeyCode(evt, 'ArrowUp')) {
-        evt.preventDefault();
-        evt.stopPropagation();
+        blockEvent(evt);
+        increment();
+        return;
       }
 
       if (hasKeyCode(evt, 'ArrowDown')) {
-        evt.preventDefault();
-        evt.stopPropagation();
+        blockEvent(evt);
+        decrement();
+        return;
       }
     },
   };

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -1,5 +1,9 @@
 import { InjectionKey, MaybeRefOrGetter, provide, ref, toValue, Ref, onBeforeUnmount, computed } from 'vue';
 import { DateTimeSegmentType } from './useDateTimeSegment';
+import { hasKeyCode } from '../utils/common';
+import { blockEvent } from '../utils/events';
+import { Direction } from '../types';
+import { useEventListener } from '../helpers/useEventListener';
 
 export interface DateTimeSegmentRegistration {
   id: string;
@@ -16,9 +20,11 @@ export const DateTimeSegmentGroupKey: InjectionKey<DateTimeSegmentGroupContext> 
 export interface DateTimeSegmentGroupProps {
   formatter: Ref<Intl.DateTimeFormat>;
   dateValue: MaybeRefOrGetter<Date | undefined>;
+  direction?: MaybeRefOrGetter<Direction>;
+  controlEl: Ref<HTMLElement | undefined>;
 }
 
-export function useDateTimeSegmentGroup({ formatter, dateValue }: DateTimeSegmentGroupProps) {
+export function useDateTimeSegmentGroup({ formatter, dateValue, direction, controlEl }: DateTimeSegmentGroupProps) {
   const renderedSegments = ref<DateTimeSegmentRegistration[]>([]);
   const segments = computed(() => {
     return formatter.value.formatToParts(toValue(dateValue)) as { type: DateTimeSegmentType; value: string }[];
@@ -30,6 +36,65 @@ export function useDateTimeSegmentGroup({ formatter, dateValue }: DateTimeSegmen
       renderedSegments.value = renderedSegments.value.filter(s => s.id !== segment.id);
     });
   }
+
+  function focusBasedOnDirection(evt: KeyboardEvent) {
+    const dir = toValue(direction) ?? 'ltr';
+    if (hasKeyCode(evt, 'ArrowLeft')) {
+      return dir === 'ltr' ? focusPreviousSegment() : focusNextSegment();
+    }
+
+    if (hasKeyCode(evt, 'ArrowRight')) {
+      return dir === 'ltr' ? focusNextSegment() : focusPreviousSegment();
+    }
+  }
+
+  function getFocusedSegment() {
+    return renderedSegments.value.find(s => s.getElem() === document.activeElement);
+  }
+
+  function getSegmentElements() {
+    return Array.from(controlEl.value?.querySelectorAll('[data-segment-type]') || []).filter(el => {
+      return (el as HTMLElement).tabIndex === 0;
+    }) as HTMLElement[];
+  }
+
+  function focusNextSegment() {
+    const focusedElement = getFocusedSegment()?.getElem();
+    if (!focusedElement) {
+      return;
+    }
+
+    const segmentElements = getSegmentElements();
+    const currentIndex = segmentElements.indexOf(focusedElement);
+    const nextIndex = currentIndex + 1;
+    if (nextIndex < segmentElements.length) {
+      segmentElements[nextIndex]?.focus();
+    }
+  }
+
+  function focusPreviousSegment() {
+    const focusedElement = getFocusedSegment()?.getElem();
+    if (!focusedElement) {
+      return;
+    }
+
+    const segmentElements = getSegmentElements();
+    const currentIndex = segmentElements.indexOf(focusedElement);
+    const previousIndex = currentIndex - 1;
+    if (previousIndex >= 0) {
+      segmentElements[previousIndex]?.focus();
+    }
+  }
+
+  function onKeydown(evt: KeyboardEvent) {
+    if (hasKeyCode(evt, 'ArrowLeft') || hasKeyCode(evt, 'ArrowRight')) {
+      blockEvent(evt);
+      focusBasedOnDirection(evt);
+      return;
+    }
+  }
+
+  useEventListener(controlEl, 'keydown', onKeydown);
 
   provide(DateTimeSegmentGroupKey, {
     useDateSegmentRegistration,

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -85,9 +85,7 @@ export function useDateTimeSegmentGroup({
   }
 
   function getSegmentElements() {
-    return Array.from(controlEl.value?.querySelectorAll('[data-segment-type]') || []).filter(el => {
-      return (el as HTMLElement).tabIndex === 0;
-    }) as HTMLElement[];
+    return Array.from(controlEl.value?.querySelectorAll('[data-segment-type]') || []);
   }
 
   function focusNextSegment() {
@@ -99,8 +97,12 @@ export function useDateTimeSegmentGroup({
     const segmentElements = getSegmentElements();
     const currentIndex = segmentElements.indexOf(focusedElement);
     const nextIndex = currentIndex + 1;
-    if (nextIndex < segmentElements.length) {
-      segmentElements[nextIndex]?.focus();
+    for (let i = nextIndex; i < segmentElements.length; i++) {
+      const element = segmentElements[i] as HTMLElement;
+      if (element.tabIndex === 0) {
+        element.focus();
+        return;
+      }
     }
   }
 
@@ -113,8 +115,12 @@ export function useDateTimeSegmentGroup({
     const segmentElements = getSegmentElements();
     const currentIndex = segmentElements.indexOf(focusedElement);
     const previousIndex = currentIndex - 1;
-    if (previousIndex >= 0) {
-      segmentElements[previousIndex]?.focus();
+    for (let i = previousIndex; i >= 0; i--) {
+      const element = segmentElements[i] as HTMLElement;
+      if (element.tabIndex === 0) {
+        element.focus();
+        return;
+      }
     }
   }
 

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -1,0 +1,42 @@
+import { InjectionKey, MaybeRefOrGetter, provide, ref, toValue, Ref, onBeforeUnmount, computed } from 'vue';
+import { DateTimeSegmentType } from './useDateTimeSegment';
+
+export interface DateTimeSegmentRegistration {
+  id: string;
+  getType(): DateTimeSegmentType;
+  getElem(): HTMLElement | undefined;
+}
+
+export interface DateTimeSegmentGroupContext {
+  useDateSegmentRegistration(segment: DateTimeSegmentRegistration): void;
+}
+
+export const DateTimeSegmentGroupKey: InjectionKey<DateTimeSegmentGroupContext> = Symbol('DateTimeSegmentGroupKey');
+
+export interface DateTimeSegmentGroupProps {
+  formatter: Ref<Intl.DateTimeFormat>;
+  dateValue: MaybeRefOrGetter<Date | undefined>;
+}
+
+export function useDateTimeSegmentGroup({ formatter, dateValue }: DateTimeSegmentGroupProps) {
+  const renderedSegments = ref<DateTimeSegmentRegistration[]>([]);
+  const segments = computed(() => {
+    return formatter.value.formatToParts(toValue(dateValue)) as { type: DateTimeSegmentType; value: string }[];
+  });
+
+  function useDateSegmentRegistration(segment: DateTimeSegmentRegistration) {
+    renderedSegments.value.push(segment);
+    onBeforeUnmount(() => {
+      renderedSegments.value = renderedSegments.value.filter(s => s.id !== segment.id);
+    });
+  }
+
+  provide(DateTimeSegmentGroupKey, {
+    useDateSegmentRegistration,
+  });
+
+  return {
+    segments,
+    useDateSegmentRegistration,
+  };
+}

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -162,6 +162,22 @@ function addToPart(part: DateTimeSegmentType, currentDate: TemporalDate, diff: n
     return currentDate;
   }
 
+  if (currentDate instanceof Temporal.ZonedDateTime || currentDate instanceof Temporal.PlainDateTime) {
+    const day = currentDate.day;
+    const month = currentDate.month;
+    const year = currentDate.year;
+
+    return currentDate
+      .add({
+        [durationPart]: diff,
+      })
+      .with({
+        day: part !== 'day' && part !== 'weekday' ? day : undefined,
+        month: part !== 'month' ? month : undefined,
+        year: part !== 'year' ? year : undefined,
+      });
+  }
+
   return currentDate.add({
     [durationPart]: diff,
   });

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -1,6 +1,6 @@
 import { InjectionKey, MaybeRefOrGetter, provide, ref, toValue, Ref, onBeforeUnmount, computed } from 'vue';
 import { Temporal, Intl as TemporalIntl } from '@js-temporal/polyfill';
-import { DateTimeSegmentType, TemporalDate } from './types';
+import { DateTimeSegmentType, TemporalValue } from './types';
 import { hasKeyCode } from '../utils/common';
 import { blockEvent } from '../utils/events';
 import { Direction } from '../types';
@@ -24,10 +24,10 @@ export const DateTimeSegmentGroupKey: InjectionKey<DateTimeSegmentGroupContext> 
 
 export interface DateTimeSegmentGroupProps {
   formatter: Ref<TemporalIntl.DateTimeFormat>;
-  dateValue: MaybeRefOrGetter<TemporalDate>;
+  dateValue: MaybeRefOrGetter<TemporalValue>;
   direction?: MaybeRefOrGetter<Direction>;
   controlEl: Ref<HTMLElement | undefined>;
-  onValueChange: (value: TemporalDate) => void;
+  onValueChange: (value: TemporalValue) => void;
 }
 
 export function useDateTimeSegmentGroup({
@@ -148,7 +148,7 @@ export function useDateTimeSegmentGroup({
   };
 }
 
-function addToPart(part: DateTimeSegmentType, currentDate: TemporalDate, diff: number) {
+function addToPart(part: DateTimeSegmentType, currentDate: TemporalValue, diff: number) {
   if (!isEditableSegmentType(part)) {
     return currentDate;
   }

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -20,9 +20,8 @@ export interface DateTimeSegmentGroupContext {
     increment(): void;
     decrement(): void;
     setValue(value: number): void;
-
-    maxValue(): number | null;
-    minValue(): number | null;
+    getMetadata(): { min: number | null; max: number | null; maxLength: number | null };
+    onDone(): void;
   };
 }
 
@@ -63,6 +62,10 @@ export function useDateTimeSegmentGroup({
     return formatter.value.formatToParts(date.toPlainDateTime()) as { type: DateTimeSegmentType; value: string }[];
   });
 
+  function onSegmentDone() {
+    focusNextSegment();
+  }
+
   function useDateSegmentRegistration(segment: DateTimeSegmentRegistration) {
     renderedSegments.value.push(segment);
     onBeforeUnmount(() => {
@@ -90,7 +93,7 @@ export function useDateTimeSegmentGroup({
       onValueChange(date);
     }
 
-    function maxValue() {
+    function getMetadata() {
       const type = segment.getType();
       const date = toValue(temporalValue);
       const maxPartsRecord: Partial<Record<DateTimeSegmentType, number>> = {
@@ -102,11 +105,6 @@ export function useDateTimeSegmentGroup({
         second: 59,
       };
 
-      return maxPartsRecord[type] ?? null;
-    }
-
-    function minValue() {
-      const type = segment.getType();
       const minPartsRecord: Partial<Record<DateTimeSegmentType, number>> = {
         day: 1,
         month: 1,
@@ -116,7 +114,20 @@ export function useDateTimeSegmentGroup({
         second: 0,
       };
 
-      return minPartsRecord[type] ?? null;
+      const maxLengths: Partial<Record<DateTimeSegmentType, number>> = {
+        day: 2,
+        month: 2,
+        year: 4,
+        hour: 2,
+        minute: 2,
+        second: 2,
+      };
+
+      return {
+        min: minPartsRecord[type] ?? null,
+        max: maxPartsRecord[type] ?? null,
+        maxLength: maxLengths[type] ?? null,
+      };
     }
 
     return {
@@ -124,8 +135,9 @@ export function useDateTimeSegmentGroup({
       decrement,
       setValue,
       parser,
-      maxValue,
-      minValue,
+      onSegmentDone,
+      getMetadata,
+      onDone: onSegmentDone,
     };
   }
 

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -1,9 +1,10 @@
 import { InjectionKey, MaybeRefOrGetter, provide, ref, toValue, Ref, onBeforeUnmount, computed } from 'vue';
-import { DateTimeSegmentType } from './useDateTimeSegment';
+import { DateTimeSegmentType } from './types';
 import { hasKeyCode } from '../utils/common';
 import { blockEvent } from '../utils/events';
 import { Direction } from '../types';
 import { useEventListener } from '../helpers/useEventListener';
+import { NON_EDITABLE_SEGMENT_TYPES } from './constants';
 
 export interface DateTimeSegmentRegistration {
   id: string;
@@ -138,6 +139,10 @@ export function useDateTimeSegmentGroup({
 }
 
 function addToPart(part: DateTimeSegmentType, currentDate: Date, diff: number) {
+  if (NON_EDITABLE_SEGMENT_TYPES.includes(part)) {
+    return currentDate;
+  }
+
   const date = new Date(currentDate.getTime());
   if (part === 'day') {
     date.setDate(date.getDate() + diff);
@@ -164,7 +169,13 @@ function addToPart(part: DateTimeSegmentType, currentDate: Date, diff: number) {
   }
 
   if (part === 'dayPeriod') {
-    date.setHours(date.getHours() + Math.sign(diff) * 12);
+    const currentHours = date.getHours();
+    const isPM = currentHours >= 12;
+    date.setHours(isPM ? currentHours - 12 : currentHours + 12);
+  }
+
+  if (part === 'weekday') {
+    date.setDate(date.getDate() + diff);
   }
 
   return date;

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -295,7 +295,7 @@ function useDateArithmetic({ currentDate }: ArithmeticInit) {
     });
 
     if (isTemporalPartial(date)) {
-      newDate['~fw_temporal_partial'] = {
+      (newDate as TemporalPartial)['~fw_temporal_partial'] = {
         ...date['~fw_temporal_partial'],
         [part]: true,
       };
@@ -334,7 +334,7 @@ function useDateArithmetic({ currentDate }: ArithmeticInit) {
               });
       }
 
-      newDate['~fw_temporal_partial'] = {
+      (newDate as TemporalPartial)['~fw_temporal_partial'] = {
         ...date['~fw_temporal_partial'],
         [part]: true,
       };

--- a/packages/core/src/useDateTimeField/useTemporalStore.ts
+++ b/packages/core/src/useDateTimeField/useTemporalStore.ts
@@ -15,6 +15,7 @@ interface TemporalValueStoreInit {
   locale: MaybeRefOrGetter<string>;
   timeZone: MaybeRefOrGetter<string>;
   calendar: MaybeRefOrGetter<CalendarIdentifier>;
+  allowPartial?: boolean;
 }
 
 export function useTemporalStore(init: TemporalValueStoreInit) {

--- a/packages/core/src/useDateTimeField/useTemporalStore.ts
+++ b/packages/core/src/useDateTimeField/useTemporalStore.ts
@@ -1,0 +1,85 @@
+import { MaybeRefOrGetter, ref, computed, toValue } from 'vue';
+import { CalendarIdentifier } from '../useCalendar';
+import { DateValue } from './types';
+import { toTemporalInstant } from '@js-temporal/polyfill';
+import { Maybe } from '../types';
+import { Temporal } from '@js-temporal/polyfill';
+import { isNullOrUndefined } from '../utils/common';
+
+interface TemporalValueStoreInit {
+  initialValue: Maybe<DateValue>;
+  locale: MaybeRefOrGetter<string>;
+  timeZone: MaybeRefOrGetter<string>;
+  calendar: MaybeRefOrGetter<CalendarIdentifier>;
+}
+
+export function useTemporalStore(init: TemporalValueStoreInit) {
+  const dateValue = ref<Date>(toDate(init.initialValue));
+
+  function toZonedDateTime(value: Maybe<DateValue>): Temporal.ZonedDateTime {
+    if (isNullOrUndefined(value)) {
+      return Temporal.Now.zonedDateTime(toValue(init.calendar), toValue(init.timeZone));
+    }
+
+    if (value instanceof Date) {
+      value = toTemporalInstant.call(value);
+    }
+
+    if (value instanceof Temporal.Instant) {
+      return value.toZonedDateTime({
+        timeZone: toValue(init.timeZone),
+        calendar: toValue(init.calendar),
+      });
+    }
+
+    if (value instanceof Temporal.PlainDate) {
+      return value.toZonedDateTime({
+        timeZone: toValue(init.timeZone),
+      });
+    }
+
+    if (value instanceof Temporal.PlainDateTime) {
+      return value.toZonedDateTime(toValue(init.timeZone));
+    }
+
+    if (value instanceof Temporal.PlainTime) {
+      return value.toZonedDateTime({
+        plainDate: Temporal.Now.plainDate(toValue(init.calendar)),
+        timeZone: toValue(init.timeZone),
+      });
+    }
+
+    if (value instanceof Temporal.PlainYearMonth) {
+      return Temporal.Now.zonedDateTime(toValue(init.calendar), toValue(init.timeZone)).with({
+        year: value.year,
+        month: value.month,
+      });
+    }
+
+    return value;
+  }
+
+  function toDate(value: Maybe<DateValue>): Date {
+    if (isNullOrUndefined(value)) {
+      return new Date();
+    }
+
+    if (value instanceof Date) {
+      return value;
+    }
+
+    return new Date(toZonedDateTime(value).epochMilliseconds);
+  }
+
+  const temporalValue = computed({
+    get: () => toZonedDateTime(dateValue.value),
+    set: value => {
+      dateValue.value = toDate(value);
+    },
+  });
+
+  return {
+    dateValue,
+    temporalValue,
+  };
+}

--- a/packages/core/src/useDateTimeField/useTemporalStore.ts
+++ b/packages/core/src/useDateTimeField/useTemporalStore.ts
@@ -1,4 +1,4 @@
-import { MaybeRefOrGetter, ref, computed, toValue } from 'vue';
+import { MaybeRefOrGetter, computed, toValue } from 'vue';
 import { CalendarIdentifier } from '../useCalendar';
 import { DateValue } from './types';
 import { toTemporalInstant } from '@js-temporal/polyfill';
@@ -7,14 +7,17 @@ import { Temporal } from '@js-temporal/polyfill';
 import { isNullOrUndefined } from '../utils/common';
 
 interface TemporalValueStoreInit {
-  initialValue: Maybe<DateValue>;
+  model: {
+    get: () => Maybe<Date>;
+    set: (value: Maybe<Date>) => void;
+  };
   locale: MaybeRefOrGetter<string>;
   timeZone: MaybeRefOrGetter<string>;
   calendar: MaybeRefOrGetter<CalendarIdentifier>;
 }
 
 export function useTemporalStore(init: TemporalValueStoreInit) {
-  const dateValue = ref<Date>(toDate(init.initialValue));
+  const model = init.model;
 
   function toZonedDateTime(value: Maybe<DateValue>): Temporal.ZonedDateTime {
     if (isNullOrUndefined(value)) {
@@ -72,14 +75,11 @@ export function useTemporalStore(init: TemporalValueStoreInit) {
   }
 
   const temporalValue = computed({
-    get: () => toZonedDateTime(dateValue.value),
+    get: () => toZonedDateTime(model.get()),
     set: value => {
-      dateValue.value = toDate(value);
+      model.set(toDate(value));
     },
   });
 
-  return {
-    dateValue,
-    temporalValue,
-  };
+  return temporalValue;
 }

--- a/packages/core/src/useDateTimeField/useTemporalStore.ts
+++ b/packages/core/src/useDateTimeField/useTemporalStore.ts
@@ -9,7 +9,7 @@ import { isNullOrUndefined } from '../utils/common';
 interface TemporalValueStoreInit {
   model: {
     get: () => Maybe<Date>;
-    set: (value: Maybe<Date>) => void;
+    set?: (value: Maybe<Date>) => void;
   };
   locale: MaybeRefOrGetter<string>;
   timeZone: MaybeRefOrGetter<string>;
@@ -77,7 +77,7 @@ export function useTemporalStore(init: TemporalValueStoreInit) {
   const temporalValue = computed({
     get: () => toZonedDateTime(model.get()),
     set: value => {
-      model.set(toDate(value));
+      model.set?.(toDate(value));
     },
   });
 

--- a/packages/core/src/useDateTimeField/useTemporalStore.ts
+++ b/packages/core/src/useDateTimeField/useTemporalStore.ts
@@ -24,6 +24,10 @@ export function useTemporalStore(init: TemporalValueStoreInit) {
   );
 
   watch(model.get, value => {
+    if (!value && isTemporalPartial(temporalVal.value)) {
+      return;
+    }
+
     temporalVal.value = toZonedDateTime(value) ?? createTemporalPartial(toValue(init.calendar), toValue(init.timeZone));
   });
 
@@ -91,9 +95,7 @@ export function useTemporalStore(init: TemporalValueStoreInit) {
     get: () => temporalVal.value,
     set: value => {
       temporalVal.value = value;
-      if (!isTemporalPartial(value)) {
-        model.set?.(toDate(value));
-      }
+      model.set?.(isTemporalPartial(value) ? undefined : toDate(value));
     },
   });
 

--- a/packages/core/src/useNumberField/useNumberField.ts
+++ b/packages/core/src/useNumberField/useNumberField.ts
@@ -144,8 +144,9 @@ export function useNumberField(
   const props = normalizeProps(_props, ['schema']);
   const inputId = useUniqId(FieldTypePrefixes.NumberField);
   const inputEl = elementRef || shallowRef<HTMLInputElement>();
-  const { locale } = useLocale();
-  const parser = useNumberParser(() => toValue(props.locale) ?? locale.value, props.formatOptions);
+  const { locale } = useLocale(props.locale);
+  const parser = useNumberParser(locale, props.formatOptions);
+
   const field = useFormField<number>({
     path: props.name,
     initialValue: toValue(props.modelValue) ?? fromNumberish(props.value),

--- a/packages/core/src/useNumberField/useNumberField.ts
+++ b/packages/core/src/useNumberField/useNumberField.ts
@@ -1,4 +1,4 @@
-import { Ref, computed, nextTick, shallowRef, toValue } from 'vue';
+import { Ref, computed, nextTick, shallowRef, toValue, watch } from 'vue';
 import {
   createDescribedByProps,
   fromNumberish,
@@ -154,19 +154,28 @@ export function useNumberField(
     schema: props.schema,
   });
 
+  const formattedText = shallowRef<string>('');
   const { validityDetails, updateValidity } = useInputValidity({
     inputEl,
     field,
     disableHtmlValidation: props.disableHtmlValidation,
   });
-  const { fieldValue, setValue, setTouched, errorMessage, isDisabled } = field;
-  const formattedText = computed<string>(() => {
-    if (Number.isNaN(fieldValue.value) || isEmpty(fieldValue.value)) {
-      return '';
-    }
 
-    return parser.format(fieldValue.value);
-  });
+  const { fieldValue, setValue, setTouched, errorMessage, isDisabled } = field;
+
+  watch(
+    [locale, () => toValue(props.formatOptions), fieldValue],
+    () => {
+      if (Number.isNaN(fieldValue.value) || isEmpty(fieldValue.value)) {
+        formattedText.value = '';
+
+        return;
+      }
+
+      formattedText.value = parser.format(fieldValue.value);
+    },
+    { immediate: true },
+  );
 
   const { labelProps, labelledByProps } = useLabel({
     for: inputId,

--- a/packages/core/src/utils/events.ts
+++ b/packages/core/src/utils/events.ts
@@ -47,3 +47,9 @@ export function onlyMainMouseButton(cb: () => unknown) {
     }
   };
 }
+
+export function blockEvent(evt: Event) {
+  evt.preventDefault();
+  evt.stopPropagation();
+  evt.stopImmediatePropagation();
+}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@formwerk/core": "workspace:*",
+    "@js-temporal/polyfill": "^0.4.4",
     "fuse.js": "^7.0.0",
     "tailwindcss": "^3.4.17",
     "vue": "^3.5.13",

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import DateField from '@/components/DateField.vue';
+
+const minDate = new Date('2025-01-01');
+const maxDate = new Date('2025-01-31');
 </script>
 
 <template>
@@ -7,6 +10,8 @@ import DateField from '@/components/DateField.vue';
     <DateField
       name="date"
       label="Date"
+      :min-date="minDate"
+      :max-date="maxDate"
       :format-options="{
         day: '2-digit',
         month: '2-digit',

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -7,13 +7,13 @@ import DateField from '@/components/DateField.vue';
     <DateField
       name="date"
       label="Date"
+      locale="ar-EG"
       :format-options="{
+        calendar: 'islamic-umalqura',
         day: '2-digit',
-        month: '2-digit',
+        month: 'long',
+        weekday: 'long',
         year: 'numeric',
-        hour: 'numeric',
-        minute: 'numeric',
-        hour12: true,
       }"
     />
   </div>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -9,7 +9,7 @@ import DateField from '@/components/DateField.vue';
       label="Date"
       :format-options="{
         day: '2-digit',
-        month: '2-digit',
+        month: 'long',
         year: 'numeric',
         hour: '2-digit',
         hour12: true,

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -10,8 +10,6 @@ const maxDate = new Date('2025-01-31');
     <DateField
       name="date"
       label="Date"
-      :min-date="minDate"
-      :max-date="maxDate"
       :format-options="{
         day: '2-digit',
         month: '2-digit',

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -9,7 +9,6 @@ import DateField from '@/components/DateField.vue';
     <DateField
       name="date"
       label="Date"
-      locale="en-EG-u-ca-islamic"
       :format-options="{
         weekday: 'long',
         day: 'numeric',

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -5,6 +5,19 @@ import DateField from '@/components/DateField.vue';
 
 <template>
   <div class="flex flex-col w-1/2 gap-4">
-    <DateField name="date" label="Date" />
+    <DateField
+      name="date"
+      label="Date"
+      :format-options="{
+        weekday: 'long',
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: 'numeric',
+        hour12: true,
+        era: 'short',
+      }"
+    />
   </div>
 </template>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,33 +1,10 @@
 <script setup lang="ts">
-import z from 'zod';
 import { useForm } from '@formwerk/core';
-import FormGroup from '@/components/FormGroup.vue';
-import InputText from '@/components/InputText.vue';
-
-const { isDirty } = useForm({
-  schema: z.object({
-    name: z.string(),
-    test: z.object({
-      name: z.string(),
-      company: z.object({
-        name: z.string(),
-        address: z.string(),
-      }),
-    }),
-  }),
-});
+import DateField from '@/components/DateField.vue';
 </script>
 
 <template>
   <div class="flex flex-col w-1/2 gap-4">
-    {{ isDirty() }}
-
-    <InputText name="name" label="Your Name" />
-    <InputText name="account.name" label="Account Name" />
-
-    <FormGroup name="company" label="Company">
-      <InputText name="name" label="Account Name" />
-      <InputText name="address" label="Address" />
-    </FormGroup>
+    <DateField name="date" label="Date" />
   </div>
 </template>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { Temporal } from '@js-temporal/polyfill';
 import { useForm } from '@formwerk/core';
 import DateField from '@/components/DateField.vue';
 </script>
@@ -8,6 +9,7 @@ import DateField from '@/components/DateField.vue';
     <DateField
       name="date"
       label="Date"
+      locale="en-EG-u-ca-islamic"
       :format-options="{
         weekday: 'long',
         day: 'numeric',
@@ -16,7 +18,6 @@ import DateField from '@/components/DateField.vue';
         hour: 'numeric',
         minute: 'numeric',
         hour12: true,
-        era: 'short',
       }"
     />
   </div>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -11,6 +11,10 @@ import DateField from '@/components/DateField.vue';
         day: '2-digit',
         month: '2-digit',
         year: 'numeric',
+        hour: '2-digit',
+        hour12: true,
+        minute: '2-digit',
+        second: '2-digit',
       }"
     />
   </div>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -3,11 +3,7 @@ import { Temporal } from '@js-temporal/polyfill';
 import { useCalendar } from '@formwerk/core';
 import DateField from '@/components/DateField.vue';
 
-const { days, daysOfTheWeek } = useCalendar({
-  currentDate: Temporal.Now.plainDate('islamic'),
-  locale: 'en-EG-u-ca-islamic',
-  calendar: 'islamic',
-});
+const { days, daysOfTheWeek } = useCalendar();
 </script>
 
 <template>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,11 +1,35 @@
 <script setup lang="ts">
 import { Temporal } from '@js-temporal/polyfill';
-import { useForm } from '@formwerk/core';
+import { useCalendar } from '@formwerk/core';
 import DateField from '@/components/DateField.vue';
+
+const { days, daysOfTheWeek } = useCalendar({
+  currentDate: Temporal.Now.plainDate('islamic'),
+  locale: 'en-EG-u-ca-islamic',
+  calendar: 'islamic',
+});
 </script>
 
 <template>
   <div class="flex flex-col w-1/2 gap-4">
+    <div class="grid grid-cols-7">
+      <div v-for="day in daysOfTheWeek" :key="day.long" class="flex flex-col items-center justify-center">
+        {{ day.short }}
+      </div>
+
+      <div
+        v-for="day in days"
+        :key="day.dayOfMonth"
+        :aria-checked="day.isToday"
+        class="flex flex-col items-center justify-center aria-checked:bg-blue-600 aria-checked:text-white aria-checked:font-medium"
+        :class="{
+          'text-zinc-500': day.isOutsideMonth,
+        }"
+      >
+        {{ day.dayOfMonth }}
+      </div>
+    </div>
+
     <DateField
       name="date"
       label="Date"

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -9,7 +9,7 @@ import DateField from '@/components/DateField.vue';
       label="Date"
       :format-options="{
         day: '2-digit',
-        month: 'long',
+        month: '2-digit',
         year: 'numeric',
         hour: '2-digit',
         hour12: true,

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,38 +1,15 @@
 <script setup lang="ts">
-import { Temporal } from '@js-temporal/polyfill';
-import { useCalendar } from '@formwerk/core';
 import DateField from '@/components/DateField.vue';
-
-const { days, daysOfTheWeek } = useCalendar();
 </script>
 
 <template>
   <div class="flex flex-col w-1/2 gap-4">
-    <div class="grid grid-cols-7">
-      <div v-for="day in daysOfTheWeek" :key="day.long" class="flex flex-col items-center justify-center">
-        {{ day.short }}
-      </div>
-
-      <div
-        v-for="day in days"
-        :key="day.dayOfMonth"
-        :aria-checked="day.isToday"
-        class="flex flex-col items-center justify-center aria-checked:bg-blue-600 aria-checked:text-white aria-checked:font-medium"
-        :class="{
-          'text-zinc-500': day.isOutsideMonth,
-        }"
-      >
-        {{ day.dayOfMonth }}
-      </div>
-    </div>
-
     <DateField
       name="date"
       label="Date"
       :format-options="{
-        weekday: 'long',
-        day: 'numeric',
-        month: 'long',
+        day: '2-digit',
+        month: '2-digit',
         year: 'numeric',
         hour: 'numeric',
         minute: 'numeric',

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -7,12 +7,9 @@ import DateField from '@/components/DateField.vue';
     <DateField
       name="date"
       label="Date"
-      locale="ar-EG"
       :format-options="{
-        calendar: 'islamic-umalqura',
         day: '2-digit',
-        month: 'long',
-        weekday: 'long',
+        month: '2-digit',
         year: 'numeric',
       }"
     />

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -3,12 +3,15 @@ import { useDateTimeField, DateTimeFieldProps, DateTimeSegment } from '@formwerk
 
 const props = defineProps<DateTimeFieldProps>();
 
-const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, segments } = useDateTimeField(props);
+const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, segments, fieldValue } =
+  useDateTimeField(props);
 </script>
 
 <template>
   <div class="InputDate" :class="{ touched: isTouched }">
     <span class="label" v-bind="labelProps">{{ label }}</span>
+
+    {{ fieldValue }}
 
     <div v-bind="controlProps" class="control">
       <DateTimeSegment v-for="segment in segments" v-bind="segment" class="segment" />

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -16,8 +16,6 @@ const {
 } = useDateTimeField(props);
 
 const {
-  days,
-  daysOfTheWeek,
   pickerProps,
   gridProps,
   buttonProps,
@@ -25,6 +23,7 @@ const {
   previousMonthButtonProps,
   monthYearLabelProps: calendarLabelProps,
   monthYearLabel,
+  currentPanel,
 } = useCalendar(calendarProps);
 </script>
 
@@ -53,28 +52,50 @@ const {
         <button v-bind="nextMonthButtonProps">⬇️</button>
       </div>
 
-      <div class="grid grid-cols-7 gap-4" :dir="direction" v-bind="gridProps">
-        <div
-          v-for="day in daysOfTheWeek"
-          :key="day.long"
-          class="flex flex-col items-center justify-center text-white font-bold"
-        >
-          {{ day.short }}
-        </div>
+      <div class="gap-4" :dir="direction" v-bind="gridProps">
+        <template v-if="currentPanel.type === 'day'">
+          <div
+            v-for="day in currentPanel.daysOfTheWeek"
+            :key="day"
+            class="flex flex-col items-center justify-center text-white font-bold"
+          >
+            {{ day }}
+          </div>
 
-        <CalendarCell
-          v-for="day in days"
-          v-bind="day"
-          class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
-          :class="{
-            'text-zinc-500': day.isOutsideMonth,
-            'text-white': !day.isOutsideMonth,
-            'border-transparent': !day.isToday,
-            'border-emerald-600': day.isToday,
-          }"
-        >
-          {{ day.dayOfMonth }}
-        </CalendarCell>
+          <CalendarCell
+            v-for="day in currentPanel.days"
+            v-bind="day"
+            class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+            :class="{
+              'text-zinc-500': day.isOutsideMonth,
+              'text-white': !day.isOutsideMonth,
+              'border-transparent': !day.isToday,
+              'border-emerald-600': day.isToday,
+            }"
+          >
+            {{ day.label }}
+          </CalendarCell>
+        </template>
+
+        <template v-if="currentPanel.type === 'month'">
+          <CalendarCell
+            v-for="month in currentPanel.months"
+            v-bind="month"
+            class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+          >
+            {{ month.label }}
+          </CalendarCell>
+        </template>
+
+        <template v-if="currentPanel.type === 'year'">
+          <CalendarCell
+            v-for="year in currentPanel.years"
+            v-bind="year"
+            class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+          >
+            {{ year.label }}
+          </CalendarCell>
+        </template>
       </div>
     </div>
 

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -17,12 +17,12 @@ const {
 
 const {
   pickerProps,
-  gridProps,
+  panelGridProps,
   buttonProps,
-  nextMonthButtonProps,
-  previousMonthButtonProps,
-  monthYearLabelProps: calendarLabelProps,
-  monthYearLabel,
+  nextPanelButtonProps,
+  previousPanelButtonProps,
+  panelLabelProps,
+  panelLabel,
   currentPanel,
 } = useCalendar(calendarProps);
 </script>
@@ -43,16 +43,16 @@ const {
 
     <div popover class="bg-zinc-800 px-4 py-4" v-bind="pickerProps">
       <div class="flex items-center justify-between text-white my-4">
-        <button v-bind="previousMonthButtonProps">⬆️</button>
+        <button v-bind="previousPanelButtonProps">⬆️</button>
 
-        <span v-bind="calendarLabelProps">
-          {{ monthYearLabel }}
+        <span v-bind="panelLabelProps">
+          {{ panelLabel }}
         </span>
 
-        <button v-bind="nextMonthButtonProps">⬇️</button>
+        <button v-bind="nextPanelButtonProps">⬇️</button>
       </div>
 
-      <div class="gap-4" :dir="direction" v-bind="gridProps">
+      <div class="gap-4" :dir="direction" v-bind="panelGridProps">
         <template v-if="currentPanel.type === 'day'">
           <div
             v-for="day in currentPanel.daysOfTheWeek"

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -14,7 +14,12 @@ const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, se
     {{ fieldValue }}
 
     <div v-bind="controlProps" class="control">
-      <DateTimeSegment v-for="segment in segments" v-bind="segment" class="segment" />
+      <DateTimeSegment
+        v-for="segment in segments"
+        v-bind="segment"
+        class="segment"
+        :disabled="segment.type === 'year'"
+      />
     </div>
 
     <span v-bind="errorMessageProps" class="w-full truncate error-message">

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -14,12 +14,7 @@ const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, se
     {{ fieldValue }}
 
     <div v-bind="controlProps" class="control">
-      <DateTimeSegment
-        v-for="segment in segments"
-        v-bind="segment"
-        class="segment"
-        :disabled="segment.type === 'year'"
-      />
+      <DateTimeSegment v-for="segment in segments" v-bind="segment" class="segment" />
     </div>
 
     <span v-bind="errorMessageProps" class="w-full truncate error-message">

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -80,7 +80,7 @@ const { days, daysOfTheWeek } = useCalendar(calendarProps);
   }
 
   .segment {
-    @apply p-0.5 rounded focus:outline-none focus:bg-blue-600;
+    @apply p-0.5 rounded focus:outline-none focus:bg-blue-600 caret-transparent;
   }
 
   .error-message {

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -15,7 +15,7 @@ const {
   direction,
 } = useDateTimeField(props);
 
-const { days, daysOfTheWeek } = useCalendar(calendarProps);
+const { days, daysOfTheWeek, pickerProps, gridProps, buttonProps } = useCalendar(calendarProps);
 </script>
 
 <template>
@@ -29,11 +29,11 @@ const { days, daysOfTheWeek } = useCalendar(calendarProps);
         <DateTimeSegment v-for="segment in segments" v-bind="segment" class="segment" />
       </div>
 
-      <button type="button" popovertarget="calendar">📅</button>
+      <button v-bind="buttonProps">📅</button>
     </div>
 
-    <div id="calendar" popover class="bg-zinc-800 px-4 py-4">
-      <div class="grid grid-cols-7 gap-4" :dir="direction">
+    <div popover class="bg-zinc-800 px-4 py-4" v-bind="pickerProps">
+      <div class="grid grid-cols-7 gap-4" :dir="direction" v-bind="gridProps">
         <div
           v-for="day in daysOfTheWeek"
           :key="day.long"
@@ -45,8 +45,7 @@ const { days, daysOfTheWeek } = useCalendar(calendarProps);
         <CalendarCell
           v-for="day in days"
           v-bind="day"
-          :aria-checked="day.isSelected"
-          class="flex flex-col items-center justify-center aria-checked:bg-emerald-600 aria-checked:text-white aria-checked:font-medium border-2"
+          class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none"
           :class="{
             'text-zinc-500': day.isOutsideMonth,
             'text-white': !day.isOutsideMonth,

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { useDateTimeField, DateTimeFieldProps, DateTimeSegment } from '@formwerk/core';
+
+const props = defineProps<DateTimeFieldProps>();
+
+const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, segments } = useDateTimeField(props);
+</script>
+
+<template>
+  <div class="InputDate" :class="{ touched: isTouched }">
+    <span class="label" v-bind="labelProps">{{ label }}</span>
+
+    <div v-bind="controlProps" class="control">
+      <DateTimeSegment v-for="segment in segments" v-bind="segment" class="segment" />
+    </div>
+
+    <span v-bind="errorMessageProps" class="w-full truncate error-message">
+      {{ errorMessage }}
+    </span>
+  </div>
+</template>
+
+<style scoped lang="postcss">
+.InputDate {
+  font-family: 'Monaspace Neon Var';
+  @apply relative w-full;
+  margin-bottom: calc(1em * 1.5);
+
+  .label {
+    @apply block mb-1 w-full font-semibold text-lg text-white;
+  }
+
+  .control {
+    @apply max-w-xs rounded-md border-2 border-transparent py-3 px-4 w-full bg-zinc-800 focus:bg-zinc-900 focus:outline-none transition-colors duration-200 focus:border-emerald-500 disabled:cursor-not-allowed text-white font-medium;
+  }
+
+  .segment {
+    @apply p-0.5 rounded focus:outline-none focus:bg-blue-600;
+  }
+
+  .error-message {
+    @apply absolute left-0 text-sm text-red-500 font-medium;
+    bottom: calc(-1.8 * 1em);
+  }
+
+  &:has(:user-invalid),
+  &:has(.error-message:not(:empty)) {
+    input {
+      @apply border-red-500;
+    }
+  }
+
+  &:has(:disabled) {
+    input {
+      @apply bg-gray-200 cursor-not-allowed;
+    }
+  }
+}
+</style>

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -3,14 +3,23 @@ import { useDateTimeField, DateTimeFieldProps, DateTimeSegment, useCalendar, Cal
 
 const props = defineProps<DateTimeFieldProps>();
 
-const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, segments, fieldValue, calendarProps } =
-  useDateTimeField(props);
+const {
+  controlProps,
+  isTouched,
+  labelProps,
+  errorMessageProps,
+  errorMessage,
+  segments,
+  fieldValue,
+  calendarProps,
+  direction,
+} = useDateTimeField(props);
 
 const { days, daysOfTheWeek } = useCalendar(calendarProps);
 </script>
 
 <template>
-  <div class="InputDate" :class="{ touched: isTouched }">
+  <div class="InputDate" :class="{ touched: isTouched }" :dir="direction">
     <span class="label" v-bind="labelProps">{{ label }}</span>
 
     {{ fieldValue }}
@@ -24,7 +33,7 @@ const { days, daysOfTheWeek } = useCalendar(calendarProps);
     </div>
 
     <div id="calendar" popover class="bg-zinc-800 px-4 py-4">
-      <div class="grid grid-cols-7 gap-4">
+      <div class="grid grid-cols-7 gap-4" :dir="direction">
         <div
           v-for="day in daysOfTheWeek"
           :key="day.long"
@@ -36,11 +45,13 @@ const { days, daysOfTheWeek } = useCalendar(calendarProps);
         <CalendarCell
           v-for="day in days"
           v-bind="day"
-          :aria-checked="day.isToday"
-          class="flex flex-col items-center justify-center aria-checked:bg-blue-600 aria-checked:text-white aria-checked:font-medium"
+          :aria-checked="day.isSelected"
+          class="flex flex-col items-center justify-center aria-checked:bg-emerald-600 aria-checked:text-white aria-checked:font-medium border-2"
           :class="{
             'text-zinc-500': day.isOutsideMonth,
             'text-white': !day.isOutsideMonth,
+            'border-transparent': !day.isToday,
+            'border-emerald-600': day.isToday,
           }"
         >
           {{ day.dayOfMonth }}

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { useDateTimeField, DateTimeFieldProps, DateTimeSegment } from '@formwerk/core';
+import { useDateTimeField, DateTimeFieldProps, DateTimeSegment, useCalendar, CalendarCell } from '@formwerk/core';
 
 const props = defineProps<DateTimeFieldProps>();
 
-const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, segments, fieldValue } =
+const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, segments, fieldValue, calendarProps } =
   useDateTimeField(props);
+
+const { days, daysOfTheWeek } = useCalendar(calendarProps);
 </script>
 
 <template>
@@ -13,8 +15,37 @@ const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, se
 
     {{ fieldValue }}
 
-    <div v-bind="controlProps" class="control">
-      <DateTimeSegment v-for="segment in segments" v-bind="segment" class="segment" />
+    <div class="flex items-center gap-1 control">
+      <div v-bind="controlProps">
+        <DateTimeSegment v-for="segment in segments" v-bind="segment" class="segment" />
+      </div>
+
+      <button type="button" popovertarget="calendar">📅</button>
+    </div>
+
+    <div id="calendar" popover class="bg-zinc-800 px-4 py-4">
+      <div class="grid grid-cols-7 gap-4">
+        <div
+          v-for="day in daysOfTheWeek"
+          :key="day.long"
+          class="flex flex-col items-center justify-center text-white font-bold"
+        >
+          {{ day.short }}
+        </div>
+
+        <CalendarCell
+          v-for="day in days"
+          v-bind="day"
+          :aria-checked="day.isToday"
+          class="flex flex-col items-center justify-center aria-checked:bg-blue-600 aria-checked:text-white aria-checked:font-medium"
+          :class="{
+            'text-zinc-500': day.isOutsideMonth,
+            'text-white': !day.isOutsideMonth,
+          }"
+        >
+          {{ day.dayOfMonth }}
+        </CalendarCell>
+      </div>
     </div>
 
     <span v-bind="errorMessageProps" class="w-full truncate error-message">
@@ -34,7 +65,7 @@ const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, se
   }
 
   .control {
-    @apply max-w-xs rounded-md border-2 border-transparent py-3 px-4 w-full bg-zinc-800 focus:bg-zinc-900 focus:outline-none transition-colors duration-200 focus:border-emerald-500 disabled:cursor-not-allowed text-white font-medium;
+    @apply max-w-lg rounded-md border-2 border-transparent py-3 px-4 w-full bg-zinc-800 focus:bg-zinc-900 focus:outline-none transition-colors duration-200 focus:border-emerald-500 disabled:cursor-not-allowed text-white font-medium;
   }
 
   .segment {

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -65,7 +65,7 @@ const {
         <CalendarCell
           v-for="day in days"
           v-bind="day"
-          class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none"
+          class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
           :class="{
             'text-zinc-500': day.isOutsideMonth,
             'text-white': !day.isOutsideMonth,

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -15,7 +15,17 @@ const {
   direction,
 } = useDateTimeField(props);
 
-const { days, daysOfTheWeek, pickerProps, gridProps, buttonProps } = useCalendar(calendarProps);
+const {
+  days,
+  daysOfTheWeek,
+  pickerProps,
+  gridProps,
+  buttonProps,
+  nextMonthButtonProps,
+  previousMonthButtonProps,
+  monthYearLabelProps: calendarLabelProps,
+  monthYearLabel,
+} = useCalendar(calendarProps);
 </script>
 
 <template>
@@ -33,6 +43,16 @@ const { days, daysOfTheWeek, pickerProps, gridProps, buttonProps } = useCalendar
     </div>
 
     <div popover class="bg-zinc-800 px-4 py-4" v-bind="pickerProps">
+      <div class="flex items-center justify-between text-white my-4">
+        <button v-bind="previousMonthButtonProps">⬆️</button>
+
+        <span v-bind="calendarLabelProps">
+          {{ monthYearLabel }}
+        </span>
+
+        <button v-bind="nextMonthButtonProps">⬇️</button>
+      </div>
+
       <div class="grid grid-cols-7 gap-4" :dir="direction" v-bind="gridProps">
         <div
           v-for="day in daysOfTheWeek"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@js-temporal/polyfill':
+        specifier: ^0.4.4
+        version: 0.4.4
       '@standard-schema/spec':
         specifier: 1.0.0
         version: 1.0.0
@@ -185,6 +188,9 @@ importers:
       '@formwerk/core':
         specifier: workspace:*
         version: link:../core
+      '@js-temporal/polyfill':
+        specifier: ^0.4.4
+        version: 0.4.4
       fuse.js:
         specifier: ^7.0.0
         version: 7.0.0
@@ -845,6 +851,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@js-temporal/polyfill@0.4.4':
+    resolution: {integrity: sha512-2X6bvghJ/JAoZO52lbgyAPFj8uCflhTo2g7nkFzEQdXd/D8rEeD4HtmTEpmtGCva260fcd66YNXBOYdnmHqSOg==}
+    engines: {node: '>=12'}
 
   '@jsdevtools/ez-spawn@3.0.4':
     resolution: {integrity: sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==}
@@ -2548,6 +2558,9 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsbi@4.3.0:
+    resolution: {integrity: sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g==}
 
   jsdom@26.0.0:
     resolution: {integrity: sha512-BZYDGVAIriBWTpIxYzrXjv3E/4u8+/pSG5bQdIYCbNCGOvsPkDQfTVLAIXAf9ETdCpduCVTkDe2NNZ8NIwUVzw==}
@@ -4432,6 +4445,11 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@js-temporal/polyfill@0.4.4':
+    dependencies:
+      jsbi: 4.3.0
+      tslib: 2.8.1
 
   '@jsdevtools/ez-spawn@3.0.4':
     dependencies:
@@ -6324,6 +6342,8 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsbi@4.3.0: {}
 
   jsdom@26.0.0:
     dependencies:

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -75,6 +75,7 @@ async function createConfig(pkg: keyof typeof pkgNameMap, format: ModuleFormat) 
         'klona',
         '@standard-schema/utils',
         '@standard-schema/spec',
+        '@js-temporal/polyfill',
       ].filter(Boolean) as string[],
       plugins: createPlugins({ version, pkg, format }),
     },


### PR DESCRIPTION
This pull request introduces several significant changes to the i18n (internationalization) and calendar functionalities within the `packages/core` module. The most important changes include the addition of new dependencies, enhancements to locale handling, and the introduction of new calendar-related utilities.

### Enhancements to locale handling:

* [`packages/core/src/i18n/getCalendar.ts`](diffhunk://#diff-df763e64eae216c5e889d9ffd05130c9e89347ba353eedb5a85f5ea84ab3d484R1-R13): Added a new function `getCalendar` to retrieve the calendar identifier for a given locale.
* [`packages/core/src/i18n/getDirection.ts`](diffhunk://#diff-59546cd108abd41f7df682a19dae4f91887426b08034b5094b6c6f70d6836795L5-R16): Modified the `getDirection` function to accept an `Intl.Locale` object instead of a string.
* [`packages/core/src/i18n/getTimezone.ts`](diffhunk://#diff-1312d7747a93fd12f40b24d5d35f36162dc605fbe299df9ead6ccdb07fad7740R1-R3): Added a new function `getTimeZone` to retrieve the timezone for a given locale.
* [`packages/core/src/i18n/getWeekInfo.ts`](diffhunk://#diff-b389733268f79a5f9ad80f25407a524864b315c1e02d56628ee7f7afc50bfbbeR1-R26): Added a new function `getWeekInfo` to retrieve week information for a given locale.
* [`packages/core/src/i18n/useLocale.ts`](diffhunk://#diff-3d16fa974fa6bd68c040eea848952e9a1131d2213d4d475a0c0bd3d28a24d7e1L1-R56): Enhanced the `useLocale` composable to support locale extensions and retrieve additional locale-related information.

### Calendar-related utilities:

* [`packages/core/src/useCalendar/index.ts`](diffhunk://#diff-59464cd8f50f89bcac5e1bcfe63ff4cdab779ed5b9206c1d918ff303a74a082bR1-R3): Introduced new exports for calendar-related functionalities.
* [`packages/core/src/useCalendar/types.ts`](diffhunk://#diff-85dddefb86676a5c5f906b30c2e4970e3ed509c93717322b61e4723cad8d43beR1-R29): Defined new types for calendar identifiers and calendar days.
* [`packages/core/src/useCalendar/useCalendar.ts`](diffhunk://#diff-983d16aafbeffe15d2ff242ff44bf8a6fe116b33a3a4a66d8bd42250f822fa4dR1-R141): Implemented the `useCalendar` composable to manage calendar state and provide calendar-related data.
* [`packages/core/src/useCalendar/useCalendarCell.ts`](diffhunk://#diff-4e5a30bbf76e46a7a8169685bd1cedcc8f3bd410cf74d49839b4f452ebc5a331R1-R33): Added the `useCalendarCell` composable and `CalendarCell` component for managing individual calendar cells.

### New dependencies:

* [`packages/core/package.json`](diffhunk://#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7R44): Added the `@js-temporal/polyfill` dependency to support temporal functionalities.

### Additional changes:

* [`packages/core/src/constants/index.ts`](diffhunk://#diff-67ebd63558637a667c8998a932d10f7c87e3c2092c74388e5ed8c4df221ef059R21-R22): Added new field type prefixes for `DateTimeField` and `DateTimeSegment`.
* [`packages/core/src/useDateTimeField/constants.ts`](diffhunk://#diff-e9b9cc76c9cdccd19833686ec0d9a847cec9ebd03518a9e8885d0daf801b917dR1-R21): Introduced utility functions for handling date-time segments.
* [`packages/core/src/useDateTimeField/index.ts`](diffhunk://#diff-ef923c477c778b1897a478221ed95f32fddd3b2781fdb63917397ba5552a6b25R1-R4): Added exports for date-time field functionalities.
* [`packages/core/src/i18n/useDateFormatter/index.ts`](diffhunk://#diff-de16ed0ccfd35d26387a000a36678df2b5b443f296bcf22787057fde2b917411R1-R40): Implemented the `useDateFormatter` composable to format dates using the temporal polyfill.
* [`packages/core/src/i18n/useNumberParser/index.ts`](diffhunk://#diff-b298c8088a5a0e47cab6aa1fe2d14f60e91ae10ee29d9e3c618aa4b3d397aca6L1-R1): Enhanced the `useNumberParser` composable with additional functionality and type definitions. [[1]](diffhunk://#diff-b298c8088a5a0e47cab6aa1fe2d14f60e91ae10ee29d9e3c618aa4b3d397aca6L1-R1) [[2]](diffhunk://#diff-b298c8088a5a0e47cab6aa1fe2d14f60e91ae10ee29d9e3c618aa4b3d397aca6L60-R60) [[3]](diffhunk://#diff-b298c8088a5a0e47cab6aa1fe2d14f60e91ae10ee29d9e3c618aa4b3d397aca6R70) [[4]](diffhunk://#diff-b298c8088a5a0e47cab6aa1fe2d14f60e91ae10ee29d9e3c618aa4b3d397aca6R210-R211) [[5]](diffhunk://#diff-b298c8088a5a0e47cab6aa1fe2d14f60e91ae10ee29d9e3c618aa4b3d397aca6L276-R290)