### PR TITLE
fix: manually track the dirty state

### DIFF
--- a/.changeset/giant-cooks-act.md
+++ b/.changeset/giant-cooks-act.md
@@ -1,0 +1,5 @@
+---
+'@formwerk/core': patch
+---
+
+fix: track dirty state manually

--- a/packages/core/src/types/forms.ts
+++ b/packages/core/src/types/forms.ts
@@ -14,6 +14,8 @@ export type FormSchema<TInput extends FormObject = FormObject, TOutput = TInput>
 
 export type TouchedSchema<TForm extends FormObject> = Simplify<Schema<TForm, boolean>>;
 
+export type DirtySchema<TForm extends FormObject> = Simplify<Schema<TForm, boolean>>;
+
 export type DisabledSchema<TForm extends FormObject> = Partial<Record<Path<TForm>, boolean>>;
 
 export type ErrorsSchema<TForm extends FormObject> = Partial<Record<Path<TForm>, string[]>>;

--- a/packages/core/src/useForm/formContext.ts
+++ b/packages/core/src/useForm/formContext.ts
@@ -9,8 +9,9 @@ import {
   StandardSchema,
   ErrorsSchema,
   IssueCollection,
+  DirtySchema,
 } from '../types';
-import { cloneDeep, isEqual, normalizeArrayable } from '../utils/common';
+import { cloneDeep, normalizeArrayable } from '../utils/common';
 import {
   escapePath,
   findLeaf,
@@ -35,6 +36,8 @@ export interface BaseFormContext<TForm extends FormObject = FormObject> {
   setTouched<TPath extends Path<TForm>>(path: TPath, value: boolean): void;
   isTouched<TPath extends Path<TForm>>(path?: TPath): boolean;
   isDirty<TPath extends Path<TForm>>(path?: TPath): boolean;
+  setDirty(value: boolean): void;
+  setDirty<TPath extends Path<TForm>>(path: TPath, value: boolean): void;
   isFieldSet<TPath extends Path<TForm>>(path: TPath): boolean;
   getFieldInitialValue<TPath extends Path<TForm>>(path: TPath): PathValue<TForm, TPath>;
   getFieldOriginalValue<TPath extends Path<TForm>>(path: TPath): PathValue<TForm, TPath>;
@@ -54,6 +57,7 @@ export interface BaseFormContext<TForm extends FormObject = FormObject> {
   setValues: (newValues: Partial<TForm>, opts?: SetValueOptions) => void;
   revertValues: () => void;
   revertTouched: () => void;
+  revertDirty: () => void;
   isPathDisabled: (path: Path<TForm>) => boolean;
 }
 
@@ -65,6 +69,7 @@ export interface FormContextCreateOptions<TForm extends FormObject = FormObject,
   id: string;
   values: TForm;
   touched: TouchedSchema<TForm>;
+  dirty: DirtySchema<TForm>;
   disabled: DisabledSchema<TForm>;
   errors: Ref<ErrorsSchema<TForm>>;
   submitErrors: Ref<ErrorsSchema<TForm>>;
@@ -72,6 +77,7 @@ export interface FormContextCreateOptions<TForm extends FormObject = FormObject,
   snapshots: {
     values: FormSnapshot<TForm>;
     touched: FormSnapshot<TouchedSchema<TForm>>;
+    dirty: FormSnapshot<DirtySchema<TForm>>;
   };
 }
 
@@ -80,6 +86,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
   values,
   disabled,
   errors,
+  dirty,
   submitErrors,
   schema,
   touched,
@@ -123,10 +130,24 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
 
   function isDirty<TPath extends Path<TForm>>(path?: TPath) {
     if (!path) {
-      return !isEqual(values, snapshots.values.originals.value);
+      return !!findLeaf(dirty, l => l === true);
     }
 
-    return !isEqual(getValue(path), getFieldOriginalValue(path));
+    return !!getFromPath(dirty, path);
+  }
+
+  function setDirty(value: boolean): void;
+  function setDirty<TPath extends Path<TForm>>(path: TPath, value: boolean): void;
+  function setDirty<TPath extends Path<TForm>>(pathOrValue: TPath | boolean, valueOrUndefined?: boolean) {
+    if (typeof pathOrValue === 'boolean') {
+      for (const key in dirty) {
+        setInPath(dirty, key, pathOrValue, true);
+      }
+
+      return;
+    }
+
+    setInPath(dirty, pathOrValue, valueOrUndefined, true);
   }
 
   function isFieldSet<TPath extends Path<TForm>>(path: TPath) {
@@ -267,6 +288,21 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     merge(touched, newTouched);
   }
 
+  function updateDirty(newDirty: Partial<DirtySchema<TForm>>, opts?: SetValueOptions) {
+    if (opts?.behavior === 'merge') {
+      merge(dirty, newDirty);
+
+      return;
+    }
+
+    // Delete all keys, then set new values
+    Object.keys(dirty).forEach(key => {
+      delete dirty[key as keyof typeof dirty];
+    });
+
+    merge(dirty, newDirty);
+  }
+
   function clearErrors(path?: string) {
     if (!path) {
       errors.value = {} as ErrorsSchema<TForm>;
@@ -301,6 +337,10 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     updateTouched(cloneDeep(snapshots.touched.originals.value), { behavior: 'replace' });
   }
 
+  function revertDirty() {
+    updateDirty(cloneDeep(snapshots.dirty.originals.value), { behavior: 'replace' });
+  }
+
   function getValidationMode(): FormValidationMode {
     return schema ? 'schema' : 'aggregate';
   }
@@ -314,6 +354,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     getValue,
     isTouched,
     isDirty,
+    setDirty,
     isFieldSet,
     destroyPath,
     unsetPath,
@@ -322,6 +363,7 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
     revertValues,
     revertTouched,
     setInitialValues,
+    revertDirty,
     setInitialTouched,
     getFieldOriginalValue,
     setFieldDisabled,

--- a/packages/core/src/useForm/formContext.ts
+++ b/packages/core/src/useForm/formContext.ts
@@ -11,7 +11,7 @@ import {
   IssueCollection,
   DirtySchema,
 } from '../types';
-import { cloneDeep, normalizeArrayable } from '../utils/common';
+import { cloneDeep, isEqual, normalizeArrayable } from '../utils/common';
 import {
   escapePath,
   findLeaf,
@@ -94,6 +94,8 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
 }: FormContextCreateOptions<TForm, TOutput>): BaseFormContext<TForm> {
   function setValue<TPath extends Path<TForm>>(path: TPath, value: PathValue<TForm, TPath> | undefined) {
     setInPath(values, path, cloneDeep(value));
+    const oldValue = getFieldOriginalValue(path);
+    setDirty(path, !isEqual(oldValue, value));
   }
 
   function setTouched(value: boolean): void;
@@ -133,7 +135,12 @@ export function createFormContext<TForm extends FormObject = FormObject, TOutput
       return !!findLeaf(dirty, l => l === true);
     }
 
-    return !!getFromPath(dirty, path);
+    const value = getFromPath(dirty, path);
+    if (isObject(value)) {
+      return !!findLeaf(value, v => !!v);
+    }
+
+    return !!value;
   }
 
   function setDirty(value: boolean): void;

--- a/packages/core/src/useForm/useForm.ts
+++ b/packages/core/src/useForm/useForm.ts
@@ -14,6 +14,7 @@ import {
   GroupValidationResult,
   GenericFormSchema,
   StandardSchema,
+  DirtySchema,
 } from '../types';
 import { createFormContext, BaseFormContext } from './formContext';
 import { FormTransactionManager, useFormTransactions } from './useFormTransactions';
@@ -43,6 +44,11 @@ export interface FormProps<
    * The initial touched state for form fields.
    */
   initialTouched?: TouchedSchema<TInput>;
+
+  /**
+   * The initial dirty state for form fields.
+   */
+  initialDirty?: DirtySchema<TInput>;
 
   /**
    * The validation schema for the form.
@@ -90,6 +96,7 @@ export function useForm<
   TOutput extends FormObject = StandardSchemaV1.InferOutput<TSchema>,
 >(props?: Partial<FormProps<TSchema, TInput>>) {
   const touchedSnapshot = useFormSnapshots(props?.initialTouched);
+  const dirtySnapshot = useFormSnapshots(props?.initialDirty);
   const valuesSnapshot = useFormSnapshots<TInput, TOutput>(props?.initialValues as TInput, {
     onAsyncInit,
     schema: props?.schema as StandardSchema<TInput, TOutput>,
@@ -100,6 +107,7 @@ export function useForm<
   const isHtmlValidationDisabled = () => props?.disableHtmlValidation ?? getConfig().disableHtmlValidation;
   const values = reactive(cloneDeep(valuesSnapshot.originals.value)) as PartialDeep<TInput>;
   const touched = reactive(cloneDeep(touchedSnapshot.originals.value)) as TouchedSchema<TInput>;
+  const dirty = reactive(cloneDeep(dirtySnapshot.originals.value)) as DirtySchema<TInput>;
   const disabled = reactive({}) as DisabledSchema<TInput>;
   const errors = ref({}) as Ref<ErrorsSchema<TInput>>;
   const submitErrors = ref({}) as Ref<ErrorsSchema<TInput>>;
@@ -109,12 +117,14 @@ export function useForm<
     values: values as TInput,
     touched,
     disabled,
+    dirty,
     schema: props?.schema as StandardSchema<TInput, TOutput>,
     errors,
     submitErrors,
     snapshots: {
       values: valuesSnapshot,
       touched: touchedSnapshot,
+      dirty: dirtySnapshot,
     },
   });
 

--- a/packages/core/src/useForm/useFormActions.ts
+++ b/packages/core/src/useForm/useFormActions.ts
@@ -165,6 +165,7 @@ export function useFormActions<TForm extends FormObject = FormObject, TOutput ex
 
     form.revertValues();
     form.revertTouched();
+    form.revertDirty();
     submitAttemptsCount.value = 0;
     isSubmitAttempted.value = false;
 

--- a/packages/core/src/useFormField/useFormField.ts
+++ b/packages/core/src/useFormField/useFormField.ts
@@ -70,16 +70,6 @@ export function useFormField<TValue = unknown>(opts?: Partial<FormFieldOptions<T
     return !isEqual(fieldValue.value, form.getFieldOriginalValue(path));
   });
 
-  // Keeps the form's dirty state in sync with the field's dirty state.
-  watch(isDirty, dirty => {
-    const path = getPath();
-    if (!path) {
-      return;
-    }
-
-    form?.setDirty(path, dirty);
-  });
-
   if (opts?.syncModel ?? true) {
     useSyncModel({
       model: fieldValue,

--- a/packages/core/src/useFormField/useFormField.ts
+++ b/packages/core/src/useFormField/useFormField.ts
@@ -12,6 +12,7 @@ interface FormFieldOptions<TValue = unknown> {
   path: MaybeRefOrGetter<string | undefined> | undefined;
   initialValue: TValue;
   initialTouched: boolean;
+  initialDirty: boolean;
   syncModel: boolean;
   modelName: string;
   disabled: MaybeRefOrGetter<boolean | undefined>;
@@ -67,6 +68,16 @@ export function useFormField<TValue = unknown>(opts?: Partial<FormFieldOptions<T
     }
 
     return !isEqual(fieldValue.value, form.getFieldOriginalValue(path));
+  });
+
+  // Keeps the form's dirty state in sync with the field's dirty state.
+  watch(isDirty, dirty => {
+    const path = getPath();
+    if (!path) {
+      return;
+    }
+
+    form?.setDirty(path, dirty);
   });
 
   if (opts?.syncModel ?? true) {
@@ -138,7 +149,14 @@ export function useFormField<TValue = unknown>(opts?: Partial<FormFieldOptions<T
     return field;
   }
 
-  initFormPathIfNecessary(form, getPath, initialValue, opts?.initialTouched ?? false, isDisabled);
+  initFormPathIfNecessary({
+    form,
+    getPath,
+    initialValue,
+    initialTouched: opts?.initialTouched ?? false,
+    initialDirty: opts?.initialDirty ?? false,
+    isDisabled,
+  });
 
   form.onSubmitAttempt(() => {
     setTouched(true);
@@ -175,6 +193,7 @@ export function useFormField<TValue = unknown>(opts?: Partial<FormFieldOptions<T
           path: newPath,
           value: cloneDeep(oldPath ? tf.getValue(oldPath) : pathlessValue.value),
           touched: oldPath ? tf.isTouched(oldPath) : pathlessTouched.value,
+          dirty: oldPath ? tf.isDirty(oldPath) : isDirty.value,
           disabled: isDisabled.value,
           errors: [...(oldPath ? tf.getErrors(oldPath) : pathlessValidity.errors.value)],
         };
@@ -298,16 +317,26 @@ function createLocalValueRef<TValue = unknown>(initialValue?: TValue) {
   };
 }
 
+interface FormPathInitOptions {
+  form: FormContext;
+  getPath: Getter<string | undefined>;
+  initialValue: unknown;
+  initialTouched: boolean;
+  initialDirty: boolean;
+  isDisabled: MaybeRefOrGetter<boolean>;
+}
+
 /**
  * Sets the initial value of the form if not already set and if an initial value is provided.
  */
-function initFormPathIfNecessary(
-  form: FormContext,
-  getPath: Getter<string | undefined>,
-  initialValue: unknown,
-  initialTouched: boolean,
-  isDisabled: MaybeRefOrGetter<boolean>,
-) {
+function initFormPathIfNecessary({
+  form,
+  getPath,
+  initialValue,
+  initialTouched,
+  initialDirty,
+  isDisabled,
+}: FormPathInitOptions) {
   const path = getPath();
   if (!path) {
     return;
@@ -320,6 +349,7 @@ function initFormPathIfNecessary(
       path,
       value: initialValue ?? form.getFieldInitialValue(path),
       touched: initialTouched,
+      dirty: initialDirty,
       disabled: toValue(isDisabled),
       errors: [...tf.getErrors(path)],
     }));

--- a/packages/core/src/useFormGroup/useFormGroup.ts
+++ b/packages/core/src/useFormGroup/useFormGroup.ts
@@ -9,7 +9,7 @@ import {
   StandardSchema,
   ValidationResult,
 } from '../types';
-import { isEqual, normalizeProps, useUniqId, warn, withRefCapture } from '../utils/common';
+import { normalizeProps, useUniqId, warn, withRefCapture } from '../utils/common';
 import { FormKey } from '../useForm';
 import { useValidationProvider } from '../validation/useValidationProvider';
 import { FormValidationMode } from '../useForm/formContext';
@@ -137,16 +137,16 @@ export function useFormGroup<TInput extends FormObject = FormObject, TOutput ext
   }
 
   function getValue(path?: string) {
-    return form?.getValue(prefixPath(path) ?? '');
+    if (!path) {
+      return form?.getValue(getPath()) ?? {};
+    }
+
+    return form?.getValue(prefixPath(path) || '');
   }
 
   const isValid = computed(() => getErrors().length === 0);
   const isTouched = computed(() => form?.isTouched(getPath()) ?? false);
-  const isDirty = computed(() => {
-    const path = getPath();
-
-    return !isEqual(getValue(), form?.getFieldOriginalValue(path) ?? {});
-  });
+  const isDirty = computed(() => form?.isDirty(getPath()) ?? false);
 
   function getError(path: string) {
     return form?.getErrors(prefixPath(path) ?? '')?.[0];
@@ -236,6 +236,11 @@ export function useFormGroup<TInput extends FormObject = FormObject, TOutput ext
      * Gets the group's value, passing in a path will return the value of that field.
      */
     getValue,
+    /**
+     * Gets the values for the form group.
+     * @deprecated Use `getValue` without arguments instead.
+     */
+    getValues: () => getValue(),
     /**
      * Gets the error for a given field.
      */

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -4,7 +4,7 @@ import { useForm } from '@formwerk/core';
 import FormGroup from '@/components/FormGroup.vue';
 import InputText from '@/components/InputText.vue';
 
-useForm({
+const { isDirty } = useForm({
   schema: z.object({
     name: z.string(),
     test: z.object({
@@ -20,14 +20,9 @@ useForm({
 
 <template>
   <div class="flex flex-col w-1/2 gap-4">
-    <InputText name="name" label="Your Name" />
-    <FormGroup name="test" label="Company">
-      <InputText name="name" label="Account Name" />
+    {{ isDirty() }}
 
-      <FormGroup name="company" label="Company">
-        <InputText name="name" label="Account Name" />
-        <InputText name="address" label="Address" />
-      </FormGroup>
-    </FormGroup>
+    <InputText name="name" label="Your Name" />
+    <InputText name="account.name" label="Account Name" />
   </div>
 </template>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -24,5 +24,10 @@ const { isDirty } = useForm({
 
     <InputText name="name" label="Your Name" />
     <InputText name="account.name" label="Account Name" />
+
+    <FormGroup name="company" label="Company">
+      <InputText name="name" label="Account Name" />
+      <InputText name="address" label="Address" />
+    </FormGroup>
   </div>
 </template>

--- a/packages/playground/src/components/FormGroup.vue
+++ b/packages/playground/src/components/FormGroup.vue
@@ -4,6 +4,8 @@
       <h2 v-bind="labelProps" class="text-2xl font-semibold text-white">{{ label }}</h2>
     </div>
 
+    {{ { isDirty, isTouched } }}
+
     <div class="flex flex-col gap-2 p-8">
       <slot :display-error="displayError" :get-error="getError" :isTouched="isTouched" />
     </div>


### PR DESCRIPTION
# What

This changes how we track the dirty state by tracking it similarly to `touched` and `disabled`. Previously we were computing if the current value(s) match the original value(s) for fields/groups/forms.

While the new approach is prone to bugs or the state going out of sync, it is more efficient, and is more reliable around field arrays and nested fields.

This still doesn't expose mutating it directly to the developer.