### PR TITLE
fix: add `autocomplete` to `useTextField`

### DIFF
--- a/.changeset/mighty-moles-stare.md
+++ b/.changeset/mighty-moles-stare.md
@@ -1,0 +1,5 @@
+---
+'@formwerk/core': patch
+---
+
+fix: add autocomplete to useTextField

--- a/packages/core/src/useTextField/useTextField.ts
+++ b/packages/core/src/useTextField/useTextField.ts
@@ -82,6 +82,11 @@ export interface TextFieldProps {
   placeholder?: string | undefined;
 
   /**
+   * Autocomplete hint for the input field.
+   */
+  autocomplete?: string | undefined;
+
+  /**
    * Whether the field is required.
    */
   required?: boolean;
@@ -154,7 +159,7 @@ export function useTextField(
   const inputProps = computed<TextInputDOMProps>(() => {
     return withRefCapture(
       {
-        ...propsToValues(props, ['name', 'type', 'placeholder', 'required', 'readonly']),
+        ...propsToValues(props, ['name', 'type', 'placeholder', 'autocomplete', 'required', 'readonly']),
         ...labelledByProps.value,
         ...describedByProps.value,
         ...accessibleErrorProps.value,


### PR DESCRIPTION
This PR adds the missing `autocomplete` attribute to the `inputProps` of the `useTextField` composable.

Fixes #123 