### PR TITLE
Unify the query/set methods

### DIFF
--- a/.changeset/chilled-monkeys-wink.md
+++ b/.changeset/chilled-monkeys-wink.md
@@ -1,5 +1,5 @@
 ---
-'@formwerk/core': patch
+'@formwerk/core': minor
 ---
 
 Use consistent API for query/set methods

--- a/.changeset/chilled-monkeys-wink.md
+++ b/.changeset/chilled-monkeys-wink.md
@@ -8,3 +8,6 @@ Use consistent API for query/set methods
 - `setFieldErrors()` is renamed to `setErrors()`
 - `setFieldValue()` is renamed to `setValue()`
 - `setFieldTouched()` is renamed to `setTouched()`
+- `getFieldvalue()` is renamed to `getValue()`
+- `getFieldErrors()` is renmaed to `getErrors()`
+    - `getErrors()` now only returns an array of errors as `string[]`

--- a/.changeset/chilled-monkeys-wink.md
+++ b/.changeset/chilled-monkeys-wink.md
@@ -1,0 +1,9 @@
+---
+'@formwerk/core': patch
+---
+
+Use consistent API for query/set methods
+- `isDirty()`, `isTouched()` and `isValid()` are now methods which can accept an optional path
+- `setFieldErrors()` is renamed to `setErrors()`
+- `setFieldValue()` is renamed to `setValue()`
+- `setFieldTouched()` is renamed to `setTouched()`

--- a/.changeset/chilled-monkeys-wink.md
+++ b/.changeset/chilled-monkeys-wink.md
@@ -4,6 +4,7 @@
 
 Use consistent API for query/set methods
 - `isDirty()`, `isTouched()` and `isValid()` are now methods which can accept an optional path
+- `getFieldValue()` is renamed to `getValue()`
 - `setFieldErrors()` is renamed to `setErrors()`
 - `setFieldValue()` is renamed to `setValue()`
 - `setFieldTouched()` is renamed to `setTouched()`

--- a/.changeset/chilled-monkeys-wink.md
+++ b/.changeset/chilled-monkeys-wink.md
@@ -10,4 +10,4 @@ Use consistent API for query/set methods
 - `setFieldTouched()` is renamed to `setTouched()`
 - `getFieldvalue()` is renamed to `getValue()`
 - `getFieldErrors()` is renmaed to `getErrors()`
-    - `getErrors()` now only returns an array of errors as `string[]`
+    - `getErrors()` now only returns an array of error messages as `string[]`

--- a/packages/core/src/useForm/formContext.ts
+++ b/packages/core/src/useForm/formContext.ts
@@ -50,7 +50,6 @@ export interface BaseFormContext<TForm extends FormObject = FormObject> {
   getSubmitErrors: () => IssueCollection[];
   clearErrors: (path?: string) => void;
   clearSubmitErrors: (path?: string) => void;
-  hasErrors: () => boolean;
   getValues: () => TForm;
   setValues: (newValues: Partial<TForm>, opts?: SetValueOptions) => void;
   revertValues: () => void;
@@ -151,13 +150,6 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
 
   function setFieldDisabled<TPath extends Path<TForm>>(path: TPath, value: boolean) {
     setInPath(disabled, escapePath(path), value);
-  }
-
-  function hasErrors() {
-    return !!findLeaf(
-      errors.value,
-      (l, path) => !isPathDisabled(path as Path<TForm>) && Array.isArray(l) && l.length > 0,
-    );
   }
 
   function isPathDisabled(path: Path<TForm>) {
@@ -338,7 +330,6 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     setFieldSubmitErrors,
     getFieldErrors,
     getFieldSubmitErrors,
-    hasErrors,
     getErrors,
     getSubmitErrors,
     clearErrors,

--- a/packages/core/src/useForm/formContext.ts
+++ b/packages/core/src/useForm/formContext.ts
@@ -31,6 +31,7 @@ export interface BaseFormContext<TForm extends FormObject = FormObject> {
   setValue<TPath extends Path<TForm>>(path: TPath, value: PathValue<TForm, TPath> | undefined): void;
   destroyPath<TPath extends Path<TForm>>(path: TPath): void;
   unsetPath<TPath extends Path<TForm>>(path: TPath): void;
+  setTouched(value: boolean): void;
   setTouched<TPath extends Path<TForm>>(path: TPath, value: boolean): void;
   isTouched<TPath extends Path<TForm>>(path?: TPath): boolean;
   isDirty<TPath extends Path<TForm>>(path?: TPath): boolean;
@@ -88,8 +89,19 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     setInPath(values, path, cloneDeep(value));
   }
 
-  function setTouched<TPath extends Path<TForm>>(path: TPath, value: boolean) {
-    setInPath(touched, path, value, true);
+  function setTouched(value: boolean);
+  function setTouched<TPath extends Path<TForm>>(path: TPath, value: boolean);
+  function setTouched<TPath extends Path<TForm>>(pathOrValue: TPath | boolean, valueOrUndefined?: boolean) {
+    // If the pathOrValue is a boolean, we want to set all touched fields to that value
+    if (typeof pathOrValue === 'boolean') {
+      for (const key in touched) {
+        setInPath(touched, key, pathOrValue, true);
+      }
+
+      return;
+    }
+
+    setInPath(touched, pathOrValue, valueOrUndefined, true);
   }
 
   function getValue<TPath extends Path<TForm>>(path: TPath) {

--- a/packages/core/src/useForm/formContext.ts
+++ b/packages/core/src/useForm/formContext.ts
@@ -31,7 +31,7 @@ export interface BaseFormContext<TForm extends FormObject = FormObject> {
   setValue<TPath extends Path<TForm>>(path: TPath, value: PathValue<TForm, TPath> | undefined): void;
   destroyPath<TPath extends Path<TForm>>(path: TPath): void;
   unsetPath<TPath extends Path<TForm>>(path: TPath): void;
-  setFieldTouched<TPath extends Path<TForm>>(path: TPath, value: boolean): void;
+  setTouched<TPath extends Path<TForm>>(path: TPath, value: boolean): void;
   isTouched<TPath extends Path<TForm>>(path?: TPath): boolean;
   isDirty<TPath extends Path<TForm>>(path?: TPath): boolean;
   isFieldSet<TPath extends Path<TForm>>(path: TPath): boolean;
@@ -89,7 +89,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     setInPath(values, path, cloneDeep(value));
   }
 
-  function setFieldTouched<TPath extends Path<TForm>>(path: TPath, value: boolean) {
+  function setTouched<TPath extends Path<TForm>>(path: TPath, value: boolean) {
     setInPath(touched, path, value, true);
   }
 
@@ -253,7 +253,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     setInPath(submitErrors.value, escapePath(path), message ? normalizeArrayable(message) : []);
   }
 
-  function setTouched(newTouched: Partial<TouchedSchema<TForm>>, opts?: SetValueOptions) {
+  function updateTouched(newTouched: Partial<TouchedSchema<TForm>>, opts?: SetValueOptions) {
     if (opts?.behavior === 'merge') {
       merge(touched, newTouched);
 
@@ -299,7 +299,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
   }
 
   function revertTouched() {
-    setTouched(cloneDeep(snapshots.touched.originals.value), { behavior: 'replace' });
+    updateTouched(cloneDeep(snapshots.touched.originals.value), { behavior: 'replace' });
   }
 
   function getValidationMode(): FormValidationMode {
@@ -311,7 +311,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     getValues: () => cloneDeep(values),
     setValue,
     getFieldInitialValue,
-    setFieldTouched,
+    setTouched,
     getFieldValue,
     isTouched,
     isDirty,

--- a/packages/core/src/useForm/formContext.ts
+++ b/packages/core/src/useForm/formContext.ts
@@ -28,7 +28,7 @@ export type FormValidationMode = 'aggregate' | 'schema';
 export interface BaseFormContext<TForm extends FormObject = FormObject> {
   id: string;
   getFieldValue<TPath extends Path<TForm>>(path: TPath): PathValue<TForm, TPath>;
-  setFieldValue<TPath extends Path<TForm>>(path: TPath, value: PathValue<TForm, TPath> | undefined): void;
+  setValue<TPath extends Path<TForm>>(path: TPath, value: PathValue<TForm, TPath> | undefined): void;
   destroyPath<TPath extends Path<TForm>>(path: TPath): void;
   unsetPath<TPath extends Path<TForm>>(path: TPath): void;
   setFieldTouched<TPath extends Path<TForm>>(path: TPath, value: boolean): void;
@@ -85,7 +85,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
   touched,
   snapshots,
 }: FormContextCreateOptions<TForm, TOutput>): BaseFormContext<TForm> {
-  function setFieldValue<TPath extends Path<TForm>>(path: TPath, value: PathValue<TForm, TPath> | undefined) {
+  function setValue<TPath extends Path<TForm>>(path: TPath, value: PathValue<TForm, TPath> | undefined) {
     setInPath(values, path, cloneDeep(value));
   }
 
@@ -218,7 +218,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
 
     // We escape paths automatically
     Object.keys(newValues).forEach(key => {
-      setFieldValue(escapePath(key) as Path<TForm>, newValues[key] as PathValue<TForm, Path<TForm>>);
+      setValue(escapePath(key) as Path<TForm>, newValues[key] as PathValue<TForm, Path<TForm>>);
     });
   }
 
@@ -309,7 +309,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
   return {
     id,
     getValues: () => cloneDeep(values),
-    setFieldValue,
+    setValue,
     getFieldInitialValue,
     setFieldTouched,
     getFieldValue,

--- a/packages/core/src/useForm/formContext.ts
+++ b/packages/core/src/useForm/formContext.ts
@@ -32,7 +32,7 @@ export interface BaseFormContext<TForm extends FormObject = FormObject> {
   destroyPath<TPath extends Path<TForm>>(path: TPath): void;
   unsetPath<TPath extends Path<TForm>>(path: TPath): void;
   setFieldTouched<TPath extends Path<TForm>>(path: TPath, value: boolean): void;
-  isFieldTouched<TPath extends Path<TForm>>(path: TPath): boolean;
+  isTouched<TPath extends Path<TForm>>(path?: TPath): boolean;
   isFieldDirty<TPath extends Path<TForm>>(path: TPath): boolean;
   isFieldSet<TPath extends Path<TForm>>(path: TPath): boolean;
   getFieldInitialValue<TPath extends Path<TForm>>(path: TPath): PathValue<TForm, TPath>;
@@ -98,7 +98,11 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     return getFromPath(values, path) as PathValue<TForm, TPath>;
   }
 
-  function isFieldTouched<TPath extends Path<TForm>>(path: TPath) {
+  function isTouched<TPath extends Path<TForm>>(path?: TPath) {
+    if (!path) {
+      return !!findLeaf(touched, l => l === true);
+    }
+
     const value = getFromPath(touched, path);
     if (isObject(value)) {
       return !!findLeaf(value, v => !!v);
@@ -313,7 +317,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     getFieldInitialValue,
     setFieldTouched,
     getFieldValue,
-    isFieldTouched,
+    isTouched,
     isFieldDirty,
     isFieldSet,
     destroyPath,

--- a/packages/core/src/useForm/formContext.ts
+++ b/packages/core/src/useForm/formContext.ts
@@ -43,7 +43,7 @@ export interface BaseFormContext<TForm extends FormObject = FormObject> {
   setFieldDisabled<TPath extends Path<TForm>>(path: TPath, value: boolean): void;
   getFieldErrors<TPath extends Path<TForm>>(path: TPath): string[];
   getFieldSubmitErrors<TPath extends Path<TForm>>(path: TPath): string[];
-  setFieldErrors<TPath extends Path<TForm>>(path: TPath, message: Arrayable<string>): void;
+  setErrors<TPath extends Path<TForm>>(path: TPath, message: Arrayable<string>): void;
   setFieldSubmitErrors<TPath extends Path<TForm>>(path: TPath, message: Arrayable<string>): void;
   getValidationMode(): FormValidationMode;
   getErrors: <TPath extends Path<TForm>>(path?: TPath) => IssueCollection[];
@@ -245,7 +245,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     return [...(getFromPath<string[]>(submitErrors.value, escapePath(path), []) || [])];
   }
 
-  function setFieldErrors<TPath extends Path<TForm>>(path: TPath, message: Arrayable<string>) {
+  function setErrors<TPath extends Path<TForm>>(path: TPath, message: Arrayable<string>) {
     setInPath(errors.value, escapePath(path), message ? normalizeArrayable(message) : []);
   }
 
@@ -326,7 +326,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     setInitialTouched,
     getFieldOriginalValue,
     setFieldDisabled,
-    setFieldErrors,
+    setErrors,
     setFieldSubmitErrors,
     getFieldErrors,
     getFieldSubmitErrors,

--- a/packages/core/src/useForm/formContext.ts
+++ b/packages/core/src/useForm/formContext.ts
@@ -33,7 +33,7 @@ export interface BaseFormContext<TForm extends FormObject = FormObject> {
   unsetPath<TPath extends Path<TForm>>(path: TPath): void;
   setFieldTouched<TPath extends Path<TForm>>(path: TPath, value: boolean): void;
   isTouched<TPath extends Path<TForm>>(path?: TPath): boolean;
-  isFieldDirty<TPath extends Path<TForm>>(path: TPath): boolean;
+  isDirty<TPath extends Path<TForm>>(path?: TPath): boolean;
   isFieldSet<TPath extends Path<TForm>>(path: TPath): boolean;
   getFieldInitialValue<TPath extends Path<TForm>>(path: TPath): PathValue<TForm, TPath>;
   getFieldOriginalValue<TPath extends Path<TForm>>(path: TPath): PathValue<TForm, TPath>;
@@ -111,7 +111,11 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     return !!value;
   }
 
-  function isFieldDirty<TPath extends Path<TForm>>(path: TPath) {
+  function isDirty<TPath extends Path<TForm>>(path?: TPath) {
+    if (!path) {
+      return !isEqual(values, snapshots.values.originals.value);
+    }
+
     return !isEqual(getFieldValue(path), getFieldOriginalValue(path));
   }
 
@@ -318,7 +322,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     setFieldTouched,
     getFieldValue,
     isTouched,
-    isFieldDirty,
+    isDirty,
     isFieldSet,
     destroyPath,
     unsetPath,

--- a/packages/core/src/useForm/formContext.ts
+++ b/packages/core/src/useForm/formContext.ts
@@ -27,7 +27,7 @@ export type FormValidationMode = 'aggregate' | 'schema';
 
 export interface BaseFormContext<TForm extends FormObject = FormObject> {
   id: string;
-  getFieldValue<TPath extends Path<TForm>>(path: TPath): PathValue<TForm, TPath>;
+  getValue<TPath extends Path<TForm>>(path: TPath): PathValue<TForm, TPath>;
   setValue<TPath extends Path<TForm>>(path: TPath, value: PathValue<TForm, TPath> | undefined): void;
   destroyPath<TPath extends Path<TForm>>(path: TPath): void;
   unsetPath<TPath extends Path<TForm>>(path: TPath): void;
@@ -93,7 +93,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     setInPath(touched, path, value, true);
   }
 
-  function getFieldValue<TPath extends Path<TForm>>(path: TPath) {
+  function getValue<TPath extends Path<TForm>>(path: TPath) {
     return getFromPath(values, path) as PathValue<TForm, TPath>;
   }
 
@@ -115,7 +115,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
       return !isEqual(values, snapshots.values.originals.value);
     }
 
-    return !isEqual(getFieldValue(path), getFieldOriginalValue(path));
+    return !isEqual(getValue(path), getFieldOriginalValue(path));
   }
 
   function isFieldSet<TPath extends Path<TForm>>(path: TPath) {
@@ -312,7 +312,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     setValue,
     getFieldInitialValue,
     setTouched,
-    getFieldValue,
+    getValue,
     isTouched,
     isDirty,
     isFieldSet,

--- a/packages/core/src/useForm/useForm.spec.ts
+++ b/packages/core/src/useForm/useForm.spec.ts
@@ -941,7 +941,7 @@ describe('form validation', () => {
       <form>
         <Child />
 
-        <span v-if="isValid">Form is valid</span>
+        <span v-if="isValid()">Form is valid</span>
         <span v-else>Form is invalid</span>
       </form>
     `,

--- a/packages/core/src/useForm/useForm.spec.ts
+++ b/packages/core/src/useForm/useForm.spec.ts
@@ -102,31 +102,31 @@ describe('form values', () => {
 
 describe('form touched', () => {
   test('can set field touched state', async () => {
-    const { setFieldTouched, isFieldTouched } = await renderSetup(() => {
+    const { setFieldTouched, isTouched } = await renderSetup(() => {
       return useForm({ initialValues: { foo: 'bar' } });
     });
 
-    expect(isFieldTouched('foo')).toBe(false);
+    expect(isTouched('foo')).toBe(false);
     setFieldTouched('foo', true);
-    expect(isFieldTouched('foo')).toBe(true);
+    expect(isTouched('foo')).toBe(true);
   });
 
   test('can set nested field touched state', async () => {
-    const { setFieldTouched, isFieldTouched } = await renderSetup(() => {
+    const { setFieldTouched, isTouched } = await renderSetup(() => {
       return useForm<any>();
     });
 
-    expect(isFieldTouched('foo.bar')).toBe(false);
+    expect(isTouched('foo.bar')).toBe(false);
     setFieldTouched('foo.bar', true);
-    expect(isFieldTouched('foo.bar')).toBe(true);
+    expect(isTouched('foo.bar')).toBe(true);
   });
 
   test('can set initial touched state', async () => {
-    const { isFieldTouched } = await renderSetup(() => {
+    const { isTouched } = await renderSetup(() => {
       return useForm({ initialValues: { foo: 'bar' }, initialTouched: { foo: true } });
     });
 
-    expect(isFieldTouched('foo')).toBe(true);
+    expect(isTouched('foo')).toBe(true);
   });
 
   test('has a form-level computed isTouched state', async () => {
@@ -134,15 +134,15 @@ describe('form touched', () => {
       return useForm({ initialValues: { foo: 'bar' } });
     });
 
-    expect(isTouched.value).toBe(false);
+    expect(isTouched()).toBe(false);
     setFieldTouched('foo', true);
-    expect(isTouched.value).toBe(true);
+    expect(isTouched()).toBe(true);
     setFieldTouched('foo', false);
-    expect(isTouched.value).toBe(false);
+    expect(isTouched()).toBe(false);
   });
 
   test('sets touched state correctly for discriminated union paths', async () => {
-    const { setFieldTouched, isFieldTouched, setFieldValue, values } = await renderSetup(() => {
+    const { setFieldTouched, isTouched, setFieldValue, values } = await renderSetup(() => {
       return useForm<any>({
         initialValues: {
           someConfig: {
@@ -166,21 +166,21 @@ describe('form touched', () => {
 
     // Touch the parent - should touch all children
     setFieldTouched('someConfig', true);
-    expect(isFieldTouched('someConfig')).toBe(true);
-    expect(isFieldTouched('someConfig.nestedField1')).toBe(true);
-    expect(isFieldTouched('someConfig.nestedField2')).toBe(true);
+    expect(isTouched('someConfig')).toBe(true);
+    expect(isTouched('someConfig.nestedField1')).toBe(true);
+    expect(isTouched('someConfig.nestedField2')).toBe(true);
 
     // Change someConfig to a boolean (discriminated union case)
     setFieldValue('someConfig', false);
     setFieldTouched('someConfig', true);
 
     // Should still work as expected with boolean value
-    expect(isFieldTouched('someConfig')).toBe(true);
+    expect(isTouched('someConfig')).toBe(true);
     expect(values.someConfig).toBe(false);
   });
 
   test('handles nested touched states independently', async () => {
-    const { setFieldTouched, isFieldTouched } = await renderSetup(() => {
+    const { setFieldTouched, isTouched } = await renderSetup(() => {
       return useForm<any>({
         initialValues: {
           parent: {
@@ -193,19 +193,19 @@ describe('form touched', () => {
 
     // Touch just one nested field
     setFieldTouched('parent.child1', true);
-    expect(isFieldTouched('parent.child1')).toBe(true);
-    expect(isFieldTouched('parent.child2')).toBe(false);
-    expect(isFieldTouched('parent')).toBe(true); // parent should be considered touched
+    expect(isTouched('parent.child1')).toBe(true);
+    expect(isTouched('parent.child2')).toBe(false);
+    expect(isTouched('parent')).toBe(true); // parent should be considered touched
 
     // Untouching parent should untouching children
     setFieldTouched('parent', false);
-    expect(isFieldTouched('parent')).toBe(false);
-    expect(isFieldTouched('parent.child1')).toBe(false);
-    expect(isFieldTouched('parent.child2')).toBe(false);
+    expect(isTouched('parent')).toBe(false);
+    expect(isTouched('parent.child1')).toBe(false);
+    expect(isTouched('parent.child2')).toBe(false);
   });
 
   test('handles escaped paths correctly for touched state', async () => {
-    const { setFieldTouched, isFieldTouched } = await renderSetup(() => {
+    const { setFieldTouched, isTouched } = await renderSetup(() => {
       return useForm<any>({
         initialValues: {
           parent: {
@@ -229,42 +229,42 @@ describe('form touched', () => {
 
     // Using escaped path notation
     setFieldTouched('[parent.child]', true);
-    expect(isFieldTouched('[parent.child]')).toBe(true);
-    expect(isFieldTouched('[parent.child.nested]')).toBe(false);
+    expect(isTouched('[parent.child]')).toBe(true);
+    expect(isTouched('[parent.child.nested]')).toBe(false);
 
     // Ensure it doesn't accidentally match unescaped paths
-    expect(isFieldTouched('parent.child')).toBe(false);
+    expect(isTouched('parent.child')).toBe(false);
   });
 });
 
 describe('form reset', () => {
   test('can reset form values and touched to their original state', async () => {
-    const { values, reset, setFieldValue, isFieldTouched, setFieldTouched } = await renderSetup(() => {
+    const { values, reset, setFieldValue, isTouched, setFieldTouched } = await renderSetup(() => {
       return useForm({ initialValues: { foo: 'bar' }, initialTouched: { foo: true } });
     });
 
     setFieldValue('foo', '');
     setFieldTouched('foo', false);
     expect(values).toEqual({ foo: '' });
-    expect(isFieldTouched('foo')).toBe(false);
+    expect(isTouched('foo')).toBe(false);
     reset();
     expect(values).toEqual({ foo: 'bar' });
-    expect(isFieldTouched('foo')).toBe(true);
+    expect(isTouched('foo')).toBe(true);
   });
 
   test('can reset form values and touched to a new state', async () => {
-    const { values, reset, setFieldValue, isFieldTouched, setFieldTouched } = await renderSetup(() => {
+    const { values, reset, setFieldValue, isTouched, setFieldTouched } = await renderSetup(() => {
       return useForm({ initialValues: { foo: 'bar' } });
     });
 
     reset({ values: { foo: 'baz' }, touched: { foo: true } });
     expect(values).toEqual({ foo: 'baz' });
-    expect(isFieldTouched('foo')).toBe(true);
+    expect(isTouched('foo')).toBe(true);
     setFieldTouched('foo', false);
     setFieldValue('foo', '');
     reset();
     expect(values).toEqual({ foo: 'baz' });
-    expect(isFieldTouched('foo')).toBe(true);
+    expect(isTouched('foo')).toBe(true);
   });
 });
 
@@ -296,11 +296,11 @@ describe('form submit', () => {
       },
     );
 
-    expect(form.isFieldTouched('field')).toBe(false);
+    expect(form.isTouched('field')).toBe(false);
     const cb = vi.fn();
     const onSubmit = form.handleSubmit(cb);
     await onSubmit(new Event('submit'));
-    expect(form.isFieldTouched('field')).toBe(true);
+    expect(form.isTouched('field')).toBe(true);
   });
 
   test('submitting sets the isSubmitting flag', async () => {

--- a/packages/core/src/useForm/useForm.spec.ts
+++ b/packages/core/src/useForm/useForm.spec.ts
@@ -1101,11 +1101,11 @@ describe('form validation', () => {
       await render({
         components: { Child: createInputComponent() },
         setup() {
-          const { handleSubmit, getError, setFieldErrors } = useForm({
+          const { handleSubmit, getError, setErrors } = useForm({
             schema,
           });
 
-          setFieldErrors('test', 'error');
+          setErrors('test', 'error');
 
           return { getError, onSubmit: handleSubmit(v => handler(v.toObject())) };
         },
@@ -1142,11 +1142,11 @@ describe('form validation', () => {
       await render({
         components: { Child: createInputComponent() },
         setup() {
-          const { handleSubmit, getError, setFieldErrors } = useForm({
+          const { handleSubmit, getError, setErrors } = useForm({
             schema,
           });
 
-          setFieldErrors('test', 'error');
+          setErrors('test', 'error');
 
           return { getError, onSubmit: handleSubmit(v => handler(v.toObject())) };
         },
@@ -1305,7 +1305,7 @@ describe('form validation', () => {
       return useForm();
     });
 
-    setFieldErrors('test', 'error');
+    setErrors('test', 'error');
     expect(displayError('test')).toBeUndefined();
     setTouched('test', true);
     expect(displayError('test')).toBe('error');
@@ -1323,8 +1323,8 @@ describe('form validation', () => {
     });
 
     // Set some errors
-    form.setFieldErrors('address.street', "Address street can't be empty");
-    form.setFieldErrors('address.city', "Address city can't be empty");
+    form.setErrors('address.street', "Address street can't be empty");
+    form.setErrors('address.city', "Address city can't be empty");
 
     expect(form.getError('address.street')).toBe("Address street can't be empty");
     expect(form.getError('address.city')).toBe("Address city can't be empty");
@@ -1343,9 +1343,9 @@ describe('form validation', () => {
     });
 
     // Set some errors
-    form.setFieldErrors('address.street', "Address street can't be empty");
-    form.setFieldErrors('address.city', "Address city can't be empty");
-    form.setFieldErrors('name', "Name can't be empty");
+    form.setErrors('address.street', "Address street can't be empty");
+    form.setErrors('address.city', "Address city can't be empty");
+    form.setErrors('name', "Name can't be empty");
 
     const allErrors = form.getErrors();
     const addressErrors = form.getErrors('address');

--- a/packages/core/src/useForm/useForm.spec.ts
+++ b/packages/core/src/useForm/useForm.spec.ts
@@ -102,22 +102,22 @@ describe('form values', () => {
 
 describe('form touched', () => {
   test('can set field touched state', async () => {
-    const { setFieldTouched, isTouched } = await renderSetup(() => {
+    const { setTouched, isTouched } = await renderSetup(() => {
       return useForm({ initialValues: { foo: 'bar' } });
     });
 
     expect(isTouched('foo')).toBe(false);
-    setFieldTouched('foo', true);
+    setTouched('foo', true);
     expect(isTouched('foo')).toBe(true);
   });
 
   test('can set nested field touched state', async () => {
-    const { setFieldTouched, isTouched } = await renderSetup(() => {
+    const { setTouched, isTouched } = await renderSetup(() => {
       return useForm<any>();
     });
 
     expect(isTouched('foo.bar')).toBe(false);
-    setFieldTouched('foo.bar', true);
+    setTouched('foo.bar', true);
     expect(isTouched('foo.bar')).toBe(true);
   });
 
@@ -130,14 +130,14 @@ describe('form touched', () => {
   });
 
   test('has a form-level computed isTouched state', async () => {
-    const { isTouched, setFieldTouched } = await renderSetup(() => {
+    const { isTouched, setTouched } = await renderSetup(() => {
       return useForm({ initialValues: { foo: 'bar' } });
     });
 
     expect(isTouched()).toBe(false);
-    setFieldTouched('foo', true);
+    setTouched('foo', true);
     expect(isTouched()).toBe(true);
-    setFieldTouched('foo', false);
+    setTouched('foo', false);
     expect(isTouched()).toBe(false);
   });
 
@@ -160,19 +160,19 @@ describe('form touched', () => {
      * internally through the `useFormField` hook, which is not used in this test.
      * Order of operations is important here.
      */
-    setFieldTouched('someConfig.nestedField1', false);
-    setFieldTouched('someConfig.nestedField2', false);
-    setFieldTouched('someConfig', false);
+    setTouched('someConfig.nestedField1', false);
+    setTouched('someConfig.nestedField2', false);
+    setTouched('someConfig', false);
 
     // Touch the parent - should touch all children
-    setFieldTouched('someConfig', true);
+    setTouched('someConfig', true);
     expect(isTouched('someConfig')).toBe(true);
     expect(isTouched('someConfig.nestedField1')).toBe(true);
     expect(isTouched('someConfig.nestedField2')).toBe(true);
 
     // Change someConfig to a boolean (discriminated union case)
-    setFieldTouched('someConfig', true);
     setValue('someConfig', false);
+    setTouched('someConfig', true);
 
     // Should still work as expected with boolean value
     expect(isTouched('someConfig')).toBe(true);
@@ -180,7 +180,7 @@ describe('form touched', () => {
   });
 
   test('handles nested touched states independently', async () => {
-    const { setFieldTouched, isTouched } = await renderSetup(() => {
+    const { setTouched, isTouched } = await renderSetup(() => {
       return useForm<any>({
         initialValues: {
           parent: {
@@ -192,20 +192,20 @@ describe('form touched', () => {
     });
 
     // Touch just one nested field
-    setFieldTouched('parent.child1', true);
+    setTouched('parent.child1', true);
     expect(isTouched('parent.child1')).toBe(true);
     expect(isTouched('parent.child2')).toBe(false);
     expect(isTouched('parent')).toBe(true); // parent should be considered touched
 
     // Untouching parent should untouching children
-    setFieldTouched('parent', false);
+    setTouched('parent', false);
     expect(isTouched('parent')).toBe(false);
     expect(isTouched('parent.child1')).toBe(false);
     expect(isTouched('parent.child2')).toBe(false);
   });
 
   test('handles escaped paths correctly for touched state', async () => {
-    const { setFieldTouched, isTouched } = await renderSetup(() => {
+    const { setTouched, isTouched } = await renderSetup(() => {
       return useForm<any>({
         initialValues: {
           parent: {
@@ -224,11 +224,11 @@ describe('form touched', () => {
      * internally through the `useFormField` hook, which is not used in this test.
      * Order of operations is important here.
      */
-    setFieldTouched('[parent.child.nested]', false);
-    setFieldTouched('[parent.child]', false);
+    setTouched('[parent.child.nested]', false);
+    setTouched('[parent.child]', false);
 
     // Using escaped path notation
-    setFieldTouched('[parent.child]', true);
+    setTouched('[parent.child]', true);
     expect(isTouched('[parent.child]')).toBe(true);
     expect(isTouched('[parent.child.nested]')).toBe(false);
 
@@ -243,8 +243,8 @@ describe('form reset', () => {
       return useForm({ initialValues: { foo: 'bar' }, initialTouched: { foo: true } });
     });
 
-    setFieldTouched('foo', false);
     setValue('foo', '');
+    setTouched('foo', false);
     expect(values).toEqual({ foo: '' });
     expect(isTouched('foo')).toBe(false);
     reset();
@@ -253,7 +253,6 @@ describe('form reset', () => {
   });
 
   test('can reset form values and touched to a new state', async () => {
-    const { values, reset, setFieldValue, isTouched, setFieldTouched } = await renderSetup(() => {
     const { values, reset, setValue, isTouched, setTouched } = await renderSetup(() => {
       return useForm({ initialValues: { foo: 'bar' } });
     });
@@ -261,7 +260,7 @@ describe('form reset', () => {
     reset({ values: { foo: 'baz' }, touched: { foo: true } });
     expect(values).toEqual({ foo: 'baz' });
     expect(isTouched('foo')).toBe(true);
-    setFieldTouched('foo', false);
+    setTouched('foo', false);
     setValue('foo', '');
     reset();
     expect(values).toEqual({ foo: 'baz' });
@@ -1302,13 +1301,13 @@ describe('form validation', () => {
   });
 
   test('displays errors if the field is touched', async () => {
-    const { setFieldTouched, displayError, setFieldErrors } = await renderSetup(() => {
+    const { setTouched, displayError, setErrors } = await renderSetup(() => {
       return useForm();
     });
 
     setFieldErrors('test', 'error');
     expect(displayError('test')).toBeUndefined();
-    setFieldTouched('test', true);
+    setTouched('test', true);
     expect(displayError('test')).toBe('error');
   });
 

--- a/packages/core/src/useForm/useForm.spec.ts
+++ b/packages/core/src/useForm/useForm.spec.ts
@@ -61,21 +61,21 @@ describe('form values', () => {
   });
 
   test('can set specific field value', async () => {
-    const { values, setFieldValue } = await renderSetup(() => {
+    const { values, setValue } = await renderSetup(() => {
       return useForm({ initialValues: { foo: 'bar' } });
     });
 
-    setFieldValue('foo', 'baz');
+    setValue('foo', 'baz');
 
     expect(values).toEqual({ foo: 'baz' });
   });
 
   test('can set nested field value', async () => {
-    const { values, setFieldValue } = await renderSetup(() => {
+    const { values, setValue } = await renderSetup(() => {
       return useForm<any>({ initialValues: {} });
     });
 
-    setFieldValue('foo.bar', 'baz');
+    setValue('foo.bar', 'baz');
 
     expect(values).toEqual({ foo: { bar: 'baz' } });
   });
@@ -142,7 +142,7 @@ describe('form touched', () => {
   });
 
   test('sets touched state correctly for discriminated union paths', async () => {
-    const { setFieldTouched, isTouched, setFieldValue, values } = await renderSetup(() => {
+    const { setTouched, isTouched, setValue, values } = await renderSetup(() => {
       return useForm<any>({
         initialValues: {
           someConfig: {
@@ -171,8 +171,8 @@ describe('form touched', () => {
     expect(isTouched('someConfig.nestedField2')).toBe(true);
 
     // Change someConfig to a boolean (discriminated union case)
-    setFieldValue('someConfig', false);
     setFieldTouched('someConfig', true);
+    setValue('someConfig', false);
 
     // Should still work as expected with boolean value
     expect(isTouched('someConfig')).toBe(true);
@@ -239,12 +239,12 @@ describe('form touched', () => {
 
 describe('form reset', () => {
   test('can reset form values and touched to their original state', async () => {
-    const { values, reset, setFieldValue, isTouched, setFieldTouched } = await renderSetup(() => {
+    const { values, reset, setValue, isTouched, setTouched } = await renderSetup(() => {
       return useForm({ initialValues: { foo: 'bar' }, initialTouched: { foo: true } });
     });
 
-    setFieldValue('foo', '');
     setFieldTouched('foo', false);
+    setValue('foo', '');
     expect(values).toEqual({ foo: '' });
     expect(isTouched('foo')).toBe(false);
     reset();
@@ -254,6 +254,7 @@ describe('form reset', () => {
 
   test('can reset form values and touched to a new state', async () => {
     const { values, reset, setFieldValue, isTouched, setFieldTouched } = await renderSetup(() => {
+    const { values, reset, setValue, isTouched, setTouched } = await renderSetup(() => {
       return useForm({ initialValues: { foo: 'bar' } });
     });
 
@@ -261,7 +262,7 @@ describe('form reset', () => {
     expect(values).toEqual({ foo: 'baz' });
     expect(isTouched('foo')).toBe(true);
     setFieldTouched('foo', false);
-    setFieldValue('foo', '');
+    setValue('foo', '');
     reset();
     expect(values).toEqual({ foo: 'baz' });
     expect(isTouched('foo')).toBe(true);
@@ -781,12 +782,12 @@ describe('form submit', () => {
 
 describe('form dirty state', () => {
   test('isDirty is true when the current values are different than the originals', async () => {
-    const { isDirty, setFieldValue, reset } = await renderSetup(() => {
+    const { isDirty, setValue, reset } = await renderSetup(() => {
       return useForm({ initialValues: { foo: 'bar' } });
     });
 
     expect(isDirty()).toBe(false);
-    setFieldValue('foo', 'baz');
+    setValue('foo', 'baz');
     expect(isDirty()).toBe(true);
     reset();
     expect(isDirty()).toBe(false);
@@ -803,14 +804,14 @@ describe('form dirty state', () => {
     );
 
     expect(form.isDirty()).toBe(false);
-    form.setFieldValue('field', 'bar');
+    form.setValue('field', 'bar');
     expect(form.isDirty()).toBe(true);
 
     expect(field.isDirty.value).toBe(false);
     field.setValue('foo');
     expect(field.isDirty.value).toBe(true);
 
-    form.setFieldValue('field', 'foo');
+    form.setValue('field', 'foo');
     field.setValue('bar');
     expect(form.isDirty()).toBe(false);
     expect(field.isDirty.value).toBe(false);
@@ -848,8 +849,8 @@ describe('form dirty state', () => {
     expect(form.isDirty('foo')).toBe(false);
     expect(form.isDirty('field')).toBe(false);
 
-    form.setFieldValue('foo', 'baz');
-    form.setFieldValue('field', 'something');
+    form.setValue('foo', 'baz');
+    form.setValue('field', 'something');
     expect(form.isDirty('foo')).toBe(true);
     expect(form.isDirty('field')).toBe(true);
   });

--- a/packages/core/src/useForm/useForm.spec.ts
+++ b/packages/core/src/useForm/useForm.spec.ts
@@ -785,11 +785,11 @@ describe('form dirty state', () => {
       return useForm({ initialValues: { foo: 'bar' } });
     });
 
-    expect(isDirty.value).toBe(false);
+    expect(isDirty()).toBe(false);
     setFieldValue('foo', 'baz');
-    expect(isDirty.value).toBe(true);
+    expect(isDirty()).toBe(true);
     reset();
-    expect(isDirty.value).toBe(false);
+    expect(isDirty()).toBe(false);
   });
 
   test('pathless fields do not contribute their dirty state to the form', async () => {
@@ -802,9 +802,9 @@ describe('form dirty state', () => {
       },
     );
 
-    expect(form.isDirty.value).toBe(false);
+    expect(form.isDirty()).toBe(false);
     form.setFieldValue('field', 'bar');
-    expect(form.isDirty.value).toBe(true);
+    expect(form.isDirty()).toBe(true);
 
     expect(field.isDirty.value).toBe(false);
     field.setValue('foo');
@@ -812,7 +812,7 @@ describe('form dirty state', () => {
 
     form.setFieldValue('field', 'foo');
     field.setValue('bar');
-    expect(form.isDirty.value).toBe(false);
+    expect(form.isDirty()).toBe(false);
     expect(field.isDirty.value).toBe(false);
   });
 
@@ -827,10 +827,10 @@ describe('form dirty state', () => {
     );
 
     expect(field.isDirty.value).toBe(false);
-    expect(form.isDirty.value).toBe(false);
+    expect(form.isDirty()).toBe(false);
     field.setValue('bar');
     expect(field.isDirty.value).toBe(true);
-    expect(form.isDirty.value).toBe(true);
+    expect(form.isDirty()).toBe(true);
     field.setValue('foo');
     expect(field.isDirty.value).toBe(false);
   });
@@ -845,13 +845,13 @@ describe('form dirty state', () => {
       },
     );
 
-    expect(form.isFieldDirty('foo')).toBe(false);
-    expect(form.isFieldDirty('field')).toBe(false);
+    expect(form.isDirty('foo')).toBe(false);
+    expect(form.isDirty('field')).toBe(false);
 
     form.setFieldValue('foo', 'baz');
     form.setFieldValue('field', 'something');
-    expect(form.isFieldDirty('foo')).toBe(true);
-    expect(form.isFieldDirty('field')).toBe(true);
+    expect(form.isDirty('foo')).toBe(true);
+    expect(form.isDirty('field')).toBe(true);
   });
 });
 

--- a/packages/core/src/useForm/useForm.ts
+++ b/packages/core/src/useForm/useForm.ts
@@ -1,4 +1,4 @@
-import { computed, InjectionKey, MaybeRefOrGetter, onMounted, provide, reactive, readonly, Ref, ref } from 'vue';
+import { InjectionKey, MaybeRefOrGetter, onMounted, provide, reactive, readonly, Ref, ref } from 'vue';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { cloneDeep, useUniqId } from '../utils/common';
 import {
@@ -118,9 +118,11 @@ export function useForm<
     },
   });
 
-  const isValid = computed(() => {
-    return !ctx.hasErrors();
-  });
+  function isValid<TPath extends Path<TInput>>(path?: TPath) {
+    const pathErrors = ctx.getErrors(path);
+
+    return pathErrors.length === 0;
+  }
 
   function onAsyncInit(v: TInput) {
     ctx.setValues(v, { behavior: 'merge' });

--- a/packages/core/src/useForm/useForm.ts
+++ b/packages/core/src/useForm/useForm.ts
@@ -240,7 +240,7 @@ export function useForm<
     /**
      * Sets the touched state of a field.
      */
-    setFieldTouched: ctx.setFieldTouched,
+    setTouched: ctx.setTouched,
     /**
      * Sets the errors for a field.
      */

--- a/packages/core/src/useForm/useForm.ts
+++ b/packages/core/src/useForm/useForm.ts
@@ -19,7 +19,6 @@ import { createFormContext, BaseFormContext } from './formContext';
 import { FormTransactionManager, useFormTransactions } from './useFormTransactions';
 import { FormActions, useFormActions } from './useFormActions';
 import { useFormSnapshots } from './formSnapshot';
-import { findLeaf } from '../utils/path';
 import { getConfig } from '../config';
 import { FieldTypePrefixes } from '../constants';
 import { appendToFormData, clearFormData } from '../utils/formData';
@@ -119,10 +118,6 @@ export function useForm<
     },
   });
 
-  const isTouched = computed(() => {
-    return !!findLeaf(touched, l => l === true);
-  });
-
   const isDirty = computed(() => {
     return !isEqual(values, valuesSnapshot.originals.value);
   });
@@ -160,7 +155,7 @@ export function useForm<
   }
 
   function displayError(path: Path<TInput>) {
-    return ctx.isFieldTouched(path) && !ctx.isPathDisabled(path) ? getError(path) : undefined;
+    return ctx.isTouched(path) && !ctx.isPathDisabled(path) ? getError(path) : undefined;
   }
 
   provide(FormKey, {
@@ -209,10 +204,6 @@ export function useForm<
      */
     isSubmitting,
     /**
-     * Whether the form is touched.
-     */
-    isTouched,
-    /**
      * Whether the form is dirty.
      */
     isDirty,
@@ -249,9 +240,9 @@ export function useForm<
      */
     getFieldValue: ctx.getFieldValue,
     /**
-     * Whether the specified field is touched.
+     * Whether the path is touched.
      */
-    isFieldTouched: ctx.isFieldTouched,
+    isTouched: ctx.isTouched,
     /**
      * Sets the touched state of a field.
      */

--- a/packages/core/src/useForm/useForm.ts
+++ b/packages/core/src/useForm/useForm.ts
@@ -224,7 +224,7 @@ export function useForm<
     /**
      * Gets the value of a field.
      */
-    getFieldValue: ctx.getFieldValue,
+    getValue: ctx.getValue,
     /**
      * Whether the path is touched.
      */

--- a/packages/core/src/useForm/useForm.ts
+++ b/packages/core/src/useForm/useForm.ts
@@ -228,7 +228,7 @@ export function useForm<
     /**
      * Sets the value of a field.
      */
-    setFieldValue: ctx.setFieldValue,
+    setValue: ctx.setValue,
     /**
      * Gets the value of a field.
      */

--- a/packages/core/src/useForm/useForm.ts
+++ b/packages/core/src/useForm/useForm.ts
@@ -1,6 +1,6 @@
 import { computed, InjectionKey, MaybeRefOrGetter, onMounted, provide, reactive, readonly, Ref, ref } from 'vue';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
-import { cloneDeep, isEqual, useUniqId } from '../utils/common';
+import { cloneDeep, useUniqId } from '../utils/common';
 import {
   FormObject,
   MaybeAsync,
@@ -118,10 +118,6 @@ export function useForm<
     },
   });
 
-  const isDirty = computed(() => {
-    return !isEqual(values, valuesSnapshot.originals.value);
-  });
-
   const isValid = computed(() => {
     return !ctx.hasErrors();
   });
@@ -204,10 +200,6 @@ export function useForm<
      */
     isSubmitting,
     /**
-     * Whether the form is dirty.
-     */
-    isDirty,
-    /**
      * Whether the form is valid.
      */
     isValid,
@@ -228,9 +220,9 @@ export function useForm<
      */
     isSubmitAttempted,
     /**
-     * Whether the specified field is dirty.
+     * Whether the path is dirty.
      */
-    isFieldDirty: ctx.isFieldDirty,
+    isDirty: ctx.isDirty,
     /**
      * Sets the value of a field.
      */

--- a/packages/core/src/useForm/useForm.ts
+++ b/packages/core/src/useForm/useForm.ts
@@ -137,7 +137,7 @@ export function useForm<
     });
 
   function getError<TPath extends Path<TInput>>(path: TPath): string | undefined {
-    return ctx.isPathDisabled(path) ? undefined : ctx.getFieldErrors(path)[0];
+    return ctx.isPathDisabled(path) ? undefined : ctx.getErrors(path)[0];
   }
 
   function getSubmitError<TPath extends Path<TInput>>(path: TPath): string | undefined {

--- a/packages/core/src/useForm/useForm.ts
+++ b/packages/core/src/useForm/useForm.ts
@@ -136,16 +136,8 @@ export function useForm<
       scrollToInvalidFieldOnSubmit: props?.scrollToInvalidFieldOnSubmit ?? true,
     });
 
-  function getErrors<TPath extends Path<TInput>>(path?: TPath) {
-    return ctx.getErrors(path);
-  }
-
   function getError<TPath extends Path<TInput>>(path: TPath): string | undefined {
     return ctx.isPathDisabled(path) ? undefined : ctx.getFieldErrors(path)[0];
-  }
-
-  function getSubmitErrors() {
-    return ctx.getSubmitErrors();
   }
 
   function getSubmitError<TPath extends Path<TInput>>(path: TPath): string | undefined {
@@ -244,7 +236,7 @@ export function useForm<
     /**
      * Sets the errors for a field.
      */
-    setFieldErrors: ctx.setFieldErrors,
+    setErrors: ctx.setErrors,
     /**
      * Sets the values of the form.
      */
@@ -260,7 +252,7 @@ export function useForm<
     /**
      * Gets all the errors for the form.
      */
-    getErrors,
+    getErrors: ctx.getErrors,
     /**
      * Gets the submit errors for a field.
      */
@@ -268,7 +260,7 @@ export function useForm<
     /**
      * Gets all the submit errors for the form.
      */
-    getSubmitErrors,
+    getSubmitErrors: ctx.getSubmitErrors,
     /**
      * Props for the form element.
      */

--- a/packages/core/src/useForm/useFormActions.ts
+++ b/packages/core/src/useForm/useFormActions.ts
@@ -142,7 +142,7 @@ export function useFormActions<TForm extends FormObject = FormObject, TOutput ex
 
   function applyErrors(errors: IssueCollection[]) {
     for (const entry of errors) {
-      form.setFieldErrors(entry.path as Path<TForm>, entry.messages);
+      form.setErrors(entry.path as Path<TForm>, entry.messages);
     }
   }
 

--- a/packages/core/src/useForm/useFormTransactions.ts
+++ b/packages/core/src/useForm/useFormTransactions.ts
@@ -90,8 +90,8 @@ export function useFormTransactions<TForm extends FormObject>(form: BaseFormCont
 
     for (const tr of trs) {
       if (tr.kind === TransactionKind.SET_PATH) {
-        form.setFieldTouched(tr.path, tr.touched);
         form.setValue(tr.path, tr.value);
+        form.setTouched(tr.path, tr.touched);
         form.setFieldDisabled(tr.path, tr.disabled);
         form.setFieldErrors(tr.path, tr.errors);
         continue;
@@ -111,7 +111,7 @@ export function useFormTransactions<TForm extends FormObject>(form: BaseFormCont
         const formInit = form.getFieldInitialValue(tr.path);
         form.setValue(tr.path, tr.value ?? formInit);
         form.setFieldDisabled(tr.path, tr.disabled);
-        form.setFieldTouched(tr.path, tr.touched);
+        form.setTouched(tr.path, tr.touched);
         form.unsetInitialValue(tr.path);
         form.setFieldErrors(tr.path, tr.errors);
         continue;

--- a/packages/core/src/useForm/useFormTransactions.ts
+++ b/packages/core/src/useForm/useFormTransactions.ts
@@ -49,10 +49,7 @@ const TransactionKind = {
 export interface FormTransactionManager<TForm extends FormObject> {
   transaction(
     tr: (
-      formCtx: Pick<
-        BaseFormContext<TForm>,
-        'getValues' | 'getFieldValue' | 'isFieldSet' | 'isTouched' | 'getFieldErrors'
-      >,
+      formCtx: Pick<BaseFormContext<TForm>, 'getValues' | 'getValue' | 'isFieldSet' | 'isTouched' | 'getFieldErrors'>,
       codes: typeof TransactionKind,
     ) => FormTransaction<TForm> | null,
   ): void;

--- a/packages/core/src/useForm/useFormTransactions.ts
+++ b/packages/core/src/useForm/useFormTransactions.ts
@@ -51,7 +51,7 @@ export interface FormTransactionManager<TForm extends FormObject> {
     tr: (
       formCtx: Pick<
         BaseFormContext<TForm>,
-        'getValues' | 'getFieldValue' | 'isFieldSet' | 'isFieldTouched' | 'getFieldErrors'
+        'getValues' | 'getFieldValue' | 'isFieldSet' | 'isTouched' | 'getFieldErrors'
       >,
       codes: typeof TransactionKind,
     ) => FormTransaction<TForm> | null,

--- a/packages/core/src/useForm/useFormTransactions.ts
+++ b/packages/core/src/useForm/useFormTransactions.ts
@@ -90,8 +90,8 @@ export function useFormTransactions<TForm extends FormObject>(form: BaseFormCont
 
     for (const tr of trs) {
       if (tr.kind === TransactionKind.SET_PATH) {
-        form.setFieldValue(tr.path, tr.value);
         form.setFieldTouched(tr.path, tr.touched);
+        form.setValue(tr.path, tr.value);
         form.setFieldDisabled(tr.path, tr.disabled);
         form.setFieldErrors(tr.path, tr.errors);
         continue;
@@ -109,7 +109,7 @@ export function useFormTransactions<TForm extends FormObject>(form: BaseFormCont
 
       if (tr.kind === TransactionKind.INIT_PATH) {
         const formInit = form.getFieldInitialValue(tr.path);
-        form.setFieldValue(tr.path, tr.value ?? formInit);
+        form.setValue(tr.path, tr.value ?? formInit);
         form.setFieldDisabled(tr.path, tr.disabled);
         form.setFieldTouched(tr.path, tr.touched);
         form.unsetInitialValue(tr.path);

--- a/packages/core/src/useForm/useFormTransactions.ts
+++ b/packages/core/src/useForm/useFormTransactions.ts
@@ -93,7 +93,7 @@ export function useFormTransactions<TForm extends FormObject>(form: BaseFormCont
         form.setValue(tr.path, tr.value);
         form.setTouched(tr.path, tr.touched);
         form.setFieldDisabled(tr.path, tr.disabled);
-        form.setFieldErrors(tr.path, tr.errors);
+        form.setErrors(tr.path, tr.errors);
         continue;
       }
 
@@ -113,7 +113,7 @@ export function useFormTransactions<TForm extends FormObject>(form: BaseFormCont
         form.setFieldDisabled(tr.path, tr.disabled);
         form.setTouched(tr.path, tr.touched);
         form.unsetInitialValue(tr.path);
-        form.setFieldErrors(tr.path, tr.errors);
+        form.setErrors(tr.path, tr.errors);
         continue;
       }
     }

--- a/packages/core/src/useForm/useFormTransactions.ts
+++ b/packages/core/src/useForm/useFormTransactions.ts
@@ -49,7 +49,7 @@ const TransactionKind = {
 export interface FormTransactionManager<TForm extends FormObject> {
   transaction(
     tr: (
-      formCtx: Pick<BaseFormContext<TForm>, 'getValues' | 'getValue' | 'isFieldSet' | 'isTouched' | 'getFieldErrors'>,
+      formCtx: Pick<BaseFormContext<TForm>, 'getValues' | 'getValue' | 'isFieldSet' | 'isTouched' | 'getErrors'>,
       codes: typeof TransactionKind,
     ) => FormTransaction<TForm> | null,
   ): void;

--- a/packages/core/src/useFormField/useFormField.ts
+++ b/packages/core/src/useFormField/useFormField.ts
@@ -344,7 +344,7 @@ function createFormValidityRef(getPath: Getter<string | undefined>, form: FormCo
     pathlessValidity.setErrors(messages);
     const path = getPath();
     if (path) {
-      form.setFieldErrors(path, messages);
+      form.setErrors(path, messages);
     }
   }
 

--- a/packages/core/src/useFormField/useFormField.ts
+++ b/packages/core/src/useFormField/useFormField.ts
@@ -173,7 +173,7 @@ export function useFormField<TValue = unknown>(opts?: Partial<FormFieldOptions<T
         return {
           kind: SET_PATH,
           path: newPath,
-          value: cloneDeep(oldPath ? tf.getFieldValue(oldPath) : pathlessValue.value),
+          value: cloneDeep(oldPath ? tf.getValue(oldPath) : pathlessValue.value),
           touched: oldPath ? tf.isTouched(oldPath) : pathlessTouched.value,
           disabled: isDisabled.value,
           errors: [...(oldPath ? tf.getFieldErrors(oldPath) : pathlessValidity.errors.value)],
@@ -268,7 +268,7 @@ function createFormValueRef<TValue = unknown>(
   const fieldValue = computed(() => {
     const path = getPath();
 
-    return path ? form.getFieldValue(path) : pathlessValue.value;
+    return path ? form.getValue(path) : pathlessValue.value;
   }) as Ref<TValue | undefined>;
 
   function setValue(value: TValue | undefined) {

--- a/packages/core/src/useFormField/useFormField.ts
+++ b/packages/core/src/useFormField/useFormField.ts
@@ -176,7 +176,7 @@ export function useFormField<TValue = unknown>(opts?: Partial<FormFieldOptions<T
           value: cloneDeep(oldPath ? tf.getValue(oldPath) : pathlessValue.value),
           touched: oldPath ? tf.isTouched(oldPath) : pathlessTouched.value,
           disabled: isDisabled.value,
-          errors: [...(oldPath ? tf.getFieldErrors(oldPath) : pathlessValidity.errors.value)],
+          errors: [...(oldPath ? tf.getErrors(oldPath) : pathlessValidity.errors.value)],
         };
       });
     }
@@ -321,7 +321,7 @@ function initFormPathIfNecessary(
       value: initialValue ?? form.getFieldInitialValue(path),
       touched: initialTouched,
       disabled: toValue(isDisabled),
-      errors: [...tf.getFieldErrors(path)],
+      errors: [...tf.getErrors(path)],
     }));
   });
 }
@@ -331,7 +331,7 @@ function createFormValidityRef(getPath: Getter<string | undefined>, form: FormCo
   const errors = computed(() => {
     const path = getPath();
 
-    return path ? form.getFieldErrors(path) : pathlessValidity.errors.value;
+    return path ? form.getErrors(path) : pathlessValidity.errors.value;
   }) as Ref<string[]>;
 
   const submitErrors = computed(() => {

--- a/packages/core/src/useFormField/useFormField.ts
+++ b/packages/core/src/useFormField/useFormField.ts
@@ -174,7 +174,7 @@ export function useFormField<TValue = unknown>(opts?: Partial<FormFieldOptions<T
           kind: SET_PATH,
           path: newPath,
           value: cloneDeep(oldPath ? tf.getFieldValue(oldPath) : pathlessValue.value),
-          touched: oldPath ? tf.isFieldTouched(oldPath) : pathlessTouched.value,
+          touched: oldPath ? tf.isTouched(oldPath) : pathlessTouched.value,
           disabled: isDisabled.value,
           errors: [...(oldPath ? tf.getFieldErrors(oldPath) : pathlessValidity.errors.value)],
         };
@@ -238,7 +238,7 @@ function createFormTouchedRef(getPath: Getter<string | undefined>, form: FormCon
   const isTouched = computed(() => {
     const path = getPath();
 
-    return path ? form.isFieldTouched(path) : pathlessTouched.value;
+    return path ? form.isTouched(path) : pathlessTouched.value;
   }) as Ref<boolean>;
 
   function setTouched(value: boolean) {

--- a/packages/core/src/useFormField/useFormField.ts
+++ b/packages/core/src/useFormField/useFormField.ts
@@ -247,7 +247,7 @@ function createFormTouchedRef(getPath: Getter<string | undefined>, form: FormCon
     pathlessTouched.value = value;
     // Only update it if the value is actually different, this avoids unnecessary path traversal/creation
     if (path && isDifferent) {
-      form.setFieldTouched(path, value);
+      form.setTouched(path, value);
     }
   }
 

--- a/packages/core/src/useFormField/useFormField.ts
+++ b/packages/core/src/useFormField/useFormField.ts
@@ -275,7 +275,7 @@ function createFormValueRef<TValue = unknown>(
     const path = getPath();
     pathlessValue.value = value;
     if (path) {
-      form.setFieldValue(path, value);
+      form.setValue(path, value);
     }
   }
 

--- a/packages/core/src/useFormGroup/useFormGroup.spec.ts
+++ b/packages/core/src/useFormGroup/useFormGroup.spec.ts
@@ -346,19 +346,19 @@ test('validation cascades', async () => {
 
   await flush();
   expect(form.getErrors()).toHaveLength(2);
-  expect(form.getErrors().flatMap(e => e.messages)).toEqual(['Constraints not satisfied', 'Constraints not satisfied']);
+  expect(form.getErrors()).toEqual(['Constraints not satisfied', 'Constraints not satisfied']);
 
   await fireEvent.update(screen.getByTestId('field'), 'test');
   await fireEvent.blur(screen.getByTestId('field'));
 
   await flush();
   expect(form.getErrors()).toHaveLength(2);
-  expect(form.getErrors().flatMap(e => e.messages)).toEqual(['Constraints not satisfied', 'error']);
+  expect(form.getErrors()).toEqual(['Constraints not satisfied', 'error']);
   await fireEvent.update(screen.getByTestId('other'), 'test');
   await fireEvent.blur(screen.getByTestId('other'));
   await flush();
   expect(form.getErrors()).toHaveLength(2);
-  expect(form.getErrors().flatMap(e => e.messages)).toEqual(['error', 'error']);
+  expect(form.getErrors()).toEqual(['error', 'error']);
 
   await fireEvent.update(screen.getByTestId('other'), 'valid');
   await fireEvent.update(screen.getByTestId('field'), 'valid');

--- a/packages/core/src/useFormGroup/useFormGroup.ts
+++ b/packages/core/src/useFormGroup/useFormGroup.ts
@@ -141,7 +141,7 @@ export function useFormGroup<TInput extends FormObject = FormObject, TOutput ext
   }
 
   const isValid = computed(() => getErrors().length === 0);
-  const isTouched = computed(() => form?.isFieldTouched(getPath()) ?? false);
+  const isTouched = computed(() => form?.isTouched(getPath()) ?? false);
   const isDirty = computed(() => {
     const path = getPath();
 
@@ -156,7 +156,7 @@ export function useFormGroup<TInput extends FormObject = FormObject, TOutput ext
     const msg = getError(name);
     const path = prefixPath(name) ?? '';
 
-    return form?.isFieldTouched(path) ? msg : undefined;
+    return form?.isTouched(path) ? msg : undefined;
   }
 
   function prefixPath(path: string | undefined) {

--- a/packages/core/src/useFormGroup/useFormGroup.ts
+++ b/packages/core/src/useFormGroup/useFormGroup.ts
@@ -97,7 +97,7 @@ export function useFormGroup<TInput extends FormObject = FormObject, TOutput ext
     // Clears Errors in that path before proceeding.
     form?.clearErrors(toValue(props.name));
     for (const entry of res.errors) {
-      form?.setFieldErrors(entry.path, entry.messages);
+      form?.setErrors(entry.path, entry.messages);
     }
 
     const parent = parentGroup || form;

--- a/packages/core/src/useFormGroup/useFormGroup.ts
+++ b/packages/core/src/useFormGroup/useFormGroup.ts
@@ -133,7 +133,7 @@ export function useFormGroup<TInput extends FormObject = FormObject, TOutput ext
   });
 
   function getValues(): TInput {
-    return form?.getFieldValue(getPath()) ?? {};
+    return form?.getValue(getPath()) ?? {};
   }
 
   function getErrors() {

--- a/packages/core/src/useFormGroup/useFormGroup.ts
+++ b/packages/core/src/useFormGroup/useFormGroup.ts
@@ -149,7 +149,7 @@ export function useFormGroup<TInput extends FormObject = FormObject, TOutput ext
   });
 
   function getError(name: string) {
-    return form?.getFieldErrors(prefixPath(name) ?? '')?.[0];
+    return form?.getErrors(prefixPath(name) ?? '')?.[0];
   }
 
   function displayError(name: string) {

--- a/packages/core/src/useFormRepeater/useFormRepeater.ts
+++ b/packages/core/src/useFormRepeater/useFormRepeater.ts
@@ -116,7 +116,7 @@ export function useFormRepeater<TItem = unknown>(_props: Reactivify<FormRepeater
   const form = inject(FormKey, null);
   const repeaterProps = normalizeProps(_props);
   const getPath = () => toValue(repeaterProps.name);
-  const getPathValue = () => (form?.getFieldValue(getPath()) || []) as TItem[];
+  const getPathValue = () => (form?.getValue(getPath()) || []) as TItem[];
   let lastControlledValueSnapshot: TItem[] | undefined;
   const records = ref(buildRecords());
 

--- a/packages/ecosystem/src/valibot/valibot.spec.ts
+++ b/packages/ecosystem/src/valibot/valibot.spec.ts
@@ -78,9 +78,7 @@ test('collects multiple errors per field', async () => {
   await fireEvent.click(screen.getByText('Submit'));
   await flush();
   expect(handler).toHaveBeenCalledWith([
-    {
-      path: 'test',
-      messages: ['Invalid email: Received "123"', 'Invalid length: Expected >=8 but received 3'],
-    },
+    'Invalid email: Received "123"',
+    'Invalid length: Expected >=8 but received 3',
   ]);
 });

--- a/packages/ecosystem/src/zod/zod.spec.ts
+++ b/packages/ecosystem/src/zod/zod.spec.ts
@@ -77,10 +77,5 @@ test('collects multiple errors per field', async () => {
 
   await fireEvent.click(screen.getByText('Submit'));
   await flush();
-  expect(handler).toHaveBeenCalledWith([
-    {
-      path: 'test',
-      messages: ['Invalid email', 'String must contain at least 8 character(s)'],
-    },
-  ]);
+  expect(handler).toHaveBeenCalledWith(['Invalid email', 'String must contain at least 8 character(s)']);
 });


### PR DESCRIPTION
Fixes #125 

Unifies `isDirty`, `isTouched`, `isValid`, `setFieldErros` and `setFieldValue`