### PR TITLE
feat: Implement `useDateField` with `@internationalized/date`

### DIFF
--- a/.changeset/gentle-cups-destroy.md
+++ b/.changeset/gentle-cups-destroy.md
@@ -1,0 +1,5 @@
+---
+'@formwerk/core': minor
+---
+
+feat: implement useDateTimeField

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
     "dist/*.d.ts"
   ],
   "dependencies": {
-    "@js-temporal/polyfill": "^0.4.4",
+    "@internationalized/date": "^3.7.0",
     "@standard-schema/spec": "1.0.0",
     "@standard-schema/utils": "^0.3.0",
     "klona": "^2.0.6",

--- a/packages/core/src/constants/index.ts
+++ b/packages/core/src/constants/index.ts
@@ -20,6 +20,7 @@ export const FieldTypePrefixes = {
   ListBox: 'lb',
   DateTimeField: 'dtf',
   DateTimeSegment: 'dts',
+  Calendar: 'cal',
 } as const;
 
 export const NOOP = () => {};

--- a/packages/core/src/helpers/useControlButtonProps/index.ts
+++ b/packages/core/src/helpers/useControlButtonProps/index.ts
@@ -1,0 +1,1 @@
+export * from './useControlButtonProps';

--- a/packages/core/src/helpers/useControlButtonProps/useControlButtonProps.ts
+++ b/packages/core/src/helpers/useControlButtonProps/useControlButtonProps.ts
@@ -6,12 +6,12 @@ interface ControlButtonProps {
   disabled?: boolean;
 }
 
-export function useControlButtonProps(props: ControlButtonProps) {
+export function useControlButtonProps(props: () => ControlButtonProps) {
   const buttonEl = shallowRef<HTMLElement>();
 
   const buttonProps = computed(() => {
     const isBtn = isButtonElement(buttonEl.value);
-    const { disabled, ...rest } = props;
+    const { disabled, ...rest } = props();
 
     return withRefCapture(
       {

--- a/packages/core/src/helpers/useControlButtonProps/useControlButtonProps.ts
+++ b/packages/core/src/helpers/useControlButtonProps/useControlButtonProps.ts
@@ -1,0 +1,29 @@
+import { computed, shallowRef } from 'vue';
+import { isButtonElement, withRefCapture } from '../../utils/common';
+
+interface ControlButtonProps {
+  [key: string]: unknown;
+  disabled?: boolean;
+}
+
+export function useControlButtonProps(props: ControlButtonProps) {
+  const buttonEl = shallowRef<HTMLElement>();
+
+  const buttonProps = computed(() => {
+    const isBtn = isButtonElement(buttonEl.value);
+    const { disabled, ...rest } = props;
+
+    return withRefCapture(
+      {
+        type: isBtn ? ('button' as const) : undefined,
+        role: isBtn ? undefined : 'button',
+        [isBtn ? 'disabled' : 'aria-disabled']: disabled || undefined,
+        tabindex: '-1',
+        ...rest,
+      },
+      buttonEl,
+    );
+  });
+
+  return buttonProps;
+}

--- a/packages/core/src/i18n/getCalendar.ts
+++ b/packages/core/src/i18n/getCalendar.ts
@@ -1,0 +1,13 @@
+import { CalendarIdentifier } from '../useDateTimeField';
+
+export function getCalendar(locale: Intl.Locale): CalendarIdentifier {
+  if (locale.calendar) {
+    return locale.calendar as CalendarIdentifier;
+  }
+
+  if ('calendars' in locale) {
+    return (locale.calendars as string[])[0] as CalendarIdentifier;
+  }
+
+  return 'gregory';
+}

--- a/packages/core/src/i18n/getCalendar.ts
+++ b/packages/core/src/i18n/getCalendar.ts
@@ -1,12 +1,10 @@
-import { CalendarIdentifier } from '../useCalendar';
-
-export function getCalendar(locale: Intl.Locale): CalendarIdentifier {
+export function getCalendar(locale: Intl.Locale): string {
   if (locale.calendar) {
-    return locale.calendar as CalendarIdentifier;
+    return locale.calendar as string;
   }
 
   if ('calendars' in locale) {
-    return (locale.calendars as string[])[0] as CalendarIdentifier;
+    return (locale.calendars as string[])[0] as string;
   }
 
   return 'gregory';

--- a/packages/core/src/i18n/getCalendar.ts
+++ b/packages/core/src/i18n/getCalendar.ts
@@ -1,4 +1,4 @@
-import { CalendarIdentifier } from '../useDateTimeField';
+import { CalendarIdentifier } from '../useCalendar';
 
 export function getCalendar(locale: Intl.Locale): CalendarIdentifier {
   if (locale.calendar) {

--- a/packages/core/src/i18n/getTimezone.ts
+++ b/packages/core/src/i18n/getTimezone.ts
@@ -1,0 +1,3 @@
+export function getTimeZone(locale: Intl.Locale) {
+  return new Intl.DateTimeFormat(locale).resolvedOptions().timeZone;
+}

--- a/packages/core/src/i18n/useDateFormatter.ts
+++ b/packages/core/src/i18n/useDateFormatter.ts
@@ -1,16 +1,17 @@
 import { MaybeRefOrGetter, shallowRef, toValue, watch } from 'vue';
-import { Intl as TemporalIntl } from '@js-temporal/polyfill';
-import { getUserLocale } from '../getUserLocale';
-import { isEqual } from '../../utils/common';
+import { DateFormatter } from '@internationalized/date';
+import { getUserLocale } from './getUserLocale';
+import { isEqual } from '../utils/common';
 
 // TODO: May memory leak in SSR
-const dateFormatterCache = new Map<string, TemporalIntl.DateTimeFormat>();
+const dateFormatterCache = new Map<string, DateFormatter>();
 
 function getFormatter(locale: string, options: Intl.DateTimeFormatOptions = {}) {
   const cacheKey = locale + JSON.stringify(options);
+  console.log(cacheKey);
   let formatter = dateFormatterCache.get(cacheKey);
   if (!formatter) {
-    formatter = new TemporalIntl.DateTimeFormat(locale, options);
+    formatter = new DateFormatter(locale, options);
     dateFormatterCache.set(cacheKey, formatter);
   }
 

--- a/packages/core/src/i18n/useDateFormatter.ts
+++ b/packages/core/src/i18n/useDateFormatter.ts
@@ -8,7 +8,6 @@ const dateFormatterCache = new Map<string, DateFormatter>();
 
 function getFormatter(locale: string, options: Intl.DateTimeFormatOptions = {}) {
   const cacheKey = locale + JSON.stringify(options);
-  console.log(cacheKey);
   let formatter = dateFormatterCache.get(cacheKey);
   if (!formatter) {
     formatter = new DateFormatter(locale, options);

--- a/packages/core/src/i18n/useDateFormatter/index.ts
+++ b/packages/core/src/i18n/useDateFormatter/index.ts
@@ -3,6 +3,7 @@ import { Intl as TemporalIntl } from '@js-temporal/polyfill';
 import { getUserLocale } from '../getUserLocale';
 import { isEqual } from '../../utils/common';
 
+// TODO: May memory leak in SSR
 const dateFormatterCache = new Map<string, TemporalIntl.DateTimeFormat>();
 
 function getFormatter(locale: string, options: Intl.DateTimeFormatOptions = {}) {

--- a/packages/core/src/i18n/useLocale.ts
+++ b/packages/core/src/i18n/useLocale.ts
@@ -4,14 +4,14 @@ import { getDirection } from './getDirection';
 import { getWeekInfo } from './getWeekInfo';
 import { Maybe, Reactivify } from '../types';
 import { getCalendar } from './getCalendar';
-import { CalendarIdentifier } from '../useCalendar';
+import { Calendar } from '@internationalized/date';
 import { getTimeZone } from './getTimezone';
 
 export type NumberLocaleExtension = `nu-${string}`;
 
 export interface LocaleExtension {
   number: Maybe<NumberLocaleExtension>;
-  calendar: Maybe<CalendarIdentifier>;
+  calendar: Maybe<Calendar>;
 }
 
 /**
@@ -37,8 +37,8 @@ export function useLocale(
     }
 
     // Add the calendar locale extension if it's not already present
-    if (!code.includes('-ca-') && calExt) {
-      code += `-ca-${calExt}`;
+    if (!code.includes('-ca-') && calExt?.identifier) {
+      code += `-ca-${calExt.identifier}`;
     }
 
     code = code.replaceAll('--', '-');

--- a/packages/core/src/i18n/useLocale.ts
+++ b/packages/core/src/i18n/useLocale.ts
@@ -4,8 +4,8 @@ import { getDirection } from './getDirection';
 import { getWeekInfo } from './getWeekInfo';
 import { Maybe, Reactivify } from '../types';
 import { getCalendar } from './getCalendar';
-import { Temporal } from '@js-temporal/polyfill';
 import { CalendarIdentifier } from '../useCalendar';
+import { getTimeZone } from './getTimezone';
 
 export type NumberLocaleExtension = `nu-${string}`;
 
@@ -49,8 +49,9 @@ export function useLocale(
   const localeInstance = computed(() => new Intl.Locale(localeString.value));
   const direction = computed(() => getDirection(localeInstance.value));
   const weekInfo = computed(() => getWeekInfo(localeInstance.value));
-  const calendar = computed(() => new Temporal.Calendar(getCalendar(localeInstance.value)));
+  const calendar = computed(() => getCalendar(localeInstance.value));
+  const timeZone = computed(() => getTimeZone(localeInstance.value));
   const locale = computed(() => localeInstance.value.toString());
 
-  return { locale, direction, weekInfo, calendar };
+  return { locale, direction, weekInfo, calendar, timeZone };
 }

--- a/packages/core/src/i18n/useLocale.ts
+++ b/packages/core/src/i18n/useLocale.ts
@@ -3,6 +3,8 @@ import { getConfig } from '../config';
 import { getDirection } from './getDirection';
 import { getWeekInfo } from './getWeekInfo';
 import { Maybe } from '../types';
+import { getCalendar } from './getCalendar';
+import { Temporal } from '@js-temporal/polyfill';
 
 /**
  * Composable that resolves the currently configured locale and direction.
@@ -11,8 +13,9 @@ export function useLocale(localeCode?: MaybeRefOrGetter<Maybe<string>>) {
   const localeInstance = computed(() => new Intl.Locale(toValue(localeCode) || getConfig().locale));
   const direction = computed(() => getDirection(localeInstance.value));
   const weekInfo = computed(() => getWeekInfo(localeInstance.value));
+  const calendar = computed(() => new Temporal.Calendar(getCalendar(localeInstance.value)));
 
   const locale = computed(() => localeInstance.value.toString());
 
-  return { locale, direction, weekInfo };
+  return { locale, direction, weekInfo, calendar };
 }

--- a/packages/core/src/i18n/useLocale.ts
+++ b/packages/core/src/i18n/useLocale.ts
@@ -11,6 +11,7 @@ export type NumberLocaleExtension = `nu-${string}`;
 export interface LocaleExtension {
   number: Maybe<NumberLocaleExtension>;
   calendar: Maybe<Calendar>;
+  timeZone: Maybe<string>;
 }
 
 /**
@@ -49,7 +50,7 @@ export function useLocale(
   const direction = computed(() => getDirection(localeInstance.value));
   const weekInfo = computed(() => getWeekInfo(localeInstance.value));
   const calendar = computed(() => toValue(extensions.calendar) ?? (new GregorianCalendar() as Calendar));
-  const timeZone = computed(() => getTimeZone(localeInstance.value));
+  const timeZone = computed(() => toValue(extensions.timeZone) ?? getTimeZone(localeInstance.value));
   const locale = computed(() => localeInstance.value.toString());
 
   return { locale, direction, weekInfo, calendar, timeZone };

--- a/packages/core/src/i18n/useLocale.ts
+++ b/packages/core/src/i18n/useLocale.ts
@@ -12,7 +12,7 @@ export function useLocale(localeCode?: MaybeRefOrGetter<Maybe<string>>) {
   const direction = computed(() => getDirection(localeInstance.value));
   const weekInfo = computed(() => getWeekInfo(localeInstance.value));
 
-  const locale = computed(() => localeInstance.value.baseName);
+  const locale = computed(() => localeInstance.value.toString());
 
   return { locale, direction, weekInfo };
 }

--- a/packages/core/src/i18n/useLocale.ts
+++ b/packages/core/src/i18n/useLocale.ts
@@ -2,19 +2,54 @@ import { computed, MaybeRefOrGetter, toValue } from 'vue';
 import { getConfig } from '../config';
 import { getDirection } from './getDirection';
 import { getWeekInfo } from './getWeekInfo';
-import { Maybe } from '../types';
+import { Maybe, Reactivify } from '../types';
 import { getCalendar } from './getCalendar';
 import { Temporal } from '@js-temporal/polyfill';
+import { CalendarIdentifier } from '../useCalendar';
+
+export type NumberLocaleExtension = `nu-${string}`;
+
+export interface LocaleExtension {
+  number: Maybe<NumberLocaleExtension>;
+  calendar: Maybe<CalendarIdentifier>;
+}
 
 /**
  * Composable that resolves the currently configured locale and direction.
  */
-export function useLocale(localeCode?: MaybeRefOrGetter<Maybe<string>>) {
-  const localeInstance = computed(() => new Intl.Locale(toValue(localeCode) || getConfig().locale));
+export function useLocale(
+  localeCode?: MaybeRefOrGetter<Maybe<string>>,
+  extensions: Partial<Reactivify<LocaleExtension>> = {},
+) {
+  const localeString = computed(() => {
+    let code = toValue(localeCode) || getConfig().locale;
+    const calExt = toValue(extensions.calendar);
+    const numExt = toValue(extensions.number);
+
+    // Add the base locale extension if it's not already present
+    if (!code.includes('-u-') && (numExt || calExt)) {
+      code += '-u-';
+    }
+
+    // Add the number locale extension if it's not already present
+    if (!code.includes('-nu-') && numExt) {
+      code += `-nu-${numExt}`;
+    }
+
+    // Add the calendar locale extension if it's not already present
+    if (!code.includes('-ca-') && calExt) {
+      code += `-ca-${calExt}`;
+    }
+
+    code = code.replaceAll('--', '-');
+
+    return code;
+  });
+
+  const localeInstance = computed(() => new Intl.Locale(localeString.value));
   const direction = computed(() => getDirection(localeInstance.value));
   const weekInfo = computed(() => getWeekInfo(localeInstance.value));
   const calendar = computed(() => new Temporal.Calendar(getCalendar(localeInstance.value)));
-
   const locale = computed(() => localeInstance.value.toString());
 
   return { locale, direction, weekInfo, calendar };

--- a/packages/core/src/i18n/useLocale.ts
+++ b/packages/core/src/i18n/useLocale.ts
@@ -3,8 +3,7 @@ import { getConfig } from '../config';
 import { getDirection } from './getDirection';
 import { getWeekInfo } from './getWeekInfo';
 import { Maybe, Reactivify } from '../types';
-import { getCalendar } from './getCalendar';
-import { Calendar } from '@internationalized/date';
+import { Calendar, GregorianCalendar } from '@internationalized/date';
 import { getTimeZone } from './getTimezone';
 
 export type NumberLocaleExtension = `nu-${string}`;
@@ -49,7 +48,7 @@ export function useLocale(
   const localeInstance = computed(() => new Intl.Locale(localeString.value));
   const direction = computed(() => getDirection(localeInstance.value));
   const weekInfo = computed(() => getWeekInfo(localeInstance.value));
-  const calendar = computed(() => getCalendar(localeInstance.value));
+  const calendar = computed(() => toValue(extensions.calendar) ?? (new GregorianCalendar() as Calendar));
   const timeZone = computed(() => getTimeZone(localeInstance.value));
   const locale = computed(() => localeInstance.value.toString());
 

--- a/packages/core/src/i18n/useNumberParser.spec.ts
+++ b/packages/core/src/i18n/useNumberParser.spec.ts
@@ -1,4 +1,4 @@
-import { useNumberParser } from '.';
+import { useNumberParser } from './useNumberParser';
 
 const enNumber = 1234567890.12;
 

--- a/packages/core/src/i18n/useNumberParser.ts
+++ b/packages/core/src/i18n/useNumberParser.ts
@@ -1,5 +1,5 @@
 import { MaybeRefOrGetter, toValue, watch } from 'vue';
-import { getUserLocale } from '../getUserLocale';
+import { getUserLocale } from './getUserLocale';
 
 /**
  * Stuff that are considered "literals" that's not part of the number itself and should be stripped out when parsing/validating.

--- a/packages/core/src/i18n/useNumberParser/index.ts
+++ b/packages/core/src/i18n/useNumberParser/index.ts
@@ -67,6 +67,7 @@ interface NumberParser {
   isValidNumberPart(value: string): boolean;
 }
 
+// TODO: May memory leak in SSR
 const numberParserCache = new Map<string, NumberParser>();
 
 function getParser(locale: string, options: Intl.NumberFormatOptions) {

--- a/packages/core/src/i18n/useNumberParser/index.ts
+++ b/packages/core/src/i18n/useNumberParser/index.ts
@@ -57,7 +57,7 @@ interface NumberSymbols {
   resolveNumber: (number: string) => string;
 }
 
-interface NumberParser {
+export interface NumberParser {
   formatter: Intl.NumberFormat;
   options: Intl.ResolvedNumberFormatOptions;
   locale: string;
@@ -206,6 +206,8 @@ export function defineNumberParser(locale: string, options: Intl.NumberFormatOpt
     isValidNumberPart,
   };
 }
+
+export type NumberParserContext = Pick<NumberParser, 'parse' | 'isValidNumberPart'>;
 
 export function useNumberParser(
   locale: MaybeRefOrGetter<string | undefined>,

--- a/packages/core/src/i18n/useNumberParser/index.ts
+++ b/packages/core/src/i18n/useNumberParser/index.ts
@@ -1,4 +1,4 @@
-import { MaybeRefOrGetter, toValue } from 'vue';
+import { MaybeRefOrGetter, toValue, watch } from 'vue';
 import { getUserLocale } from '../getUserLocale';
 
 /**
@@ -276,11 +276,17 @@ export function useNumberParser(
     return resolveParser(value).isValidNumberPart(value);
   }
 
-  function format(value: number): string {
-    const defaultParser = getParser(toValue(locale) ?? toValue(resolvedLocale), toValue(opts) || {});
-
-    return (lastResolvedParser ?? defaultParser).format(value);
+  function getDefaultParser() {
+    return getParser(toValue(locale) ?? toValue(resolvedLocale), toValue(opts) || {});
   }
+
+  function format(value: number): string {
+    return (lastResolvedParser ?? getDefaultParser()).format(value);
+  }
+
+  watch([() => toValue(locale), () => toValue(opts)], () => {
+    lastResolvedParser = getDefaultParser();
+  });
 
   return {
     parse,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './useComboBox';
 export * from './useHiddenField';
 export * from './useCustomField';
 export * from './useDateTimeField';
+export * from './useCalendar';
 export * from './types';
 export * from './config';
 export * from './useForm';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export * from './useHiddenField';
 export * from './useCustomField';
 export * from './useDateTimeField';
 export * from './useCalendar';
+export * from './usePicker';
 export * from './types';
 export * from './config';
 export * from './useForm';

--- a/packages/core/src/useCalendar/constants.ts
+++ b/packages/core/src/useCalendar/constants.ts
@@ -1,0 +1,4 @@
+import { InjectionKey } from 'vue';
+import { CalendarContext } from './types';
+
+export const CalendarContextKey: InjectionKey<CalendarContext> = Symbol('CalendarContext');

--- a/packages/core/src/useCalendar/constants.ts
+++ b/packages/core/src/useCalendar/constants.ts
@@ -2,3 +2,9 @@ import { InjectionKey } from 'vue';
 import { CalendarContext } from './types';
 
 export const CalendarContextKey: InjectionKey<CalendarContext> = Symbol('CalendarContext');
+
+export const YEAR_CELLS_COUNT = 9;
+
+export const MONTHS_COLUMNS_COUNT = 3;
+
+export const YEARS_COLUMNS_COUNT = 3;

--- a/packages/core/src/useCalendar/index.ts
+++ b/packages/core/src/useCalendar/index.ts
@@ -1,4 +1,4 @@
 export * from './useCalendar';
 export * from './types';
 export * from './useCalendarCell';
-export * from './useCalendarPanel';
+export * from './useCalendarView';

--- a/packages/core/src/useCalendar/index.ts
+++ b/packages/core/src/useCalendar/index.ts
@@ -1,3 +1,4 @@
 export * from './useCalendar';
 export * from './types';
 export * from './useCalendarCell';
+export * from './useCalendarPanel';

--- a/packages/core/src/useCalendar/index.ts
+++ b/packages/core/src/useCalendar/index.ts
@@ -1,0 +1,3 @@
+export * from './useCalendar';
+export * from './types';
+export * from './useCalendarCell';

--- a/packages/core/src/useCalendar/types.ts
+++ b/packages/core/src/useCalendar/types.ts
@@ -1,4 +1,8 @@
 import { Temporal } from '@js-temporal/polyfill';
+import { MaybeRefOrGetter } from 'vue';
+import { WeekInfo } from '../i18n/getWeekInfo';
+import { Ref } from 'vue';
+import { Maybe } from '../types';
 
 export type CalendarIdentifier =
   | 'buddhist'
@@ -20,18 +24,50 @@ export type CalendarIdentifier =
   | 'persian'
   | 'roc';
 
-export interface CalendarDay {
+export interface CalendarDayCell {
+  type: 'day';
   value: Temporal.ZonedDateTime;
-
   dayOfMonth: number;
-
+  label: string;
   isToday: boolean;
-
   isOutsideMonth: boolean;
-
   selected: boolean;
-
   disabled: boolean;
-
   focused: boolean;
+}
+
+export interface CalendarMonthCell {
+  type: 'month';
+  label: string;
+  value: Temporal.ZonedDateTime;
+  monthOfYear: number;
+  selected: boolean;
+  disabled: boolean;
+  focused: boolean;
+}
+
+export interface CalendarYearCell {
+  type: 'year';
+  label: string;
+  value: Temporal.ZonedDateTime;
+  year: number;
+  selected: boolean;
+  disabled: boolean;
+  focused: boolean;
+}
+
+export type CalendarCellProps = CalendarDayCell | CalendarMonthCell | CalendarYearCell;
+
+export type CalendarPanelType = 'day' | 'month' | 'year';
+
+export interface CalendarContext {
+  locale: Ref<string>;
+  weekInfo: Ref<WeekInfo>;
+  calendar: Ref<CalendarIdentifier>;
+  selectedDate: MaybeRefOrGetter<Temporal.ZonedDateTime>;
+  getMinDate: () => Maybe<Temporal.ZonedDateTime>;
+  getMaxDate: () => Maybe<Temporal.ZonedDateTime>;
+  getFocusedDate: () => Temporal.ZonedDateTime;
+  setFocusedDate: (date: Temporal.ZonedDateTime) => void;
+  setDate: (date: Temporal.ZonedDateTime, panel?: CalendarPanelType) => void;
 }

--- a/packages/core/src/useCalendar/types.ts
+++ b/packages/core/src/useCalendar/types.ts
@@ -37,7 +37,7 @@ export interface CalendarYearCell {
 
 export type CalendarCellProps = CalendarDayCell | CalendarMonthCell | CalendarYearCell;
 
-export type CalendarPanelType = 'weeks' | 'months' | 'years';
+export type CalendarViewType = 'weeks' | 'months' | 'years';
 
 export interface CalendarContext {
   locale: Ref<string>;
@@ -49,5 +49,5 @@ export interface CalendarContext {
   getMaxDate: () => Maybe<ZonedDateTime>;
   getFocusedDate: () => ZonedDateTime;
   setFocusedDate: (date: ZonedDateTime) => void;
-  setDate: (date: ZonedDateTime, panel?: CalendarPanelType) => void;
+  setDate: (date: ZonedDateTime, view?: CalendarViewType) => void;
 }

--- a/packages/core/src/useCalendar/types.ts
+++ b/packages/core/src/useCalendar/types.ts
@@ -43,6 +43,7 @@ export interface CalendarContext {
   locale: Ref<string>;
   weekInfo: Ref<WeekInfo>;
   calendar: Ref<Calendar>;
+  timeZone: Ref<string>;
   getSelectedDate: () => ZonedDateTime;
   getMinDate: () => Maybe<ZonedDateTime>;
   getMaxDate: () => Maybe<ZonedDateTime>;

--- a/packages/core/src/useCalendar/types.ts
+++ b/packages/core/src/useCalendar/types.ts
@@ -22,8 +22,16 @@ export type CalendarIdentifier =
 
 export interface CalendarDay {
   value: Temporal.ZonedDateTime;
+
   dayOfMonth: number;
+
   isToday: boolean;
-  isSelected: boolean;
+
   isOutsideMonth: boolean;
+
+  selected: boolean;
+
+  disabled: boolean;
+
+  focused: boolean;
 }

--- a/packages/core/src/useCalendar/types.ts
+++ b/packages/core/src/useCalendar/types.ts
@@ -1,5 +1,4 @@
 import { Temporal } from '@js-temporal/polyfill';
-import { MaybeRefOrGetter } from 'vue';
 import { WeekInfo } from '../i18n/getWeekInfo';
 import { Ref } from 'vue';
 import { Maybe } from '../types';
@@ -64,7 +63,7 @@ export interface CalendarContext {
   locale: Ref<string>;
   weekInfo: Ref<WeekInfo>;
   calendar: Ref<CalendarIdentifier>;
-  selectedDate: MaybeRefOrGetter<Temporal.ZonedDateTime>;
+  getSelectedDate: () => Temporal.ZonedDateTime;
   getMinDate: () => Maybe<Temporal.ZonedDateTime>;
   getMaxDate: () => Maybe<Temporal.ZonedDateTime>;
   getFocusedDate: () => Temporal.ZonedDateTime;

--- a/packages/core/src/useCalendar/types.ts
+++ b/packages/core/src/useCalendar/types.ts
@@ -21,7 +21,7 @@ export type CalendarIdentifier =
   | 'roc';
 
 export interface CalendarDay {
-  value: Temporal.PlainDate;
+  value: Temporal.ZonedDateTime;
   dayOfMonth: number;
   isToday: boolean;
   isSelected: boolean;

--- a/packages/core/src/useCalendar/types.ts
+++ b/packages/core/src/useCalendar/types.ts
@@ -1,31 +1,11 @@
-import { Temporal } from '@js-temporal/polyfill';
 import { WeekInfo } from '../i18n/getWeekInfo';
 import { Ref } from 'vue';
 import { Maybe } from '../types';
-
-export type CalendarIdentifier =
-  | 'buddhist'
-  | 'chinese'
-  | 'coptic'
-  | 'dangi'
-  | 'ethioaa'
-  | 'ethiopic'
-  | 'gregory'
-  | 'hebrew'
-  | 'indian'
-  | 'islamic'
-  | 'islamic-umalqura'
-  | 'islamic-tbla'
-  | 'islamic-civil'
-  | 'islamic-rgsa'
-  | 'iso8601'
-  | 'japanese'
-  | 'persian'
-  | 'roc';
+import type { ZonedDateTime, Calendar } from '@internationalized/date';
 
 export interface CalendarDayCell {
   type: 'day';
-  value: Temporal.ZonedDateTime;
+  value: ZonedDateTime;
   dayOfMonth: number;
   label: string;
   isToday: boolean;
@@ -38,7 +18,7 @@ export interface CalendarDayCell {
 export interface CalendarMonthCell {
   type: 'month';
   label: string;
-  value: Temporal.ZonedDateTime;
+  value: ZonedDateTime;
   monthOfYear: number;
   selected: boolean;
   disabled: boolean;
@@ -48,7 +28,7 @@ export interface CalendarMonthCell {
 export interface CalendarYearCell {
   type: 'year';
   label: string;
-  value: Temporal.ZonedDateTime;
+  value: ZonedDateTime;
   year: number;
   selected: boolean;
   disabled: boolean;
@@ -62,11 +42,11 @@ export type CalendarPanelType = 'day' | 'month' | 'year';
 export interface CalendarContext {
   locale: Ref<string>;
   weekInfo: Ref<WeekInfo>;
-  calendar: Ref<CalendarIdentifier>;
-  getSelectedDate: () => Temporal.ZonedDateTime;
-  getMinDate: () => Maybe<Temporal.ZonedDateTime>;
-  getMaxDate: () => Maybe<Temporal.ZonedDateTime>;
-  getFocusedDate: () => Temporal.ZonedDateTime;
-  setFocusedDate: (date: Temporal.ZonedDateTime) => void;
-  setDate: (date: Temporal.ZonedDateTime, panel?: CalendarPanelType) => void;
+  calendar: Ref<Calendar>;
+  getSelectedDate: () => ZonedDateTime;
+  getMinDate: () => Maybe<ZonedDateTime>;
+  getMaxDate: () => Maybe<ZonedDateTime>;
+  getFocusedDate: () => ZonedDateTime;
+  setFocusedDate: (date: ZonedDateTime) => void;
+  setDate: (date: ZonedDateTime, panel?: CalendarPanelType) => void;
 }

--- a/packages/core/src/useCalendar/types.ts
+++ b/packages/core/src/useCalendar/types.ts
@@ -37,7 +37,7 @@ export interface CalendarYearCell {
 
 export type CalendarCellProps = CalendarDayCell | CalendarMonthCell | CalendarYearCell;
 
-export type CalendarPanelType = 'day' | 'month' | 'year';
+export type CalendarPanelType = 'weeks' | 'months' | 'years';
 
 export interface CalendarContext {
   locale: Ref<string>;

--- a/packages/core/src/useCalendar/types.ts
+++ b/packages/core/src/useCalendar/types.ts
@@ -1,0 +1,29 @@
+import { Temporal } from '@js-temporal/polyfill';
+
+export type CalendarIdentifier =
+  | 'buddhist'
+  | 'chinese'
+  | 'coptic'
+  | 'dangi'
+  | 'ethioaa'
+  | 'ethiopic'
+  | 'gregory'
+  | 'hebrew'
+  | 'indian'
+  | 'islamic'
+  | 'islamic-umalqura'
+  | 'islamic-tbla'
+  | 'islamic-civil'
+  | 'islamic-rgsa'
+  | 'iso8601'
+  | 'japanese'
+  | 'persian'
+  | 'roc';
+
+export interface CalendarDay {
+  value: Temporal.PlainDate;
+  dayOfMonth: number;
+  isToday: boolean;
+  isSelected: boolean;
+  isOutsideMonth: boolean;
+}

--- a/packages/core/src/useCalendar/useCalendar.spec.ts
+++ b/packages/core/src/useCalendar/useCalendar.spec.ts
@@ -465,22 +465,46 @@ describe('useCalendar', () => {
 
       // Test next button (next set of years)
       await fireEvent.click(screen.getByText('Next'));
-      expect(screen.getByText(currentDate.add({ years: 9 }).set({ month: 1, day: 1 }).toString())).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          currentDate
+            .add({ years: 9 })
+            .set({ month: 1, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0 })
+            .toString(),
+        ),
+      ).toBeInTheDocument();
 
       // Test previous button (previous set of years)
       await fireEvent.click(screen.getByText('Previous'));
-      expect(screen.getByText(currentDate.add({ years: 8 }).set({ month: 1, day: 1 }).toString())).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          currentDate
+            .add({ years: 8 })
+            .set({ month: 1, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0 })
+            .toString(),
+        ),
+      ).toBeInTheDocument();
 
       // Test multiple clicks
       await fireEvent.click(screen.getByText('Previous'));
       await fireEvent.click(screen.getByText('Previous'));
       expect(
-        screen.getByText(currentDate.subtract({ years: 10 }).set({ month: 1, day: 1 }).toString()),
+        screen.getByText(
+          currentDate
+            .subtract({ years: 10 })
+            .set({ month: 1, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0 })
+            .toString(),
+        ),
       ).toBeInTheDocument();
 
       await fireEvent.click(screen.getByText('Next'));
       expect(
-        screen.getByText(currentDate.subtract({ years: 9 }).set({ month: 1, day: 1 }).toString()),
+        screen.getByText(
+          currentDate
+            .subtract({ years: 9 })
+            .set({ month: 1, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0 })
+            .toString(),
+        ),
       ).toBeInTheDocument();
     });
   });

--- a/packages/core/src/useCalendar/useCalendar.spec.ts
+++ b/packages/core/src/useCalendar/useCalendar.spec.ts
@@ -9,13 +9,13 @@ describe('useCalendar', () => {
     test('calendar should not have accessibility violations', async () => {
       await render({
         setup() {
-          const { calendarProps, gridProps, buttonProps, gridLabelProps, nextButtonProps, previousButtonProps } =
-            useCalendar({ label: 'Calendar' });
+          const { calendarProps, gridProps, gridLabelProps, nextButtonProps, previousButtonProps } = useCalendar({
+            label: 'Calendar',
+          });
 
           return {
             calendarProps,
             gridProps,
-            buttonProps,
             gridLabelProps,
             nextButtonProps,
             previousButtonProps,
@@ -24,7 +24,6 @@ describe('useCalendar', () => {
         template: `
           <div data-testid="fixture">
             <div v-bind="calendarProps">
-              <button v-bind="buttonProps">Open Calendar</button>
               <div v-bind="gridLabelProps">Month Year</div>
               <button v-bind="previousButtonProps">Previous</button>
               <button v-bind="nextButtonProps">Next</button>
@@ -43,87 +42,6 @@ describe('useCalendar', () => {
     });
   });
 
-  describe('calendar controls', () => {
-    test('opens calendar when button is clicked', async () => {
-      await render({
-        setup() {
-          const { buttonProps, isOpen } = useCalendar({ label: 'Calendar' });
-
-          return {
-            buttonProps,
-            isOpen,
-          };
-        },
-        template: `
-          <div data-testid="fixture">
-            <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen">Calendar Content</div>
-          </div>
-        `,
-      });
-
-      await flush();
-      expect(screen.queryByText('Calendar Content')).not.toBeInTheDocument();
-      await fireEvent.click(screen.getByText('Open Calendar'));
-      expect(screen.getByText('Calendar Content')).toBeInTheDocument();
-    });
-
-    test('closes calendar when Escape is pressed', async () => {
-      await render({
-        setup() {
-          const { calendarProps, isOpen, buttonProps } = useCalendar({ label: 'Calendar' });
-
-          return {
-            calendarProps,
-            isOpen,
-            buttonProps,
-          };
-        },
-        template: `
-          <div data-testid="fixture">
-            <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="calendarProps">Calendar Content</div>
-          </div>
-        `,
-      });
-
-      await flush();
-      await fireEvent.click(screen.getByText('Open Calendar'));
-      expect(screen.getByText('Calendar Content')).toBeInTheDocument();
-      await fireEvent.keyDown(screen.getByText('Calendar Content'), { code: 'Escape' });
-      expect(screen.queryByText('Calendar Content')).not.toBeInTheDocument();
-    });
-
-    test('closes calendar when Tab is pressed', async () => {
-      await render({
-        setup() {
-          const { calendarProps, isOpen, buttonProps, gridProps } = useCalendar({ label: 'Calendar' });
-
-          return {
-            calendarProps,
-            isOpen,
-            buttonProps,
-            gridProps,
-          };
-        },
-        template: `
-          <div data-testid="fixture">
-            <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="calendarProps">
-              <span v-bind="gridProps" tabindex="0">Calendar Content</span>
-            </div>
-          </div>
-        `,
-      });
-
-      await flush();
-      await fireEvent.click(screen.getByText('Open Calendar'));
-      expect(screen.getByText('Calendar Content')).toBeInTheDocument();
-      await fireEvent.keyDown(screen.getByText('Calendar Content'), { code: 'Tab' });
-      expect(screen.queryByText('Calendar Content')).not.toBeInTheDocument();
-    });
-  });
-
   describe('date selection', () => {
     test('calls onUpdateModelValue when a date is selected', async () => {
       const currentDate = now('UTC');
@@ -133,7 +51,7 @@ describe('useCalendar', () => {
           CalendarCell,
         },
         setup() {
-          const { calendarProps, buttonProps } = useCalendar({
+          const { calendarProps } = useCalendar({
             label: 'Calendar',
             timeZone: 'UTC',
             modelValue: currentDate.toDate(),
@@ -141,13 +59,11 @@ describe('useCalendar', () => {
 
           return {
             calendarProps,
-            buttonProps,
             currentDate,
           };
         },
         template: `
           <div data-testid="fixture">
-            <button v-bind="buttonProps">Open Calendar</button>
             <div v-bind="calendarProps">
               <CalendarCell label="Select Date" type="day" :value="currentDate" />
             </div>
@@ -194,7 +110,7 @@ describe('useCalendar', () => {
           CalendarCell,
         },
         setup() {
-          const { calendarProps, buttonProps, isOpen, focusedDate } = useCalendar({
+          const { calendarProps, focusedDate } = useCalendar({
             label: 'Calendar',
             modelValue: currentDate.toDate(),
             timeZone: 'UTC',
@@ -202,16 +118,13 @@ describe('useCalendar', () => {
 
           return {
             calendarProps,
-            buttonProps,
-            isOpen,
             focusedDate,
             currentDate,
           };
         },
         template: `
           <div data-testid="fixture">
-            <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="calendarProps">
+            <div v-bind="calendarProps">
               <CalendarCell
                 label="Select Date"
                 type="day"
@@ -225,13 +138,11 @@ describe('useCalendar', () => {
       });
 
       await flush();
-      await fireEvent.click(screen.getByText('Open Calendar'));
       const cell = screen.getByTestId('calendar-cell');
 
       // Test Enter key selects the date
       await fireEvent.keyDown(cell, { code: 'Enter' });
       expect(vm.emitted('update:modelValue')[0]).toEqual([currentDate.toDate()]);
-      expect(screen.queryByText(currentDate.toString())).not.toBeInTheDocument(); // Calendar should close after selection
     });
 
     test('handles Enter key in different panels', async () => {
@@ -239,7 +150,7 @@ describe('useCalendar', () => {
 
       const vm = await render({
         setup() {
-          const { calendarProps, buttonProps, isOpen, focusedDate, gridLabelProps, currentView } = useCalendar({
+          const { calendarProps, focusedDate, gridLabelProps, currentView } = useCalendar({
             label: 'Calendar',
             modelValue: currentDate.toDate(),
             timeZone: 'UTC',
@@ -247,8 +158,6 @@ describe('useCalendar', () => {
 
           return {
             calendarProps,
-            buttonProps,
-            isOpen,
             focusedDate,
             gridLabelProps,
             currentView,
@@ -256,9 +165,8 @@ describe('useCalendar', () => {
         },
         template: `
           <div data-testid="fixture">
-            <button v-bind="buttonProps">Open Calendar</button>
             <div v-bind="gridLabelProps" data-testid="panel-label">{{ currentView.type }}</div>
-            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
+            <div v-bind="calendarProps" data-testid="calendar">
               <div>{{ focusedDate?.toString() }}</div>
             </div>
           </div>
@@ -266,7 +174,6 @@ describe('useCalendar', () => {
       });
 
       await flush();
-      await fireEvent.click(screen.getByText('Open Calendar'));
       const calendar = screen.getByTestId('calendar');
       const panelLabel = screen.getByTestId('panel-label');
       await fireEvent.keyDown(calendar, { code: 'Escape' });
@@ -352,15 +259,7 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const {
-            nextButtonProps,
-            previousButtonProps,
-            gridLabelProps,
-            focusedDate,
-            calendarProps,
-            isOpen,
-            buttonProps,
-          } = useCalendar({
+          const { nextButtonProps, previousButtonProps, gridLabelProps, focusedDate, calendarProps } = useCalendar({
             label: 'Calendar',
             modelValue: currentDate.toDate(),
             timeZone: 'UTC',
@@ -372,14 +271,11 @@ describe('useCalendar', () => {
             gridLabelProps,
             focusedDate,
             calendarProps,
-            isOpen,
-            buttonProps,
           };
         },
         template: `
           <div data-testid="fixture">
-            <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="calendarProps">
+            <div v-bind="calendarProps">
               <div v-bind="gridLabelProps" data-testid="panel-label">Month Panel</div>
               <button v-bind="previousButtonProps">Previous</button>
               <button v-bind="nextButtonProps">Next</button>
@@ -390,7 +286,6 @@ describe('useCalendar', () => {
       });
 
       await flush();
-      await fireEvent.click(screen.getByText('Open Calendar'));
       const panelLabel = screen.getByTestId('panel-label');
 
       // Switch to month panel
@@ -418,15 +313,7 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const {
-            nextButtonProps,
-            previousButtonProps,
-            gridLabelProps,
-            focusedDate,
-            calendarProps,
-            isOpen,
-            buttonProps,
-          } = useCalendar({
+          const { nextButtonProps, previousButtonProps, gridLabelProps, focusedDate, calendarProps } = useCalendar({
             label: 'Calendar',
             modelValue: currentDate.toDate(),
             timeZone: 'UTC',
@@ -438,14 +325,11 @@ describe('useCalendar', () => {
             gridLabelProps,
             focusedDate,
             calendarProps,
-            isOpen,
-            buttonProps,
           };
         },
         template: `
           <div data-testid="fixture">
-            <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="calendarProps">
+            <div v-bind="calendarProps">
               <div v-bind="gridLabelProps" data-testid="panel-label">Year Panel</div>
               <button v-bind="previousButtonProps">Previous</button>
               <button v-bind="nextButtonProps">Next</button>
@@ -456,7 +340,6 @@ describe('useCalendar', () => {
       });
 
       await flush();
-      await fireEvent.click(screen.getByText('Open Calendar'));
       const panelLabel = screen.getByTestId('panel-label');
 
       // Switch to month panel then year panel
@@ -515,7 +398,7 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { calendarProps, isOpen, buttonProps, selectedDate, focusedDate } = useCalendar({
+          const { calendarProps, selectedDate, focusedDate } = useCalendar({
             label: 'Calendar',
             modelValue: currentDate.toDate(),
             timeZone: 'UTC',
@@ -523,16 +406,13 @@ describe('useCalendar', () => {
 
           return {
             calendarProps,
-            isOpen,
-            buttonProps,
             selectedDate,
             focusedDate,
           };
         },
         template: `
           <div data-testid="fixture">
-            <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
+            <div v-bind="calendarProps" data-testid="calendar">
               <div>{{ focusedDate?.toString() }}</div>
             </div>
           </div>
@@ -540,7 +420,6 @@ describe('useCalendar', () => {
       });
 
       await flush();
-      await fireEvent.click(screen.getByText('Open Calendar'));
       const calendar = screen.getByTestId('calendar');
 
       // Test right arrow (next day)
@@ -583,7 +462,7 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { calendarProps, isOpen, buttonProps, selectedDate, focusedDate, gridLabelProps } = useCalendar({
+          const { calendarProps, selectedDate, focusedDate, gridLabelProps } = useCalendar({
             label: 'Calendar',
             modelValue: currentDate.toDate(),
             timeZone: 'UTC',
@@ -591,8 +470,6 @@ describe('useCalendar', () => {
 
           return {
             calendarProps,
-            isOpen,
-            buttonProps,
             selectedDate,
             focusedDate,
             gridLabelProps,
@@ -600,8 +477,7 @@ describe('useCalendar', () => {
         },
         template: `
           <div data-testid="fixture">
-            <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
+            <div v-bind="calendarProps" data-testid="calendar">
               <div v-bind="gridLabelProps" data-testid="panel-label">Month Panel</div>
               <div>{{ focusedDate?.toString() }}</div>
             </div>
@@ -610,7 +486,6 @@ describe('useCalendar', () => {
       });
 
       await flush();
-      await fireEvent.click(screen.getByText('Open Calendar'));
       const calendar = screen.getByTestId('calendar');
       const panelLabel = screen.getByTestId('panel-label');
 
@@ -657,7 +532,7 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { calendarProps, isOpen, buttonProps, selectedDate, focusedDate, gridLabelProps } = useCalendar({
+          const { calendarProps, selectedDate, focusedDate, gridLabelProps } = useCalendar({
             label: 'Calendar',
             modelValue: currentDate.toDate(),
             timeZone: 'UTC',
@@ -665,8 +540,6 @@ describe('useCalendar', () => {
 
           return {
             calendarProps,
-            isOpen,
-            buttonProps,
             selectedDate,
             focusedDate,
             gridLabelProps,
@@ -674,8 +547,7 @@ describe('useCalendar', () => {
         },
         template: `
           <div data-testid="fixture">
-            <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
+            <div v-bind="calendarProps" data-testid="calendar">
               <div v-bind="gridLabelProps" data-testid="panel-label">Year Panel</div>
               <div>{{ focusedDate?.toString() }}</div>
             </div>
@@ -684,7 +556,6 @@ describe('useCalendar', () => {
       });
 
       await flush();
-      await fireEvent.click(screen.getByText('Open Calendar'));
       const calendar = screen.getByTestId('calendar');
       const panelLabel = screen.getByTestId('panel-label');
 
@@ -732,7 +603,7 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { calendarProps, isOpen, buttonProps, selectedDate, focusedDate } = useCalendar({
+          const { calendarProps, selectedDate, focusedDate } = useCalendar({
             label: 'Calendar',
             modelValue: currentDate.toDate(),
             timeZone: 'UTC',
@@ -742,16 +613,13 @@ describe('useCalendar', () => {
 
           return {
             calendarProps,
-            isOpen,
-            buttonProps,
             selectedDate,
             focusedDate,
           };
         },
         template: `
           <div data-testid="fixture">
-            <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
+            <div v-bind="calendarProps" data-testid="calendar">
               <div>{{ focusedDate?.toString() }}</div>
             </div>
           </div>
@@ -759,7 +627,6 @@ describe('useCalendar', () => {
       });
 
       await flush();
-      await fireEvent.click(screen.getByText('Open Calendar'));
       const calendar = screen.getByTestId('calendar');
 
       // Try to go before min date
@@ -770,157 +637,6 @@ describe('useCalendar', () => {
       await fireEvent.keyDown(calendar, { code: 'ArrowRight' });
       await fireEvent.keyDown(calendar, { code: 'ArrowRight' });
       expect(screen.getByText(maxDate.toString())).toBeInTheDocument();
-    });
-
-    test('handles double-press Home and End keys in day panel', async () => {
-      const currentDate = now('UTC');
-
-      await render({
-        setup() {
-          const { calendarProps, isOpen, buttonProps, focusedDate } = useCalendar({
-            label: 'Calendar',
-            modelValue: currentDate.toDate(),
-            timeZone: 'UTC',
-          });
-
-          return {
-            calendarProps,
-            isOpen,
-            buttonProps,
-            focusedDate,
-          };
-        },
-        template: `
-          <div data-testid="fixture">
-            <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
-              <div>{{ focusedDate?.toString() }}</div>
-            </div>
-          </div>
-        `,
-      });
-
-      await flush();
-      await fireEvent.click(screen.getByText('Open Calendar'));
-      const calendar = screen.getByTestId('calendar');
-
-      // Test Home key (first press - start of current month)
-      await fireEvent.keyDown(calendar, { code: 'Home' });
-      expect(screen.getByText(currentDate.set({ day: 1 }).toString())).toBeInTheDocument();
-
-      // Test Home key (second press - start of previous month)
-      await fireEvent.keyDown(calendar, { code: 'Home' });
-      expect(screen.getByText(currentDate.subtract({ months: 1 }).set({ day: 1 }).toString())).toBeInTheDocument();
-
-      // Reset to current date
-      await fireEvent.keyDown(calendar, { code: 'Escape' });
-      await fireEvent.click(screen.getByText('Open Calendar'));
-
-      // Test End key (first press - end of current month)
-      await fireEvent.keyDown(calendar, { code: 'End' });
-      expect(
-        screen.getByText(currentDate.set({ day: currentDate.calendar.getDaysInMonth(currentDate) }).toString()),
-      ).toBeInTheDocument();
-
-      // Test End key (second press - start of next month)
-      await fireEvent.keyDown(calendar, { code: 'End' });
-      expect(screen.getByText(currentDate.add({ months: 1 }).set({ day: 1 }).toString())).toBeInTheDocument();
-    });
-
-    test('handles double-press Home month panel', async () => {
-      const currentDate = now('UTC');
-
-      await render({
-        setup() {
-          const { calendarProps, isOpen, buttonProps, focusedDate, gridLabelProps } = useCalendar({
-            label: 'Calendar',
-            modelValue: currentDate.toDate(),
-            timeZone: 'UTC',
-          });
-
-          return {
-            calendarProps,
-            isOpen,
-            buttonProps,
-            focusedDate,
-            gridLabelProps,
-          };
-        },
-        template: `
-          <div data-testid="fixture">
-            <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
-              <div v-bind="gridLabelProps" data-testid="panel-label">Month Panel</div>
-              <div>{{ focusedDate?.toString() }}</div>
-            </div>
-          </div>
-        `,
-      });
-
-      await flush();
-      await fireEvent.click(screen.getByText('Open Calendar'));
-      const calendar = screen.getByTestId('calendar');
-      const panelLabel = screen.getByTestId('panel-label');
-
-      // Switch to month panel
-      await fireEvent.click(panelLabel);
-
-      // Test Home key (first press - start of current year)
-      await fireEvent.keyDown(calendar, { code: 'Home' });
-      expect(screen.getByText(currentDate.set({ month: 1 }).toString())).toBeInTheDocument();
-
-      // Test Home key (second press - start of previous year)
-      await fireEvent.keyDown(calendar, { code: 'Home' });
-      expect(screen.getByText(currentDate.subtract({ years: 1 }).set({ month: 1 }).toString())).toBeInTheDocument();
-    });
-
-    test('handles double-press End month panel', async () => {
-      const currentDate = now('UTC');
-
-      await render({
-        setup() {
-          const { calendarProps, isOpen, buttonProps, focusedDate, gridLabelProps } = useCalendar({
-            label: 'Calendar',
-            modelValue: currentDate.toDate(),
-            timeZone: 'UTC',
-          });
-
-          return {
-            calendarProps,
-            isOpen,
-            buttonProps,
-            focusedDate,
-            gridLabelProps,
-          };
-        },
-        template: `
-          <div data-testid="fixture">
-            <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
-              <div v-bind="gridLabelProps" data-testid="panel-label">Month Panel</div>
-              <div>{{ focusedDate?.toString() }}</div>
-            </div>
-          </div>
-        `,
-      });
-
-      await flush();
-      await fireEvent.click(screen.getByText('Open Calendar'));
-      const calendar = screen.getByTestId('calendar');
-      const panelLabel = screen.getByTestId('panel-label');
-
-      // Switch to month panel
-      await fireEvent.click(panelLabel);
-
-      // Test End key (first press - end of current year)
-      await fireEvent.keyDown(calendar, { code: 'End' });
-      expect(
-        screen.getByText(currentDate.set({ month: currentDate.calendar.getMonthsInYear(currentDate) }).toString()),
-      ).toBeInTheDocument();
-
-      // Test End key (second press - start of next year)
-      await fireEvent.keyDown(calendar, { code: 'End' });
-      expect(screen.getByText(currentDate.add({ years: 1 }).set({ month: 1 }).toString())).toBeInTheDocument();
     });
   });
 });

--- a/packages/core/src/useCalendar/useCalendar.spec.ts
+++ b/packages/core/src/useCalendar/useCalendar.spec.ts
@@ -10,7 +10,7 @@ describe('useCalendar', () => {
       await render({
         setup() {
           const { pickerProps, gridProps, buttonProps, gridLabelProps, nextButtonProps, previousButtonProps } =
-            useCalendar();
+            useCalendar({ label: 'Calendar' });
 
           return {
             pickerProps,
@@ -47,7 +47,7 @@ describe('useCalendar', () => {
     test('opens calendar when button is clicked', async () => {
       await render({
         setup() {
-          const { buttonProps, isOpen } = useCalendar();
+          const { buttonProps, isOpen } = useCalendar({ label: 'Calendar' });
 
           return {
             buttonProps,
@@ -71,7 +71,7 @@ describe('useCalendar', () => {
     test('closes calendar when Escape is pressed', async () => {
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps } = useCalendar();
+          const { pickerProps, isOpen, buttonProps } = useCalendar({ label: 'Calendar' });
 
           return {
             pickerProps,
@@ -97,7 +97,7 @@ describe('useCalendar', () => {
     test('closes calendar when Tab is pressed', async () => {
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps, gridProps } = useCalendar();
+          const { pickerProps, isOpen, buttonProps, gridProps } = useCalendar({ label: 'Calendar' });
 
           return {
             pickerProps,
@@ -125,8 +125,8 @@ describe('useCalendar', () => {
   });
 
   describe('date selection', () => {
-    test('calls onDaySelected when a date is selected', async () => {
-      const onDaySelected = vi.fn();
+    test('calls onUpdateModelValue when a date is selected', async () => {
+      const onUpdateModelValue = vi.fn();
       const currentDate = now('UTC');
 
       await render({
@@ -135,8 +135,9 @@ describe('useCalendar', () => {
         },
         setup() {
           const { pickerProps, buttonProps } = useCalendar({
-            onDaySelected,
-            currentDate,
+            label: 'Calendar',
+            onUpdateModelValue,
+            modelValue: currentDate,
           });
 
           return {
@@ -158,7 +159,7 @@ describe('useCalendar', () => {
       await flush();
       await fireEvent.click(screen.getByText('Select Date'));
       await flush();
-      expect(onDaySelected).toHaveBeenCalledWith(currentDate);
+      expect(onUpdateModelValue).toHaveBeenCalledWith(currentDate);
     });
 
     test('uses provided calendar type', async () => {
@@ -167,6 +168,7 @@ describe('useCalendar', () => {
       await render({
         setup() {
           const { selectedDate } = useCalendar({
+            label: 'Calendar',
             calendar,
           });
 
@@ -186,7 +188,7 @@ describe('useCalendar', () => {
     });
 
     test('handles Enter key on calendar cell', async () => {
-      const onDaySelected = vi.fn();
+      const onUpdateModelValue = vi.fn();
       const currentDate = now('UTC');
 
       await render({
@@ -195,8 +197,9 @@ describe('useCalendar', () => {
         },
         setup() {
           const { pickerProps, buttonProps, isOpen, focusedDate } = useCalendar({
-            onDaySelected,
-            currentDate,
+            label: 'Calendar',
+            onUpdateModelValue,
+            modelValue: currentDate,
           });
 
           return {
@@ -229,19 +232,20 @@ describe('useCalendar', () => {
 
       // Test Enter key selects the date
       await fireEvent.keyDown(cell, { code: 'Enter' });
-      expect(onDaySelected).toHaveBeenCalledWith(currentDate);
+      expect(onUpdateModelValue).toHaveBeenCalledWith(currentDate);
       expect(screen.queryByText(currentDate.toString())).not.toBeInTheDocument(); // Calendar should close after selection
     });
 
     test('handles Enter key in different panels', async () => {
-      const onDaySelected = vi.fn();
+      const onUpdateModelValue = vi.fn();
       const currentDate = now('UTC');
 
       await render({
         setup() {
           const { pickerProps, buttonProps, isOpen, focusedDate, gridLabelProps, currentPanel } = useCalendar({
-            onDaySelected,
-            currentDate,
+            label: 'Calendar',
+            onUpdateModelValue,
+            modelValue: currentDate,
           });
 
           return {
@@ -272,7 +276,7 @@ describe('useCalendar', () => {
 
       // Test Enter in day panel
       await fireEvent.keyDown(calendar, { code: 'Enter' });
-      expect(onDaySelected).toHaveBeenCalledWith(currentDate);
+      expect(onUpdateModelValue).toHaveBeenCalledWith(currentDate);
 
       // Switch to month panel
       await fireEvent.click(panelLabel);
@@ -291,7 +295,7 @@ describe('useCalendar', () => {
     test('switches between day, month, and year panels', async () => {
       await render({
         setup() {
-          const { gridLabelProps, currentPanel } = useCalendar();
+          const { gridLabelProps, currentPanel } = useCalendar({ label: 'Calendar' });
 
           return {
             gridLabelProps,
@@ -317,12 +321,13 @@ describe('useCalendar', () => {
     });
 
     test('navigates to next/previous panels', async () => {
-      const onDaySelected = vi.fn();
+      const onUpdateModelValue = vi.fn();
 
       await render({
         setup() {
           const { nextButtonProps, previousButtonProps, currentPanel } = useCalendar({
-            onDaySelected,
+            label: 'Calendar',
+            onUpdateModelValue,
           });
 
           return {
@@ -362,7 +367,8 @@ describe('useCalendar', () => {
             isOpen,
             buttonProps,
           } = useCalendar({
-            currentDate,
+            label: 'Calendar',
+            modelValue: currentDate,
           });
 
           return {
@@ -426,7 +432,8 @@ describe('useCalendar', () => {
             isOpen,
             buttonProps,
           } = useCalendar({
-            currentDate,
+            label: 'Calendar',
+            modelValue: currentDate,
           });
 
           return {
@@ -489,7 +496,8 @@ describe('useCalendar', () => {
       await render({
         setup() {
           const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate } = useCalendar({
-            currentDate,
+            label: 'Calendar',
+            modelValue: currentDate,
           });
 
           return {
@@ -555,7 +563,8 @@ describe('useCalendar', () => {
       await render({
         setup() {
           const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate, gridLabelProps } = useCalendar({
-            currentDate,
+            label: 'Calendar',
+            modelValue: currentDate,
           });
 
           return {
@@ -627,7 +636,8 @@ describe('useCalendar', () => {
       await render({
         setup() {
           const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate, gridLabelProps } = useCalendar({
-            currentDate,
+            label: 'Calendar',
+            modelValue: currentDate,
           });
 
           return {
@@ -700,7 +710,8 @@ describe('useCalendar', () => {
       await render({
         setup() {
           const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate } = useCalendar({
-            currentDate,
+            label: 'Calendar',
+            modelValue: currentDate,
             minDate,
             maxDate,
           });
@@ -743,7 +754,8 @@ describe('useCalendar', () => {
       await render({
         setup() {
           const { pickerProps, isOpen, buttonProps, focusedDate } = useCalendar({
-            currentDate,
+            label: 'Calendar',
+            modelValue: currentDate,
           });
 
           return {
@@ -796,7 +808,8 @@ describe('useCalendar', () => {
       await render({
         setup() {
           const { pickerProps, isOpen, buttonProps, focusedDate, gridLabelProps } = useCalendar({
-            currentDate,
+            label: 'Calendar',
+            modelValue: currentDate,
           });
 
           return {
@@ -841,7 +854,8 @@ describe('useCalendar', () => {
       await render({
         setup() {
           const { pickerProps, isOpen, buttonProps, focusedDate, gridLabelProps } = useCalendar({
-            currentDate,
+            label: 'Calendar',
+            modelValue: currentDate,
           });
 
           return {

--- a/packages/core/src/useCalendar/useCalendar.spec.ts
+++ b/packages/core/src/useCalendar/useCalendar.spec.ts
@@ -1,0 +1,891 @@
+import { fireEvent, render, screen } from '@testing-library/vue';
+import { axe } from 'vitest-axe';
+import { useCalendar, CalendarCell } from './index';
+import { flush } from '@test-utils/flush';
+import { createCalendar, now } from '@internationalized/date';
+
+describe('useCalendar', () => {
+  describe('a11y', () => {
+    test('calendar should not have accessibility violations', async () => {
+      await render({
+        setup() {
+          const {
+            pickerProps,
+            panelGridProps,
+            buttonProps,
+            panelLabelProps,
+            nextPanelButtonProps,
+            previousPanelButtonProps,
+          } = useCalendar();
+
+          return {
+            pickerProps,
+            panelGridProps,
+            buttonProps,
+            panelLabelProps,
+            nextPanelButtonProps,
+            previousPanelButtonProps,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <div v-bind="pickerProps">
+              <button v-bind="buttonProps">Open Calendar</button>
+              <div v-bind="panelLabelProps">Month Year</div>
+              <button v-bind="previousPanelButtonProps">Previous</button>
+              <button v-bind="nextPanelButtonProps">Next</button>
+              <div v-bind="panelGridProps">
+                <!-- Calendar grid content would go here -->
+              </div>
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      vi.useRealTimers();
+      expect(await axe(screen.getByTestId('fixture'))).toHaveNoViolations();
+      vi.useFakeTimers();
+    });
+  });
+
+  describe('calendar controls', () => {
+    test('opens calendar when button is clicked', async () => {
+      await render({
+        setup() {
+          const { buttonProps, isOpen } = useCalendar();
+
+          return {
+            buttonProps,
+            isOpen,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="buttonProps">Open Calendar</button>
+            <div v-if="isOpen">Calendar Content</div>
+          </div>
+        `,
+      });
+
+      await flush();
+      expect(screen.queryByText('Calendar Content')).not.toBeInTheDocument();
+      await fireEvent.click(screen.getByText('Open Calendar'));
+      expect(screen.getByText('Calendar Content')).toBeInTheDocument();
+    });
+
+    test('closes calendar when Escape is pressed', async () => {
+      await render({
+        setup() {
+          const { pickerProps, isOpen, buttonProps } = useCalendar();
+
+          return {
+            pickerProps,
+            isOpen,
+            buttonProps,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="buttonProps">Open Calendar</button>
+            <div v-if="isOpen" v-bind="pickerProps">Calendar Content</div>
+          </div>
+        `,
+      });
+
+      await flush();
+      await fireEvent.click(screen.getByText('Open Calendar'));
+      expect(screen.getByText('Calendar Content')).toBeInTheDocument();
+      await fireEvent.keyDown(screen.getByText('Calendar Content'), { code: 'Escape' });
+      expect(screen.queryByText('Calendar Content')).not.toBeInTheDocument();
+    });
+
+    test('closes calendar when Tab is pressed', async () => {
+      await render({
+        setup() {
+          const { pickerProps, isOpen, buttonProps, panelGridProps } = useCalendar();
+
+          return {
+            pickerProps,
+            isOpen,
+            buttonProps,
+            panelGridProps,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="buttonProps">Open Calendar</button>
+            <div v-if="isOpen" v-bind="pickerProps">
+              <span v-bind="panelGridProps" tabindex="0">Calendar Content</span>
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      await fireEvent.click(screen.getByText('Open Calendar'));
+      expect(screen.getByText('Calendar Content')).toBeInTheDocument();
+      await fireEvent.keyDown(screen.getByText('Calendar Content'), { code: 'Tab' });
+      expect(screen.queryByText('Calendar Content')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('date selection', () => {
+    test('calls onDaySelected when a date is selected', async () => {
+      const onDaySelected = vi.fn();
+      const currentDate = now('UTC');
+
+      await render({
+        components: {
+          CalendarCell,
+        },
+        setup() {
+          const { pickerProps, buttonProps } = useCalendar({
+            onDaySelected,
+            currentDate,
+          });
+
+          return {
+            pickerProps,
+            buttonProps,
+            currentDate,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="buttonProps">Open Calendar</button>
+            <div v-bind="pickerProps">
+              <CalendarCell label="Select Date" type="day" :value="currentDate" />
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      await fireEvent.click(screen.getByText('Select Date'));
+      await flush();
+      expect(onDaySelected).toHaveBeenCalledWith(currentDate);
+    });
+
+    test('uses provided calendar type', async () => {
+      const calendar = createCalendar('islamic-umalqura');
+
+      await render({
+        setup() {
+          const { selectedDate } = useCalendar({
+            calendar,
+          });
+
+          return {
+            selectedDate,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <div>{{ selectedDate.calendar.identifier }}</div>
+          </div>
+        `,
+      });
+
+      await flush();
+      expect(screen.getByText('islamic-umalqura')).toBeInTheDocument();
+    });
+
+    test('handles Enter key on calendar cell', async () => {
+      const onDaySelected = vi.fn();
+      const currentDate = now('UTC');
+
+      await render({
+        components: {
+          CalendarCell,
+        },
+        setup() {
+          const { pickerProps, buttonProps, isOpen, focusedDate } = useCalendar({
+            onDaySelected,
+            currentDate,
+          });
+
+          return {
+            pickerProps,
+            buttonProps,
+            isOpen,
+            focusedDate,
+            currentDate,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="buttonProps">Open Calendar</button>
+            <div v-if="isOpen" v-bind="pickerProps">
+              <CalendarCell
+                label="Select Date"
+                type="day"
+                :value="currentDate"
+                data-testid="calendar-cell"
+              />
+              <div>{{ focusedDate?.toString() }}</div>
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      await fireEvent.click(screen.getByText('Open Calendar'));
+      const cell = screen.getByTestId('calendar-cell');
+
+      // Test Enter key selects the date
+      await fireEvent.keyDown(cell, { code: 'Enter' });
+      expect(onDaySelected).toHaveBeenCalledWith(currentDate);
+      expect(screen.queryByText(currentDate.toString())).not.toBeInTheDocument(); // Calendar should close after selection
+    });
+
+    test('handles Enter key in different panels', async () => {
+      const onDaySelected = vi.fn();
+      const currentDate = now('UTC');
+
+      await render({
+        setup() {
+          const { pickerProps, buttonProps, isOpen, focusedDate, panelLabelProps, currentPanel } = useCalendar({
+            onDaySelected,
+            currentDate,
+          });
+
+          return {
+            pickerProps,
+            buttonProps,
+            isOpen,
+            focusedDate,
+            panelLabelProps,
+            currentPanel,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="buttonProps">Open Calendar</button>
+            <div v-bind="panelLabelProps" data-testid="panel-label">{{ currentPanel.type }}</div>
+            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+              <div>{{ focusedDate?.toString() }}</div>
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      await fireEvent.click(screen.getByText('Open Calendar'));
+      const calendar = screen.getByTestId('calendar');
+      const panelLabel = screen.getByTestId('panel-label');
+      await fireEvent.keyDown(calendar, { code: 'Escape' });
+
+      // Test Enter in day panel
+      await fireEvent.keyDown(calendar, { code: 'Enter' });
+      expect(onDaySelected).toHaveBeenCalledWith(currentDate);
+
+      // Switch to month panel
+      await fireEvent.click(panelLabel);
+      await fireEvent.keyDown(calendar, { code: 'Enter' });
+      expect(screen.getByTestId('panel-label')).toHaveTextContent('day'); // Should switch back to day panel
+
+      // Switch to year panel
+      await fireEvent.click(panelLabel);
+      await fireEvent.click(panelLabel);
+      await fireEvent.keyDown(calendar, { code: 'Enter' });
+      expect(screen.getByTestId('panel-label')).toHaveTextContent('month'); // Should switch back to month panel
+    });
+  });
+
+  describe('panel navigation', () => {
+    test('switches between day, month, and year panels', async () => {
+      await render({
+        setup() {
+          const { panelLabelProps, currentPanel } = useCalendar();
+
+          return {
+            panelLabelProps,
+            currentPanel,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <div v-bind="panelLabelProps" data-testid="panel-label">{{ currentPanel.type }}</div>
+          </div>
+        `,
+      });
+
+      await flush();
+      const panelLabel = screen.getByTestId('panel-label');
+      expect(panelLabel).toHaveTextContent('day');
+
+      await fireEvent.click(panelLabel);
+      expect(panelLabel).toHaveTextContent('month');
+
+      await fireEvent.click(panelLabel);
+      expect(panelLabel).toHaveTextContent('year');
+    });
+
+    test('navigates to next/previous panels', async () => {
+      const onDaySelected = vi.fn();
+
+      await render({
+        setup() {
+          const { nextPanelButtonProps, previousPanelButtonProps, currentPanel } = useCalendar({
+            onDaySelected,
+          });
+
+          return {
+            nextPanelButtonProps,
+            previousPanelButtonProps,
+            currentPanel,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="previousPanelButtonProps">Previous</button>
+            <div data-testid="panel-type">{{ currentPanel.type }}</div>
+            <button v-bind="nextPanelButtonProps">Next</button>
+          </div>
+        `,
+      });
+
+      await flush();
+      expect(screen.getByTestId('panel-type')).toHaveTextContent('day');
+
+      // Test navigation buttons
+      await fireEvent.click(screen.getByText('Next'));
+      await fireEvent.click(screen.getByText('Previous'));
+    });
+
+    test('navigates months using next/previous buttons in month panel', async () => {
+      const currentDate = now('UTC');
+
+      await render({
+        setup() {
+          const {
+            nextPanelButtonProps,
+            previousPanelButtonProps,
+            panelLabelProps,
+            focusedDate,
+            pickerProps,
+            isOpen,
+            buttonProps,
+          } = useCalendar({
+            currentDate,
+          });
+
+          return {
+            nextPanelButtonProps,
+            previousPanelButtonProps,
+            panelLabelProps,
+            focusedDate,
+            pickerProps,
+            isOpen,
+            buttonProps,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="buttonProps">Open Calendar</button>
+            <div v-if="isOpen" v-bind="pickerProps">
+              <div v-bind="panelLabelProps" data-testid="panel-label">Month Panel</div>
+              <button v-bind="previousPanelButtonProps">Previous</button>
+              <button v-bind="nextPanelButtonProps">Next</button>
+              <div>{{ focusedDate?.toString() }}</div>
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      await fireEvent.click(screen.getByText('Open Calendar'));
+      const panelLabel = screen.getByTestId('panel-label');
+
+      // Switch to month panel
+      await fireEvent.click(panelLabel);
+
+      // Test next button (next year in month panel)
+      await fireEvent.click(screen.getByText('Next'));
+      expect(screen.getByText(currentDate.add({ years: 1 }).toString())).toBeInTheDocument();
+
+      // Test previous button (previous year in month panel)
+      await fireEvent.click(screen.getByText('Previous'));
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+
+      // Test multiple clicks
+      await fireEvent.click(screen.getByText('Previous'));
+      await fireEvent.click(screen.getByText('Previous'));
+      expect(screen.getByText(currentDate.subtract({ years: 2 }).toString())).toBeInTheDocument();
+
+      await fireEvent.click(screen.getByText('Next'));
+      expect(screen.getByText(currentDate.subtract({ years: 1 }).toString())).toBeInTheDocument();
+    });
+
+    test('navigates years using next/previous buttons in year panel', async () => {
+      const currentDate = now('UTC');
+
+      await render({
+        setup() {
+          const {
+            nextPanelButtonProps,
+            previousPanelButtonProps,
+            panelLabelProps,
+            focusedDate,
+            pickerProps,
+            isOpen,
+            buttonProps,
+          } = useCalendar({
+            currentDate,
+          });
+
+          return {
+            nextPanelButtonProps,
+            previousPanelButtonProps,
+            panelLabelProps,
+            focusedDate,
+            pickerProps,
+            isOpen,
+            buttonProps,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="buttonProps">Open Calendar</button>
+            <div v-if="isOpen" v-bind="pickerProps">
+              <div v-bind="panelLabelProps" data-testid="panel-label">Year Panel</div>
+              <button v-bind="previousPanelButtonProps">Previous</button>
+              <button v-bind="nextPanelButtonProps">Next</button>
+              <div>{{ focusedDate?.toString() }}</div>
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      await fireEvent.click(screen.getByText('Open Calendar'));
+      const panelLabel = screen.getByTestId('panel-label');
+
+      // Switch to month panel then year panel
+      await fireEvent.click(panelLabel);
+      await fireEvent.click(panelLabel);
+
+      // Test next button (next set of years)
+      await fireEvent.click(screen.getByText('Next'));
+      expect(screen.getByText(currentDate.add({ years: 9 }).set({ month: 1, day: 1 }).toString())).toBeInTheDocument();
+
+      // Test previous button (previous set of years)
+      await fireEvent.click(screen.getByText('Previous'));
+      expect(screen.getByText(currentDate.add({ years: 8 }).set({ month: 1, day: 1 }).toString())).toBeInTheDocument();
+
+      // Test multiple clicks
+      await fireEvent.click(screen.getByText('Previous'));
+      await fireEvent.click(screen.getByText('Previous'));
+      expect(
+        screen.getByText(currentDate.subtract({ years: 10 }).set({ month: 1, day: 1 }).toString()),
+      ).toBeInTheDocument();
+
+      await fireEvent.click(screen.getByText('Next'));
+      expect(
+        screen.getByText(currentDate.subtract({ years: 9 }).set({ month: 1, day: 1 }).toString()),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    test('handles arrow key navigation in day panel', async () => {
+      const currentDate = now('UTC');
+
+      await render({
+        setup() {
+          const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate } = useCalendar({
+            currentDate,
+          });
+
+          return {
+            pickerProps,
+            isOpen,
+            buttonProps,
+            selectedDate,
+            focusedDate,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="buttonProps">Open Calendar</button>
+            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+              <div>{{ focusedDate?.toString() }}</div>
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      await fireEvent.click(screen.getByText('Open Calendar'));
+      const calendar = screen.getByTestId('calendar');
+
+      // Test right arrow (next day)
+      await fireEvent.keyDown(calendar, { code: 'ArrowRight' });
+      expect(screen.getByText(currentDate.add({ days: 1 }).toString())).toBeInTheDocument();
+
+      // Test left arrow (previous day)
+      await fireEvent.keyDown(calendar, { code: 'ArrowLeft' });
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+
+      // Test down arrow (next week)
+      await fireEvent.keyDown(calendar, { code: 'ArrowDown' });
+      expect(screen.getByText(currentDate.add({ weeks: 1 }).toString())).toBeInTheDocument();
+
+      // Test up arrow (previous week)
+      await fireEvent.keyDown(calendar, { code: 'ArrowUp' });
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+
+      // Test PageUp (previous month)
+      await fireEvent.keyDown(calendar, { code: 'PageUp' });
+      expect(screen.getByText(currentDate.subtract({ months: 1 }).toString())).toBeInTheDocument();
+
+      // Test PageDown (next month)
+      await fireEvent.keyDown(calendar, { code: 'PageDown' });
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+
+      // Test Home (start of month)
+      await fireEvent.keyDown(calendar, { code: 'Home' });
+      expect(screen.getByText(currentDate.set({ day: 1 }).toString())).toBeInTheDocument();
+
+      // Test End (end of month)
+      await fireEvent.keyDown(calendar, { code: 'End' });
+      expect(
+        screen.getByText(currentDate.set({ day: currentDate.calendar.getDaysInMonth(currentDate) }).toString()),
+      ).toBeInTheDocument();
+    });
+
+    test('handles arrow key navigation in month panel', async () => {
+      const currentDate = now('UTC');
+
+      await render({
+        setup() {
+          const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate, panelLabelProps } = useCalendar({
+            currentDate,
+          });
+
+          return {
+            pickerProps,
+            isOpen,
+            buttonProps,
+            selectedDate,
+            focusedDate,
+            panelLabelProps,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="buttonProps">Open Calendar</button>
+            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+              <div v-bind="panelLabelProps" data-testid="panel-label">Month Panel</div>
+              <div>{{ focusedDate?.toString() }}</div>
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      await fireEvent.click(screen.getByText('Open Calendar'));
+      const calendar = screen.getByTestId('calendar');
+      const panelLabel = screen.getByTestId('panel-label');
+
+      // Switch to month panel
+      await fireEvent.click(panelLabel);
+
+      // Test right arrow (next month)
+      await fireEvent.keyDown(calendar, { code: 'ArrowRight' });
+      expect(screen.getByText(currentDate.add({ months: 1 }).toString())).toBeInTheDocument();
+
+      // Test left arrow (previous month)
+      await fireEvent.keyDown(calendar, { code: 'ArrowLeft' });
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+
+      // Test down arrow (3 months forward)
+      await fireEvent.keyDown(calendar, { code: 'ArrowDown' });
+      expect(screen.getByText(currentDate.add({ months: 3 }).toString())).toBeInTheDocument();
+
+      // Test up arrow (3 months back)
+      await fireEvent.keyDown(calendar, { code: 'ArrowUp' });
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+
+      // Test PageUp (previous year)
+      await fireEvent.keyDown(calendar, { code: 'PageUp' });
+      expect(screen.getByText(currentDate.subtract({ years: 1 }).toString())).toBeInTheDocument();
+
+      // Test PageDown (next year)
+      await fireEvent.keyDown(calendar, { code: 'PageDown' });
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+
+      // Test Home (start of year)
+      await fireEvent.keyDown(calendar, { code: 'Home' });
+      expect(screen.getByText(currentDate.set({ month: 1 }).toString())).toBeInTheDocument();
+
+      // Test End (end of year)
+      await fireEvent.keyDown(calendar, { code: 'End' });
+      expect(
+        screen.getByText(currentDate.set({ month: currentDate.calendar.getMonthsInYear(currentDate) }).toString()),
+      ).toBeInTheDocument();
+    });
+
+    test('handles arrow key navigation in year panel', async () => {
+      const currentDate = now('UTC');
+
+      await render({
+        setup() {
+          const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate, panelLabelProps } = useCalendar({
+            currentDate,
+          });
+
+          return {
+            pickerProps,
+            isOpen,
+            buttonProps,
+            selectedDate,
+            focusedDate,
+            panelLabelProps,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="buttonProps">Open Calendar</button>
+            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+              <div v-bind="panelLabelProps" data-testid="panel-label">Year Panel</div>
+              <div>{{ focusedDate?.toString() }}</div>
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      await fireEvent.click(screen.getByText('Open Calendar'));
+      const calendar = screen.getByTestId('calendar');
+      const panelLabel = screen.getByTestId('panel-label');
+
+      // Switch to month panel then year panel
+      await fireEvent.click(panelLabel);
+      await fireEvent.click(panelLabel);
+
+      // Test right arrow (next year)
+      await fireEvent.keyDown(calendar, { code: 'ArrowRight' });
+      expect(screen.getByText(currentDate.add({ years: 1 }).toString())).toBeInTheDocument();
+
+      // Test left arrow (previous year)
+      await fireEvent.keyDown(calendar, { code: 'ArrowLeft' });
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+
+      // Test down arrow (3 years forward)
+      await fireEvent.keyDown(calendar, { code: 'ArrowDown' });
+      expect(screen.getByText(currentDate.add({ years: 3 }).toString())).toBeInTheDocument();
+
+      // Test up arrow (3 years back)
+      await fireEvent.keyDown(calendar, { code: 'ArrowUp' });
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+
+      // Test PageUp (previous set of years)
+      await fireEvent.keyDown(calendar, { code: 'PageUp' });
+      expect(screen.getByText(currentDate.subtract({ years: 9 }).toString())).toBeInTheDocument();
+
+      // Test PageDown (next set of years)
+      await fireEvent.keyDown(calendar, { code: 'PageDown' });
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+
+      // Test Home (start of year set)
+      await fireEvent.keyDown(calendar, { code: 'Home' });
+      expect(screen.getByText(currentDate.subtract({ years: 9 }).toString())).toBeInTheDocument();
+
+      // Test End (end of year set)
+      await fireEvent.keyDown(calendar, { code: 'End' });
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+    });
+
+    test('respects min and max date boundaries', async () => {
+      const currentDate = now('UTC');
+      const minDate = currentDate.subtract({ days: 1 });
+      const maxDate = currentDate.add({ days: 1 });
+
+      await render({
+        setup() {
+          const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate } = useCalendar({
+            currentDate,
+            minDate,
+            maxDate,
+          });
+
+          return {
+            pickerProps,
+            isOpen,
+            buttonProps,
+            selectedDate,
+            focusedDate,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="buttonProps">Open Calendar</button>
+            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+              <div>{{ focusedDate?.toString() }}</div>
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      await fireEvent.click(screen.getByText('Open Calendar'));
+      const calendar = screen.getByTestId('calendar');
+
+      // Try to go before min date
+      await fireEvent.keyDown(calendar, { code: 'ArrowLeft' });
+      expect(screen.getByText(minDate.toString())).toBeInTheDocument();
+
+      // Try to go after max date
+      await fireEvent.keyDown(calendar, { code: 'ArrowRight' });
+      await fireEvent.keyDown(calendar, { code: 'ArrowRight' });
+      expect(screen.getByText(maxDate.toString())).toBeInTheDocument();
+    });
+
+    test('handles double-press Home and End keys in day panel', async () => {
+      const currentDate = now('UTC');
+
+      await render({
+        setup() {
+          const { pickerProps, isOpen, buttonProps, focusedDate } = useCalendar({
+            currentDate,
+          });
+
+          return {
+            pickerProps,
+            isOpen,
+            buttonProps,
+            focusedDate,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="buttonProps">Open Calendar</button>
+            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+              <div>{{ focusedDate?.toString() }}</div>
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      await fireEvent.click(screen.getByText('Open Calendar'));
+      const calendar = screen.getByTestId('calendar');
+
+      // Test Home key (first press - start of current month)
+      await fireEvent.keyDown(calendar, { code: 'Home' });
+      expect(screen.getByText(currentDate.set({ day: 1 }).toString())).toBeInTheDocument();
+
+      // Test Home key (second press - start of previous month)
+      await fireEvent.keyDown(calendar, { code: 'Home' });
+      expect(screen.getByText(currentDate.subtract({ months: 1 }).set({ day: 1 }).toString())).toBeInTheDocument();
+
+      // Reset to current date
+      await fireEvent.keyDown(calendar, { code: 'Escape' });
+      await fireEvent.click(screen.getByText('Open Calendar'));
+
+      // Test End key (first press - end of current month)
+      await fireEvent.keyDown(calendar, { code: 'End' });
+      expect(
+        screen.getByText(currentDate.set({ day: currentDate.calendar.getDaysInMonth(currentDate) }).toString()),
+      ).toBeInTheDocument();
+
+      // Test End key (second press - start of next month)
+      await fireEvent.keyDown(calendar, { code: 'End' });
+      expect(screen.getByText(currentDate.add({ months: 1 }).set({ day: 1 }).toString())).toBeInTheDocument();
+    });
+
+    test('handles double-press Home month panel', async () => {
+      const currentDate = now('UTC');
+
+      await render({
+        setup() {
+          const { pickerProps, isOpen, buttonProps, focusedDate, panelLabelProps } = useCalendar({
+            currentDate,
+          });
+
+          return {
+            pickerProps,
+            isOpen,
+            buttonProps,
+            focusedDate,
+            panelLabelProps,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="buttonProps">Open Calendar</button>
+            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+              <div v-bind="panelLabelProps" data-testid="panel-label">Month Panel</div>
+              <div>{{ focusedDate?.toString() }}</div>
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      await fireEvent.click(screen.getByText('Open Calendar'));
+      const calendar = screen.getByTestId('calendar');
+      const panelLabel = screen.getByTestId('panel-label');
+
+      // Switch to month panel
+      await fireEvent.click(panelLabel);
+
+      // Test Home key (first press - start of current year)
+      await fireEvent.keyDown(calendar, { code: 'Home' });
+      expect(screen.getByText(currentDate.set({ month: 1 }).toString())).toBeInTheDocument();
+
+      // Test Home key (second press - start of previous year)
+      await fireEvent.keyDown(calendar, { code: 'Home' });
+      expect(screen.getByText(currentDate.subtract({ years: 1 }).set({ month: 1 }).toString())).toBeInTheDocument();
+    });
+
+    test('handles double-press End month panel', async () => {
+      const currentDate = now('UTC');
+
+      await render({
+        setup() {
+          const { pickerProps, isOpen, buttonProps, focusedDate, panelLabelProps } = useCalendar({
+            currentDate,
+          });
+
+          return {
+            pickerProps,
+            isOpen,
+            buttonProps,
+            focusedDate,
+            panelLabelProps,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <button v-bind="buttonProps">Open Calendar</button>
+            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+              <div v-bind="panelLabelProps" data-testid="panel-label">Month Panel</div>
+              <div>{{ focusedDate?.toString() }}</div>
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      await fireEvent.click(screen.getByText('Open Calendar'));
+      const calendar = screen.getByTestId('calendar');
+      const panelLabel = screen.getByTestId('panel-label');
+
+      // Switch to month panel
+      await fireEvent.click(panelLabel);
+
+      // Test End key (first press - end of current year)
+      await fireEvent.keyDown(calendar, { code: 'End' });
+      expect(
+        screen.getByText(currentDate.set({ month: currentDate.calendar.getMonthsInYear(currentDate) }).toString()),
+      ).toBeInTheDocument();
+
+      // Test End key (second press - start of next year)
+      await fireEvent.keyDown(calendar, { code: 'End' });
+      expect(screen.getByText(currentDate.add({ years: 1 }).set({ month: 1 }).toString())).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/core/src/useCalendar/useCalendar.spec.ts
+++ b/packages/core/src/useCalendar/useCalendar.spec.ts
@@ -9,11 +9,11 @@ describe('useCalendar', () => {
     test('calendar should not have accessibility violations', async () => {
       await render({
         setup() {
-          const { pickerProps, gridProps, buttonProps, gridLabelProps, nextButtonProps, previousButtonProps } =
+          const { calendarProps, gridProps, buttonProps, gridLabelProps, nextButtonProps, previousButtonProps } =
             useCalendar({ label: 'Calendar' });
 
           return {
-            pickerProps,
+            calendarProps,
             gridProps,
             buttonProps,
             gridLabelProps,
@@ -23,7 +23,7 @@ describe('useCalendar', () => {
         },
         template: `
           <div data-testid="fixture">
-            <div v-bind="pickerProps">
+            <div v-bind="calendarProps">
               <button v-bind="buttonProps">Open Calendar</button>
               <div v-bind="gridLabelProps">Month Year</div>
               <button v-bind="previousButtonProps">Previous</button>
@@ -71,10 +71,10 @@ describe('useCalendar', () => {
     test('closes calendar when Escape is pressed', async () => {
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps } = useCalendar({ label: 'Calendar' });
+          const { calendarProps, isOpen, buttonProps } = useCalendar({ label: 'Calendar' });
 
           return {
-            pickerProps,
+            calendarProps,
             isOpen,
             buttonProps,
           };
@@ -82,7 +82,7 @@ describe('useCalendar', () => {
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="pickerProps">Calendar Content</div>
+            <div v-if="isOpen" v-bind="calendarProps">Calendar Content</div>
           </div>
         `,
       });
@@ -97,10 +97,10 @@ describe('useCalendar', () => {
     test('closes calendar when Tab is pressed', async () => {
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps, gridProps } = useCalendar({ label: 'Calendar' });
+          const { calendarProps, isOpen, buttonProps, gridProps } = useCalendar({ label: 'Calendar' });
 
           return {
-            pickerProps,
+            calendarProps,
             isOpen,
             buttonProps,
             gridProps,
@@ -109,7 +109,7 @@ describe('useCalendar', () => {
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="pickerProps">
+            <div v-if="isOpen" v-bind="calendarProps">
               <span v-bind="gridProps" tabindex="0">Calendar Content</span>
             </div>
           </div>
@@ -126,22 +126,21 @@ describe('useCalendar', () => {
 
   describe('date selection', () => {
     test('calls onUpdateModelValue when a date is selected', async () => {
-      const onUpdateModelValue = vi.fn();
       const currentDate = now('UTC');
 
-      await render({
+      const vm = await render({
         components: {
           CalendarCell,
         },
         setup() {
-          const { pickerProps, buttonProps } = useCalendar({
+          const { calendarProps, buttonProps } = useCalendar({
             label: 'Calendar',
-            onUpdateModelValue,
-            modelValue: currentDate,
+            timeZone: 'UTC',
+            modelValue: currentDate.toDate(),
           });
 
           return {
-            pickerProps,
+            calendarProps,
             buttonProps,
             currentDate,
           };
@@ -149,7 +148,7 @@ describe('useCalendar', () => {
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
-            <div v-bind="pickerProps">
+            <div v-bind="calendarProps">
               <CalendarCell label="Select Date" type="day" :value="currentDate" />
             </div>
           </div>
@@ -159,7 +158,7 @@ describe('useCalendar', () => {
       await flush();
       await fireEvent.click(screen.getByText('Select Date'));
       await flush();
-      expect(onUpdateModelValue).toHaveBeenCalledWith(currentDate);
+      expect(vm.emitted('update:modelValue')[0]).toEqual([currentDate.toDate()]);
     });
 
     test('uses provided calendar type', async () => {
@@ -188,22 +187,21 @@ describe('useCalendar', () => {
     });
 
     test('handles Enter key on calendar cell', async () => {
-      const onUpdateModelValue = vi.fn();
       const currentDate = now('UTC');
 
-      await render({
+      const vm = await render({
         components: {
           CalendarCell,
         },
         setup() {
-          const { pickerProps, buttonProps, isOpen, focusedDate } = useCalendar({
+          const { calendarProps, buttonProps, isOpen, focusedDate } = useCalendar({
             label: 'Calendar',
-            onUpdateModelValue,
-            modelValue: currentDate,
+            modelValue: currentDate.toDate(),
+            timeZone: 'UTC',
           });
 
           return {
-            pickerProps,
+            calendarProps,
             buttonProps,
             isOpen,
             focusedDate,
@@ -213,7 +211,7 @@ describe('useCalendar', () => {
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="pickerProps">
+            <div v-if="isOpen" v-bind="calendarProps">
               <CalendarCell
                 label="Select Date"
                 type="day"
@@ -232,36 +230,35 @@ describe('useCalendar', () => {
 
       // Test Enter key selects the date
       await fireEvent.keyDown(cell, { code: 'Enter' });
-      expect(onUpdateModelValue).toHaveBeenCalledWith(currentDate);
+      expect(vm.emitted('update:modelValue')[0]).toEqual([currentDate.toDate()]);
       expect(screen.queryByText(currentDate.toString())).not.toBeInTheDocument(); // Calendar should close after selection
     });
 
     test('handles Enter key in different panels', async () => {
-      const onUpdateModelValue = vi.fn();
       const currentDate = now('UTC');
 
-      await render({
+      const vm = await render({
         setup() {
-          const { pickerProps, buttonProps, isOpen, focusedDate, gridLabelProps, currentPanel } = useCalendar({
+          const { calendarProps, buttonProps, isOpen, focusedDate, gridLabelProps, currentView } = useCalendar({
             label: 'Calendar',
-            onUpdateModelValue,
-            modelValue: currentDate,
+            modelValue: currentDate.toDate(),
+            timeZone: 'UTC',
           });
 
           return {
-            pickerProps,
+            calendarProps,
             buttonProps,
             isOpen,
             focusedDate,
             gridLabelProps,
-            currentPanel,
+            currentView,
           };
         },
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
-            <div v-bind="gridLabelProps" data-testid="panel-label">{{ currentPanel.type }}</div>
-            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+            <div v-bind="gridLabelProps" data-testid="panel-label">{{ currentView.type }}</div>
+            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
               <div>{{ focusedDate?.toString() }}</div>
             </div>
           </div>
@@ -276,7 +273,7 @@ describe('useCalendar', () => {
 
       // Test Enter in day panel
       await fireEvent.keyDown(calendar, { code: 'Enter' });
-      expect(onUpdateModelValue).toHaveBeenCalledWith(currentDate);
+      expect(vm.emitted('update:modelValue')[0]).toEqual([currentDate.toDate()]);
 
       // Switch to month panel
       await fireEvent.click(panelLabel);
@@ -295,16 +292,16 @@ describe('useCalendar', () => {
     test('switches between day, month, and year panels', async () => {
       await render({
         setup() {
-          const { gridLabelProps, currentPanel } = useCalendar({ label: 'Calendar' });
+          const { gridLabelProps, currentView } = useCalendar({ label: 'Calendar' });
 
           return {
             gridLabelProps,
-            currentPanel,
+            currentView,
           };
         },
         template: `
           <div data-testid="fixture">
-            <div v-bind="gridLabelProps" data-testid="panel-label">{{ currentPanel.type }}</div>
+            <div v-bind="gridLabelProps" data-testid="panel-label">{{ currentView.type }}</div>
           </div>
         `,
       });
@@ -321,25 +318,22 @@ describe('useCalendar', () => {
     });
 
     test('navigates to next/previous panels', async () => {
-      const onUpdateModelValue = vi.fn();
-
       await render({
         setup() {
-          const { nextButtonProps, previousButtonProps, currentPanel } = useCalendar({
+          const { nextButtonProps, previousButtonProps, currentView } = useCalendar({
             label: 'Calendar',
-            onUpdateModelValue,
           });
 
           return {
             nextButtonProps,
             previousButtonProps,
-            currentPanel,
+            currentView,
           };
         },
         template: `
           <div data-testid="fixture">
             <button v-bind="previousButtonProps">Previous</button>
-            <div data-testid="panel-type">{{ currentPanel.type }}</div>
+            <div data-testid="panel-type">{{ currentView.type }}</div>
             <button v-bind="nextButtonProps">Next</button>
           </div>
         `,
@@ -363,12 +357,13 @@ describe('useCalendar', () => {
             previousButtonProps,
             gridLabelProps,
             focusedDate,
-            pickerProps,
+            calendarProps,
             isOpen,
             buttonProps,
           } = useCalendar({
             label: 'Calendar',
-            modelValue: currentDate,
+            modelValue: currentDate.toDate(),
+            timeZone: 'UTC',
           });
 
           return {
@@ -376,7 +371,7 @@ describe('useCalendar', () => {
             previousButtonProps,
             gridLabelProps,
             focusedDate,
-            pickerProps,
+            calendarProps,
             isOpen,
             buttonProps,
           };
@@ -384,7 +379,7 @@ describe('useCalendar', () => {
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="pickerProps">
+            <div v-if="isOpen" v-bind="calendarProps">
               <div v-bind="gridLabelProps" data-testid="panel-label">Month Panel</div>
               <button v-bind="previousButtonProps">Previous</button>
               <button v-bind="nextButtonProps">Next</button>
@@ -428,12 +423,13 @@ describe('useCalendar', () => {
             previousButtonProps,
             gridLabelProps,
             focusedDate,
-            pickerProps,
+            calendarProps,
             isOpen,
             buttonProps,
           } = useCalendar({
             label: 'Calendar',
-            modelValue: currentDate,
+            modelValue: currentDate.toDate(),
+            timeZone: 'UTC',
           });
 
           return {
@@ -441,7 +437,7 @@ describe('useCalendar', () => {
             previousButtonProps,
             gridLabelProps,
             focusedDate,
-            pickerProps,
+            calendarProps,
             isOpen,
             buttonProps,
           };
@@ -449,7 +445,7 @@ describe('useCalendar', () => {
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="pickerProps">
+            <div v-if="isOpen" v-bind="calendarProps">
               <div v-bind="gridLabelProps" data-testid="panel-label">Year Panel</div>
               <button v-bind="previousButtonProps">Previous</button>
               <button v-bind="nextButtonProps">Next</button>
@@ -495,13 +491,14 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate } = useCalendar({
+          const { calendarProps, isOpen, buttonProps, selectedDate, focusedDate } = useCalendar({
             label: 'Calendar',
-            modelValue: currentDate,
+            modelValue: currentDate.toDate(),
+            timeZone: 'UTC',
           });
 
           return {
-            pickerProps,
+            calendarProps,
             isOpen,
             buttonProps,
             selectedDate,
@@ -511,7 +508,7 @@ describe('useCalendar', () => {
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
               <div>{{ focusedDate?.toString() }}</div>
             </div>
           </div>
@@ -562,13 +559,14 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate, gridLabelProps } = useCalendar({
+          const { calendarProps, isOpen, buttonProps, selectedDate, focusedDate, gridLabelProps } = useCalendar({
             label: 'Calendar',
-            modelValue: currentDate,
+            modelValue: currentDate.toDate(),
+            timeZone: 'UTC',
           });
 
           return {
-            pickerProps,
+            calendarProps,
             isOpen,
             buttonProps,
             selectedDate,
@@ -579,7 +577,7 @@ describe('useCalendar', () => {
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
               <div v-bind="gridLabelProps" data-testid="panel-label">Month Panel</div>
               <div>{{ focusedDate?.toString() }}</div>
             </div>
@@ -635,13 +633,14 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate, gridLabelProps } = useCalendar({
+          const { calendarProps, isOpen, buttonProps, selectedDate, focusedDate, gridLabelProps } = useCalendar({
             label: 'Calendar',
-            modelValue: currentDate,
+            modelValue: currentDate.toDate(),
+            timeZone: 'UTC',
           });
 
           return {
-            pickerProps,
+            calendarProps,
             isOpen,
             buttonProps,
             selectedDate,
@@ -652,7 +651,7 @@ describe('useCalendar', () => {
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
               <div v-bind="gridLabelProps" data-testid="panel-label">Year Panel</div>
               <div>{{ focusedDate?.toString() }}</div>
             </div>
@@ -709,15 +708,16 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate } = useCalendar({
+          const { calendarProps, isOpen, buttonProps, selectedDate, focusedDate } = useCalendar({
             label: 'Calendar',
-            modelValue: currentDate,
+            modelValue: currentDate.toDate(),
+            timeZone: 'UTC',
             minDate,
             maxDate,
           });
 
           return {
-            pickerProps,
+            calendarProps,
             isOpen,
             buttonProps,
             selectedDate,
@@ -727,7 +727,7 @@ describe('useCalendar', () => {
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
               <div>{{ focusedDate?.toString() }}</div>
             </div>
           </div>
@@ -753,13 +753,14 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps, focusedDate } = useCalendar({
+          const { calendarProps, isOpen, buttonProps, focusedDate } = useCalendar({
             label: 'Calendar',
-            modelValue: currentDate,
+            modelValue: currentDate.toDate(),
+            timeZone: 'UTC',
           });
 
           return {
-            pickerProps,
+            calendarProps,
             isOpen,
             buttonProps,
             focusedDate,
@@ -768,7 +769,7 @@ describe('useCalendar', () => {
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
               <div>{{ focusedDate?.toString() }}</div>
             </div>
           </div>
@@ -807,13 +808,14 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps, focusedDate, gridLabelProps } = useCalendar({
+          const { calendarProps, isOpen, buttonProps, focusedDate, gridLabelProps } = useCalendar({
             label: 'Calendar',
-            modelValue: currentDate,
+            modelValue: currentDate.toDate(),
+            timeZone: 'UTC',
           });
 
           return {
-            pickerProps,
+            calendarProps,
             isOpen,
             buttonProps,
             focusedDate,
@@ -823,7 +825,7 @@ describe('useCalendar', () => {
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
               <div v-bind="gridLabelProps" data-testid="panel-label">Month Panel</div>
               <div>{{ focusedDate?.toString() }}</div>
             </div>
@@ -853,13 +855,14 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps, focusedDate, gridLabelProps } = useCalendar({
+          const { calendarProps, isOpen, buttonProps, focusedDate, gridLabelProps } = useCalendar({
             label: 'Calendar',
-            modelValue: currentDate,
+            modelValue: currentDate.toDate(),
+            timeZone: 'UTC',
           });
 
           return {
-            pickerProps,
+            calendarProps,
             isOpen,
             buttonProps,
             focusedDate,
@@ -869,7 +872,7 @@ describe('useCalendar', () => {
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
-            <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
+            <div v-if="isOpen" v-bind="calendarProps" data-testid="calendar">
               <div v-bind="gridLabelProps" data-testid="panel-label">Month Panel</div>
               <div>{{ focusedDate?.toString() }}</div>
             </div>

--- a/packages/core/src/useCalendar/useCalendar.spec.ts
+++ b/packages/core/src/useCalendar/useCalendar.spec.ts
@@ -712,8 +712,8 @@ describe('useCalendar', () => {
             label: 'Calendar',
             modelValue: currentDate.toDate(),
             timeZone: 'UTC',
-            minDate,
-            maxDate,
+            min: minDate.toDate(),
+            max: maxDate.toDate(),
           });
 
           return {

--- a/packages/core/src/useCalendar/useCalendar.spec.ts
+++ b/packages/core/src/useCalendar/useCalendar.spec.ts
@@ -9,32 +9,26 @@ describe('useCalendar', () => {
     test('calendar should not have accessibility violations', async () => {
       await render({
         setup() {
-          const {
-            pickerProps,
-            panelGridProps,
-            buttonProps,
-            panelLabelProps,
-            nextPanelButtonProps,
-            previousPanelButtonProps,
-          } = useCalendar();
+          const { pickerProps, gridProps, buttonProps, gridLabelProps, nextButtonProps, previousButtonProps } =
+            useCalendar();
 
           return {
             pickerProps,
-            panelGridProps,
+            gridProps,
             buttonProps,
-            panelLabelProps,
-            nextPanelButtonProps,
-            previousPanelButtonProps,
+            gridLabelProps,
+            nextButtonProps,
+            previousButtonProps,
           };
         },
         template: `
           <div data-testid="fixture">
             <div v-bind="pickerProps">
               <button v-bind="buttonProps">Open Calendar</button>
-              <div v-bind="panelLabelProps">Month Year</div>
-              <button v-bind="previousPanelButtonProps">Previous</button>
-              <button v-bind="nextPanelButtonProps">Next</button>
-              <div v-bind="panelGridProps">
+              <div v-bind="gridLabelProps">Month Year</div>
+              <button v-bind="previousButtonProps">Previous</button>
+              <button v-bind="nextButtonProps">Next</button>
+              <div v-bind="gridProps">
                 <!-- Calendar grid content would go here -->
               </div>
             </div>
@@ -103,20 +97,20 @@ describe('useCalendar', () => {
     test('closes calendar when Tab is pressed', async () => {
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps, panelGridProps } = useCalendar();
+          const { pickerProps, isOpen, buttonProps, gridProps } = useCalendar();
 
           return {
             pickerProps,
             isOpen,
             buttonProps,
-            panelGridProps,
+            gridProps,
           };
         },
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
             <div v-if="isOpen" v-bind="pickerProps">
-              <span v-bind="panelGridProps" tabindex="0">Calendar Content</span>
+              <span v-bind="gridProps" tabindex="0">Calendar Content</span>
             </div>
           </div>
         `,
@@ -245,7 +239,7 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { pickerProps, buttonProps, isOpen, focusedDate, panelLabelProps, currentPanel } = useCalendar({
+          const { pickerProps, buttonProps, isOpen, focusedDate, gridLabelProps, currentPanel } = useCalendar({
             onDaySelected,
             currentDate,
           });
@@ -255,14 +249,14 @@ describe('useCalendar', () => {
             buttonProps,
             isOpen,
             focusedDate,
-            panelLabelProps,
+            gridLabelProps,
             currentPanel,
           };
         },
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
-            <div v-bind="panelLabelProps" data-testid="panel-label">{{ currentPanel.type }}</div>
+            <div v-bind="gridLabelProps" data-testid="panel-label">{{ currentPanel.type }}</div>
             <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
               <div>{{ focusedDate?.toString() }}</div>
             </div>
@@ -283,13 +277,13 @@ describe('useCalendar', () => {
       // Switch to month panel
       await fireEvent.click(panelLabel);
       await fireEvent.keyDown(calendar, { code: 'Enter' });
-      expect(screen.getByTestId('panel-label')).toHaveTextContent('day'); // Should switch back to day panel
+      expect(screen.getByTestId('panel-label')).toHaveTextContent('weeks'); // Should switch back to day panel
 
       // Switch to year panel
       await fireEvent.click(panelLabel);
       await fireEvent.click(panelLabel);
       await fireEvent.keyDown(calendar, { code: 'Enter' });
-      expect(screen.getByTestId('panel-label')).toHaveTextContent('month'); // Should switch back to month panel
+      expect(screen.getByTestId('panel-label')).toHaveTextContent('months'); // Should switch back to month panel
     });
   });
 
@@ -297,29 +291,29 @@ describe('useCalendar', () => {
     test('switches between day, month, and year panels', async () => {
       await render({
         setup() {
-          const { panelLabelProps, currentPanel } = useCalendar();
+          const { gridLabelProps, currentPanel } = useCalendar();
 
           return {
-            panelLabelProps,
+            gridLabelProps,
             currentPanel,
           };
         },
         template: `
           <div data-testid="fixture">
-            <div v-bind="panelLabelProps" data-testid="panel-label">{{ currentPanel.type }}</div>
+            <div v-bind="gridLabelProps" data-testid="panel-label">{{ currentPanel.type }}</div>
           </div>
         `,
       });
 
       await flush();
       const panelLabel = screen.getByTestId('panel-label');
-      expect(panelLabel).toHaveTextContent('day');
+      expect(panelLabel).toHaveTextContent('weeks');
 
       await fireEvent.click(panelLabel);
-      expect(panelLabel).toHaveTextContent('month');
+      expect(panelLabel).toHaveTextContent('months');
 
       await fireEvent.click(panelLabel);
-      expect(panelLabel).toHaveTextContent('year');
+      expect(panelLabel).toHaveTextContent('years');
     });
 
     test('navigates to next/previous panels', async () => {
@@ -327,27 +321,27 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { nextPanelButtonProps, previousPanelButtonProps, currentPanel } = useCalendar({
+          const { nextButtonProps, previousButtonProps, currentPanel } = useCalendar({
             onDaySelected,
           });
 
           return {
-            nextPanelButtonProps,
-            previousPanelButtonProps,
+            nextButtonProps,
+            previousButtonProps,
             currentPanel,
           };
         },
         template: `
           <div data-testid="fixture">
-            <button v-bind="previousPanelButtonProps">Previous</button>
+            <button v-bind="previousButtonProps">Previous</button>
             <div data-testid="panel-type">{{ currentPanel.type }}</div>
-            <button v-bind="nextPanelButtonProps">Next</button>
+            <button v-bind="nextButtonProps">Next</button>
           </div>
         `,
       });
 
       await flush();
-      expect(screen.getByTestId('panel-type')).toHaveTextContent('day');
+      expect(screen.getByTestId('panel-type')).toHaveTextContent('weeks');
 
       // Test navigation buttons
       await fireEvent.click(screen.getByText('Next'));
@@ -360,9 +354,9 @@ describe('useCalendar', () => {
       await render({
         setup() {
           const {
-            nextPanelButtonProps,
-            previousPanelButtonProps,
-            panelLabelProps,
+            nextButtonProps,
+            previousButtonProps,
+            gridLabelProps,
             focusedDate,
             pickerProps,
             isOpen,
@@ -372,9 +366,9 @@ describe('useCalendar', () => {
           });
 
           return {
-            nextPanelButtonProps,
-            previousPanelButtonProps,
-            panelLabelProps,
+            nextButtonProps,
+            previousButtonProps,
+            gridLabelProps,
             focusedDate,
             pickerProps,
             isOpen,
@@ -385,9 +379,9 @@ describe('useCalendar', () => {
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
             <div v-if="isOpen" v-bind="pickerProps">
-              <div v-bind="panelLabelProps" data-testid="panel-label">Month Panel</div>
-              <button v-bind="previousPanelButtonProps">Previous</button>
-              <button v-bind="nextPanelButtonProps">Next</button>
+              <div v-bind="gridLabelProps" data-testid="panel-label">Month Panel</div>
+              <button v-bind="previousButtonProps">Previous</button>
+              <button v-bind="nextButtonProps">Next</button>
               <div>{{ focusedDate?.toString() }}</div>
             </div>
           </div>
@@ -424,9 +418,9 @@ describe('useCalendar', () => {
       await render({
         setup() {
           const {
-            nextPanelButtonProps,
-            previousPanelButtonProps,
-            panelLabelProps,
+            nextButtonProps,
+            previousButtonProps,
+            gridLabelProps,
             focusedDate,
             pickerProps,
             isOpen,
@@ -436,9 +430,9 @@ describe('useCalendar', () => {
           });
 
           return {
-            nextPanelButtonProps,
-            previousPanelButtonProps,
-            panelLabelProps,
+            nextButtonProps,
+            previousButtonProps,
+            gridLabelProps,
             focusedDate,
             pickerProps,
             isOpen,
@@ -449,9 +443,9 @@ describe('useCalendar', () => {
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
             <div v-if="isOpen" v-bind="pickerProps">
-              <div v-bind="panelLabelProps" data-testid="panel-label">Year Panel</div>
-              <button v-bind="previousPanelButtonProps">Previous</button>
-              <button v-bind="nextPanelButtonProps">Next</button>
+              <div v-bind="gridLabelProps" data-testid="panel-label">Year Panel</div>
+              <button v-bind="previousButtonProps">Previous</button>
+              <button v-bind="nextButtonProps">Next</button>
               <div>{{ focusedDate?.toString() }}</div>
             </div>
           </div>
@@ -560,7 +554,7 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate, panelLabelProps } = useCalendar({
+          const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate, gridLabelProps } = useCalendar({
             currentDate,
           });
 
@@ -570,14 +564,14 @@ describe('useCalendar', () => {
             buttonProps,
             selectedDate,
             focusedDate,
-            panelLabelProps,
+            gridLabelProps,
           };
         },
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
             <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
-              <div v-bind="panelLabelProps" data-testid="panel-label">Month Panel</div>
+              <div v-bind="gridLabelProps" data-testid="panel-label">Month Panel</div>
               <div>{{ focusedDate?.toString() }}</div>
             </div>
           </div>
@@ -632,7 +626,7 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate, panelLabelProps } = useCalendar({
+          const { pickerProps, isOpen, buttonProps, selectedDate, focusedDate, gridLabelProps } = useCalendar({
             currentDate,
           });
 
@@ -642,14 +636,14 @@ describe('useCalendar', () => {
             buttonProps,
             selectedDate,
             focusedDate,
-            panelLabelProps,
+            gridLabelProps,
           };
         },
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
             <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
-              <div v-bind="panelLabelProps" data-testid="panel-label">Year Panel</div>
+              <div v-bind="gridLabelProps" data-testid="panel-label">Year Panel</div>
               <div>{{ focusedDate?.toString() }}</div>
             </div>
           </div>
@@ -801,7 +795,7 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps, focusedDate, panelLabelProps } = useCalendar({
+          const { pickerProps, isOpen, buttonProps, focusedDate, gridLabelProps } = useCalendar({
             currentDate,
           });
 
@@ -810,14 +804,14 @@ describe('useCalendar', () => {
             isOpen,
             buttonProps,
             focusedDate,
-            panelLabelProps,
+            gridLabelProps,
           };
         },
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
             <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
-              <div v-bind="panelLabelProps" data-testid="panel-label">Month Panel</div>
+              <div v-bind="gridLabelProps" data-testid="panel-label">Month Panel</div>
               <div>{{ focusedDate?.toString() }}</div>
             </div>
           </div>
@@ -846,7 +840,7 @@ describe('useCalendar', () => {
 
       await render({
         setup() {
-          const { pickerProps, isOpen, buttonProps, focusedDate, panelLabelProps } = useCalendar({
+          const { pickerProps, isOpen, buttonProps, focusedDate, gridLabelProps } = useCalendar({
             currentDate,
           });
 
@@ -855,14 +849,14 @@ describe('useCalendar', () => {
             isOpen,
             buttonProps,
             focusedDate,
-            panelLabelProps,
+            gridLabelProps,
           };
         },
         template: `
           <div data-testid="fixture">
             <button v-bind="buttonProps">Open Calendar</button>
             <div v-if="isOpen" v-bind="pickerProps" data-testid="calendar">
-              <div v-bind="panelLabelProps" data-testid="panel-label">Month Panel</div>
+              <div v-bind="gridLabelProps" data-testid="panel-label">Month Panel</div>
               <div>{{ focusedDate?.toString() }}</div>
             </div>
           </div>

--- a/packages/core/src/useCalendar/useCalendar.spec.ts
+++ b/packages/core/src/useCalendar/useCalendar.spec.ts
@@ -639,4 +639,164 @@ describe('useCalendar', () => {
       expect(screen.getByText(maxDate.toString())).toBeInTheDocument();
     });
   });
+
+  describe('disabled state', () => {
+    test('prevents all interactions when disabled', async () => {
+      const currentDate = now('UTC');
+
+      await render({
+        components: {
+          CalendarCell,
+        },
+        setup() {
+          const { calendarProps, gridLabelProps, nextButtonProps, previousButtonProps, focusedDate, currentView } =
+            useCalendar({
+              label: 'Calendar',
+              modelValue: currentDate.toDate(),
+              timeZone: 'UTC',
+              disabled: true,
+            });
+
+          return {
+            calendarProps,
+            gridLabelProps,
+            nextButtonProps,
+            previousButtonProps,
+            focusedDate,
+            currentView,
+            currentDate,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <div v-bind="calendarProps" data-testid="calendar">
+              <div v-bind="gridLabelProps" data-testid="panel-label">{{ currentView.type }}</div>
+              <button v-bind="previousButtonProps">Previous</button>
+              <button v-bind="nextButtonProps">Next</button>
+              <CalendarCell
+                label="Select Date"
+                type="day"
+                :value="currentDate"
+                data-testid="calendar-cell"
+              />
+              <div>{{ focusedDate?.toString() }}</div>
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+
+      // Verify navigation buttons are disabled
+      expect(screen.getByText('Previous')).toBeDisabled();
+      expect(screen.getByText('Next')).toBeDisabled();
+
+      // Try to click navigation buttons
+      await fireEvent.click(screen.getByText('Previous'));
+      await fireEvent.click(screen.getByText('Next'));
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+
+      // Try to change panel view
+      await fireEvent.click(screen.getByTestId('panel-label'));
+      expect(screen.getByTestId('panel-label')).toHaveTextContent('weeks');
+
+      // Try keyboard navigation
+      const calendar = screen.getByTestId('calendar');
+      await fireEvent.keyDown(calendar, { code: 'ArrowRight' });
+      await fireEvent.keyDown(calendar, { code: 'ArrowLeft' });
+      await fireEvent.keyDown(calendar, { code: 'ArrowUp' });
+      await fireEvent.keyDown(calendar, { code: 'ArrowDown' });
+      await fireEvent.keyDown(calendar, { code: 'PageUp' });
+      await fireEvent.keyDown(calendar, { code: 'PageDown' });
+      await fireEvent.keyDown(calendar, { code: 'Home' });
+      await fireEvent.keyDown(calendar, { code: 'End' });
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+
+      // Try to select a date
+      const cell = screen.getByTestId('calendar-cell');
+      await fireEvent.click(cell);
+      await fireEvent.keyDown(cell, { code: 'Enter' });
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+    });
+  });
+
+  describe('readonly state', () => {
+    test('prevents all interactions when readonly', async () => {
+      const currentDate = now('UTC');
+
+      await render({
+        components: {
+          CalendarCell,
+        },
+        setup() {
+          const { calendarProps, gridLabelProps, nextButtonProps, previousButtonProps, focusedDate, currentView } =
+            useCalendar({
+              label: 'Calendar',
+              modelValue: currentDate.toDate(),
+              timeZone: 'UTC',
+              readonly: true,
+            });
+
+          return {
+            calendarProps,
+            gridLabelProps,
+            nextButtonProps,
+            previousButtonProps,
+            focusedDate,
+            currentView,
+            currentDate,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <div v-bind="calendarProps" data-testid="calendar">
+              <div v-bind="gridLabelProps" data-testid="panel-label">{{ currentView.type }}</div>
+              <button v-bind="previousButtonProps">Previous</button>
+              <button v-bind="nextButtonProps">Next</button>
+              <CalendarCell
+                label="Select Date"
+                type="day"
+                :value="currentDate"
+                data-testid="calendar-cell"
+              />
+              <div>{{ focusedDate?.toString() }}</div>
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+
+      // Verify navigation buttons are disabled
+      expect(screen.getByText('Previous')).toBeDisabled();
+      expect(screen.getByText('Next')).toBeDisabled();
+
+      // Try to click navigation buttons
+      await fireEvent.click(screen.getByText('Previous'));
+      await fireEvent.click(screen.getByText('Next'));
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+
+      // Try to change panel view
+      await fireEvent.click(screen.getByTestId('panel-label'));
+      expect(screen.getByTestId('panel-label')).toHaveTextContent('weeks');
+
+      // Try keyboard navigation
+      const calendar = screen.getByTestId('calendar');
+      await fireEvent.keyDown(calendar, { code: 'ArrowRight' });
+      await fireEvent.keyDown(calendar, { code: 'ArrowLeft' });
+      await fireEvent.keyDown(calendar, { code: 'ArrowUp' });
+      await fireEvent.keyDown(calendar, { code: 'ArrowDown' });
+      await fireEvent.keyDown(calendar, { code: 'PageUp' });
+      await fireEvent.keyDown(calendar, { code: 'PageDown' });
+      await fireEvent.keyDown(calendar, { code: 'Home' });
+      await fireEvent.keyDown(calendar, { code: 'End' });
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+
+      // Try to select a date
+      const cell = screen.getByTestId('calendar-cell');
+      await fireEvent.click(cell);
+      await fireEvent.keyDown(cell, { code: 'Enter' });
+      expect(screen.getByText(currentDate.toString())).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -14,7 +14,8 @@ import { Calendar, ZonedDateTime, now, toCalendar } from '@internationalized/dat
 import { createDisabledContext } from '../helpers/createDisabledContext';
 import { exposeField, FormField, useFormField } from '../useFormField';
 import { useInputValidity } from '../validation';
-import { useTemporalStore } from '../useDateTimeField/useTemporalStore';
+import { fromDateToCalendarZonedDateTime, useTemporalStore } from '../useDateTimeField/useTemporalStore';
+import { isTemporalPartial } from '../useDateTimeField/temporalPartial';
 
 export interface CalendarProps {
   /**
@@ -75,12 +76,12 @@ export interface CalendarProps {
   /**
    * The minimum date to use for the calendar.
    */
-  minDate?: Maybe<ZonedDateTime>;
+  min?: Maybe<Date>;
 
   /**
    * The maximum date to use for the calendar.
    */
-  maxDate?: Maybe<ZonedDateTime>;
+  max?: Maybe<Date>;
 
   /**
    * The format option for the days of the week.
@@ -161,6 +162,9 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'field' | 'schema'
     return selectedDate.value;
   }
 
+  const min = computed(() => fromDateToCalendarZonedDateTime(toValue(props.min), calendar.value, timeZone.value));
+  const max = computed(() => fromDateToCalendarZonedDateTime(toValue(props.max), calendar.value, timeZone.value));
+
   const context: CalendarContext = {
     weekInfo,
     locale,
@@ -174,8 +178,8 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'field' | 'schema'
       await nextTick();
       focusCurrent();
     },
-    getMinDate: () => toValue(props.minDate),
-    getMaxDate: () => toValue(props.maxDate),
+    getMinDate: () => (isTemporalPartial(min.value) ? undefined : min.value),
+    getMaxDate: () => (isTemporalPartial(max.value) ? undefined : max.value),
   };
 
   provide(CalendarContextKey, context);

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -260,7 +260,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     const panelType = currentPanel.value.type;
     const columns =
       panelType === 'day'
-        ? currentPanel.value.daysOfTheWeek.length
+        ? currentPanel.value.weekDays.length
         : panelType === 'month'
           ? MONTHS_COLUMNS_COUNT
           : YEARS_COLUMNS_COUNT;

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -237,7 +237,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'field' | 'schema'
   watch(
     () => pickerContext?.isOpen(),
     async value => {
-      if (!value) {
+      if (pickerContext && !value) {
         focusedDay.value = undefined;
         setView('weeks');
         return;

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -174,6 +174,10 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'field' | 'schema'
     getFocusedDate: getFocusedOrSelected,
     setDate,
     setFocusedDate: async (date: ZonedDateTime) => {
+      if (isDisabled.value || toValue(props.readonly)) {
+        return;
+      }
+
       focusedDay.value = date;
       await nextTick();
       focusCurrent();
@@ -198,6 +202,10 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'field' | 'schema'
   );
 
   function setDate(date: ZonedDateTime, view?: CalendarViewType) {
+    if (isDisabled.value || toValue(props.readonly)) {
+      return;
+    }
+
     temporalValue.value = date;
     focusedDay.value = date;
     if (view) {
@@ -270,7 +278,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'field' | 'schema'
   const nextButtonProps = useControlButtonProps(() => ({
     id: `${calendarId}-next`,
     'aria-label': 'Next',
-    disabled: isDisabled.value,
+    disabled: isDisabled.value || toValue(props.readonly),
     onClick: () => {
       if (currentView.value.type === 'weeks') {
         context.setFocusedDate(context.getFocusedDate().add({ months: 1 }));
@@ -289,7 +297,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'field' | 'schema'
   const previousButtonProps = useControlButtonProps(() => ({
     id: `${calendarId}-previous`,
     'aria-label': 'Previous',
-    disabled: isDisabled.value,
+    disabled: isDisabled.value || toValue(props.readonly),
     onClick: () => {
       if (currentView.value.type === 'weeks') {
         context.setFocusedDate(context.getFocusedDate().subtract({ months: 1 }));
@@ -322,7 +330,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'field' | 'schema'
         'aria-live': 'polite' as const,
         tabindex: '-1',
         onClick: () => {
-          if (isDisabled.value) {
+          if (isDisabled.value || toValue(props.readonly)) {
             return;
           }
 

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -31,7 +31,7 @@ export interface CalendarProps {
 interface CalendarContext {
   locale: Ref<string>;
   weekInfo: Ref<WeekInfo>;
-  calendar: Ref<Temporal.Calendar>;
+  calendar: Ref<CalendarIdentifier>;
   currentDate: MaybeRefOrGetter<Temporal.PlainDate | Temporal.PlainDateTime>;
   setDay: (date: Temporal.PlainDate) => void;
 }

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -15,12 +15,12 @@ export interface CalendarProps {
   /**
    * The current date to use for the calendar.
    */
-  currentDate?: Temporal.PlainDate | Temporal.PlainDateTime;
+  currentDate?: Temporal.ZonedDateTime;
 
   /**
    * The callback to call when a day is selected.
    */
-  onDaySelected?: (day: Temporal.PlainDate) => void;
+  onDaySelected?: (day: Temporal.ZonedDateTime) => void;
 
   /**
    * The calendar type to use for the calendar, e.g. `gregory`, `islamic-umalqura`, etc.
@@ -32,8 +32,8 @@ interface CalendarContext {
   locale: Ref<string>;
   weekInfo: Ref<WeekInfo>;
   calendar: Ref<CalendarIdentifier>;
-  currentDate: MaybeRefOrGetter<Temporal.PlainDate | Temporal.PlainDateTime>;
-  setDay: (date: Temporal.PlainDate) => void;
+  currentDate: MaybeRefOrGetter<Temporal.ZonedDateTime>;
+  setDay: (date: Temporal.ZonedDateTime) => void;
 }
 
 export const CalendarContextKey: InjectionKey<CalendarContext> = Symbol('CalendarContext');
@@ -44,14 +44,14 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     calendar: () => toValue(props.calendar),
   });
 
-  const currentDate = computed(() => toValue(props.currentDate) ?? Temporal.Now.plainDate(calendar.value));
+  const currentDate = computed(() => toValue(props.currentDate) ?? Temporal.Now.zonedDateTime(calendar.value));
 
   const context: CalendarContext = {
     weekInfo,
     locale,
     calendar,
     currentDate,
-    setDay: (date: Temporal.PlainDate) => {
+    setDay: (date: Temporal.ZonedDateTime) => {
       props.onDaySelected?.(date);
     },
   };
@@ -93,9 +93,9 @@ function useDaysOfTheWeek({ weekInfo, locale, currentDate }: CalendarContext) {
     }[] = [];
     for (let i = 0; i < daysPerWeek; i++) {
       days.push({
-        long: longFormatter.value.format(current.add({ days: i })),
-        short: shortFormatter.value.format(current.add({ days: i })),
-        narrow: narrowFormatter.value.format(current.add({ days: i })),
+        long: longFormatter.value.format(current.add({ days: i }).toPlainDateTime()),
+        short: shortFormatter.value.format(current.add({ days: i }).toPlainDateTime()),
+        narrow: narrowFormatter.value.format(current.add({ days: i }).toPlainDateTime()),
       });
     }
 
@@ -122,7 +122,7 @@ function useCalendarDays({ weekInfo, currentDate, calendar }: CalendarContext) {
     const totalDays = daysInMonth + daysToSubtract;
     const remainingDays = 7 - (totalDays % 7);
     const gridDays = totalDays + (remainingDays === 7 ? 0 : remainingDays);
-    const now = Temporal.Now.plainDate(calendar.value);
+    const now = Temporal.Now.zonedDateTime(calendar.value);
 
     return Array.from({ length: gridDays }, (_, i) => {
       const dayOfMonth = firstDay.add({ days: i });

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -10,7 +10,7 @@ import { useLabel } from '../a11y';
 import { useControlButtonProps } from '../helpers/useControlButtonProps';
 import { CalendarContextKey, MONTHS_COLUMNS_COUNT, YEAR_CELLS_COUNT, YEARS_COLUMNS_COUNT } from './constants';
 import { CalendarPanel, useCalendarPanel } from './useCalendarPanel';
-import { Calendar, ZonedDateTime, fromDate, now } from '@internationalized/date';
+import { Calendar, ZonedDateTime, now, toCalendar } from '@internationalized/date';
 
 export interface CalendarProps {
   /**
@@ -85,7 +85,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     calendar: () => toValue(props.calendar),
   });
 
-  const selectedDate = computed(() => toValue(props.currentDate) ?? now(toValue(timeZone)));
+  const selectedDate = computed(() => toValue(props.currentDate) ?? toCalendar(now(toValue(timeZone)), calendar.value));
   const focusedDay = shallowRef<ZonedDateTime>();
   const { isOpen } = usePopoverController(pickerEl, { disabled: props.disabled });
 
@@ -101,6 +101,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     weekInfo,
     locale,
     calendar,
+    timeZone,
     getSelectedDate: () => selectedDate.value,
     getFocusedDate: getFocusedOrSelected,
     setDate: (date: ZonedDateTime, panel?: CalendarPanelType) => {
@@ -175,7 +176,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     }
 
     if (!focusedDay.value) {
-      focusedDay.value = fromDate(selectedDate.value.toDate(), selectedDate.value.timeZone);
+      focusedDay.value = selectedDate.value.copy();
     }
 
     await nextTick();

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -148,7 +148,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
         return;
       }
 
-      if (e.key === 'Escape') {
+      if (hasKeyCode(e, 'Escape')) {
         isOpen.value = false;
         return;
       }
@@ -299,6 +299,10 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
      * The current date.
      */
     selectedDate,
+    /**
+     * The focused date.
+     */
+    focusedDate: focusedDay,
     /**
      * The current panel.
      */
@@ -469,11 +473,6 @@ export function useCalendarKeyboard(context: CalendarContext, currentPanel: Ref<
           return current.set({ month: current.calendar.getMonthsInYear(current) });
         }
 
-        const selected = context.getSelectedDate();
-        if (selected.year !== current.year) {
-          return selected.set({ year: current.year });
-        }
-
         return current.set({ year: current.year + YEAR_CELLS_COUNT });
       },
     },
@@ -492,7 +491,7 @@ export function useCalendarKeyboard(context: CalendarContext, currentPanel: Ref<
   };
 
   function handleKeyDown(e: KeyboardEvent): boolean {
-    const shortcut = shortcuts[e.key];
+    const shortcut = shortcuts[e.code];
     if (!shortcut) {
       return false;
     }
@@ -505,7 +504,8 @@ export function useCalendarKeyboard(context: CalendarContext, currentPanel: Ref<
     if (shortcut.type === 'focus') {
       context.setFocusedDate(newDate);
     } else {
-      context.setDate(newDate);
+      const panelType = currentPanel.value.type;
+      context.setDate(newDate, panelType === 'year' ? 'month' : panelType === 'month' ? 'day' : undefined);
     }
 
     return true;

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -115,10 +115,11 @@ export interface CalendarProps {
 
 export function useCalendar(_props: Reactivify<CalendarProps, 'field' | 'schema'>) {
   const props = normalizeProps(_props, ['field', 'schema']);
-  const { weekInfo, locale, calendar, timeZone } = useLocale(props.locale, {
+  const { weekInfo, locale, calendar, timeZone, direction } = useLocale(props.locale, {
     calendar: () => toValue(props.calendar),
     timeZone: () => toValue(props.timeZone),
   });
+
   const pickerContext = inject(PickerContextKey, null);
   const calendarId = useUniqId(FieldTypePrefixes.Calendar);
   const gridId = `${calendarId}-g`;
@@ -260,6 +261,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'field' | 'schema'
         id: calendarId,
         ...pickerHandlers,
         role: 'application',
+        dir: direction.value,
       },
       calendarEl,
     );

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -198,6 +198,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'field' | 'schema'
 
   function setDate(date: ZonedDateTime, view?: CalendarViewType) {
     temporalValue.value = date;
+    focusedDay.value = date;
     if (view) {
       setView(view);
     } else if (currentView.value.type === 'weeks') {

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -14,6 +14,16 @@ import { Calendar, ZonedDateTime, now, toCalendar } from '@internationalized/dat
 
 export interface CalendarProps {
   /**
+   * The field name of the calendar.
+   */
+  name?: string;
+
+  /**
+   * The label for the calendar.
+   */
+  label: string;
+
+  /**
    * The locale to use for the calendar.
    */
   locale?: string;
@@ -21,12 +31,12 @@ export interface CalendarProps {
   /**
    * The current date to use for the calendar.
    */
-  currentDate?: ZonedDateTime;
+  modelValue?: ZonedDateTime;
 
   /**
-   * The callback to call when a day is selected.
+   * The initial value to use for the calendar.
    */
-  onDaySelected?: (day: ZonedDateTime) => void;
+  value?: ZonedDateTime;
 
   /**
    * The calendar type to use for the calendar, e.g. `gregory`, `islamic-umalqura`, etc.
@@ -77,10 +87,15 @@ export interface CalendarProps {
    * The available panels to switch to and from in the calendar.
    */
   allowedPanels?: CalendarPanelType[];
+
+  /**
+   * The callback to call when the calendar value is updated.
+   */
+  onUpdateModelValue?: (value: ZonedDateTime) => void;
 }
 
-export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> = {}) {
-  const props = normalizeProps(_props, ['onDaySelected']);
+export function useCalendar(_props: Reactivify<CalendarProps, 'onUpdateModelValue'>) {
+  const props = normalizeProps(_props, ['onUpdateModelValue']);
   const calendarId = useUniqId(FieldTypePrefixes.Calendar);
   const gridId = `${calendarId}-g`;
   const pickerEl = ref<HTMLElement>();
@@ -90,7 +105,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     calendar: () => toValue(props.calendar),
   });
 
-  const selectedDate = computed(() => toValue(props.currentDate) ?? toCalendar(now(toValue(timeZone)), calendar.value));
+  const selectedDate = computed(() => toValue(props.modelValue) ?? toCalendar(now(toValue(timeZone)), calendar.value));
   const focusedDay = shallowRef<ZonedDateTime>();
   const { isOpen } = usePopoverController(pickerEl, { disabled: props.disabled });
 
@@ -110,7 +125,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     getSelectedDate: () => selectedDate.value,
     getFocusedDate: getFocusedOrSelected,
     setDate: (date: ZonedDateTime, panel?: CalendarPanelType) => {
-      props.onDaySelected?.(date);
+      props.onUpdateModelValue?.(date);
       if (panel) {
         switchPanel(panel);
       } else if (currentPanel.value.type === 'weeks') {

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -15,7 +15,6 @@ import { createDisabledContext } from '../helpers/createDisabledContext';
 import { exposeField, FormField, useFormField } from '../useFormField';
 import { useInputValidity } from '../validation';
 import { fromDateToCalendarZonedDateTime, useTemporalStore } from '../useDateTimeField/useTemporalStore';
-import { isTemporalPartial } from '../useDateTimeField/temporalPartial';
 
 export interface CalendarProps {
   /**
@@ -178,8 +177,8 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'field' | 'schema'
       await nextTick();
       focusCurrent();
     },
-    getMinDate: () => (isTemporalPartial(min.value) ? undefined : min.value),
-    getMaxDate: () => (isTemporalPartial(max.value) ? undefined : max.value),
+    getMinDate: () => min.value,
+    getMaxDate: () => max.value,
   };
 
   provide(CalendarContextKey, context);

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -112,11 +112,11 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
   const { daysOfTheWeek } = useDaysOfTheWeek(context);
   const { days } = useCalendarDays(context);
 
-  const buttonProps = useControlButtonProps({
+  const buttonProps = useControlButtonProps(() => ({
     onClick: () => {
       isOpen.value = true;
     },
-  });
+  }));
 
   const pickerHandlers = {
     onKeydown(e: KeyboardEvent) {
@@ -170,19 +170,19 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     );
   });
 
-  const nextMonthButtonProps = useControlButtonProps({
+  const nextMonthButtonProps = useControlButtonProps(() => ({
     id: `${calendarId}-next-month`,
     onClick: () => {
       context.setFocusedDay(context.getFocusedDate().add({ months: 1 }));
     },
-  });
+  }));
 
-  const previousMonthButtonProps = useControlButtonProps({
+  const previousMonthButtonProps = useControlButtonProps(() => ({
     id: `${calendarId}-previous-month`,
     onClick: () => {
       context.setFocusedDay(context.getFocusedDate().subtract({ months: 1 }));
     },
-  });
+  }));
 
   const monthYearLabel = computed(() => {
     return formatter.value.format(context.getFocusedDate().toPlainDateTime());

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -192,17 +192,37 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     );
   });
 
-  const nextMonthButtonProps = useControlButtonProps(() => ({
-    id: `${calendarId}-next-month`,
+  const nextPanelButtonProps = useControlButtonProps(() => ({
+    id: `${calendarId}-next`,
     onClick: () => {
-      context.setFocusedDate(context.getFocusedDate().add({ months: 1 }));
+      if (currentPanel.value.type === 'day') {
+        context.setFocusedDate(context.getFocusedDate().add({ months: 1 }));
+        return;
+      }
+
+      if (currentPanel.value.type === 'month') {
+        context.setFocusedDate(context.getFocusedDate().add({ years: 1 }));
+        return;
+      }
+
+      context.setFocusedDate(currentPanel.value.years[currentPanel.value.years.length - 1].value.add({ years: 1 }));
     },
   }));
 
-  const previousMonthButtonProps = useControlButtonProps(() => ({
-    id: `${calendarId}-previous-month`,
+  const previousPanelButtonProps = useControlButtonProps(() => ({
+    id: `${calendarId}-previous`,
     onClick: () => {
-      context.setFocusedDate(context.getFocusedDate().subtract({ months: 1 }));
+      if (currentPanel.value.type === 'day') {
+        context.setFocusedDate(context.getFocusedDate().subtract({ months: 1 }));
+        return;
+      }
+
+      if (currentPanel.value.type === 'month') {
+        context.setFocusedDate(context.getFocusedDate().subtract({ years: 1 }));
+        return;
+      }
+
+      context.setFocusedDate(currentPanel.value.years[0].value.subtract({ years: 1 }));
     },
   }));
 
@@ -212,7 +232,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     label: panelLabel,
   });
 
-  const monthYearLabelProps = computed(() => {
+  const panelLabelProps = computed(() => {
     return withRefCapture(
       {
         ...monthYearLabelBaseProps.value,
@@ -235,7 +255,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     );
   });
 
-  const gridProps = computed(() => {
+  const panelGridProps = computed(() => {
     return withRefCapture(
       {
         id: `${calendarId}-g`,
@@ -259,9 +279,9 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
      */
     pickerProps,
     /**
-     * The props for the grid element.
+     * The props for the grid element that displays the panel values.
      */
-    gridProps,
+    panelGridProps,
     /**
      * The props for the button element.
      */
@@ -271,10 +291,6 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
      */
     selectedDate,
     /**
-     * The grid element.
-     */
-    gridEl,
-    /**
      * The current panel.
      */
     currentPanel,
@@ -283,21 +299,21 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
      */
     switchPanel,
     /**
-     * The props for the month and year label element.
+     * The props for the panel label element.
      */
-    monthYearLabelProps,
+    panelLabelProps,
     /**
-     * The props for the next month button.
+     * The props for the next panel values button. if it is a day panel, the button will move the panel to the next month. If it is a month panel, the button will move the panel to the next year. If it is a year panel, the button will move the panel to the next set of years.
      */
-    nextMonthButtonProps,
+    nextPanelButtonProps,
     /**
-     * The props for the previous month button.
+     * The props for the previous panel values button. If it is a day panel, the button will move the panel to the previous month. If it is a month panel, the button will move the panel to the previous year. If it is a year panel, the button will move the panel to the previous set of years.
      */
-    previousMonthButtonProps,
+    previousPanelButtonProps,
     /**
-     * The month and year label.
+     * The label for the current panel. If it is a day panel, the label will be the month and year. If it is a month panel, the label will be the year. If it is a year panel, the label will be the range of years currently being displayed.
      */
-    monthYearLabel: panelLabel,
+    panelLabel,
   };
 }
 

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -195,6 +195,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
 
   const nextPanelButtonProps = useControlButtonProps(() => ({
     id: `${calendarId}-next`,
+    'aria-label': 'Next',
     onClick: () => {
       if (currentPanel.value.type === 'day') {
         context.setFocusedDate(context.getFocusedDate().add({ months: 1 }));
@@ -212,6 +213,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
 
   const previousPanelButtonProps = useControlButtonProps(() => ({
     id: `${calendarId}-previous`,
+    'aria-label': 'Previous',
     onClick: () => {
       if (currentPanel.value.type === 'day') {
         context.setFocusedDate(context.getFocusedDate().subtract({ months: 1 }));
@@ -227,7 +229,7 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
     },
   }));
 
-  const { labelProps: monthYearLabelBaseProps } = useLabel({
+  const { labelProps: monthYearLabelBaseProps, labelledByProps } = useLabel({
     targetRef: gridEl,
     for: gridId,
     label: panelLabel,
@@ -267,8 +269,9 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> =
 
     return withRefCapture(
       {
-        id: `${calendarId}-g`,
+        id: gridId,
         role: 'grid',
+        ...labelledByProps.value,
         style: {
           display: 'grid',
           gridTemplateColumns: `repeat(${columns}, 1fr)`,

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -1,6 +1,6 @@
 import { computed, InjectionKey, MaybeRefOrGetter, provide, Ref, toValue } from 'vue';
 import { Temporal } from '@js-temporal/polyfill';
-import { CalendarDay } from './types';
+import { CalendarDay, CalendarIdentifier } from './types';
 import { normalizeProps } from '../utils/common';
 import { Reactivify } from '../types';
 import { useDateFormatter, useLocale } from '../i18n';
@@ -21,6 +21,11 @@ export interface CalendarProps {
    * The callback to call when a day is selected.
    */
   onDaySelected?: (day: Temporal.PlainDate) => void;
+
+  /**
+   * The calendar type to use for the calendar, e.g. `gregory`, `islamic-umalqura`, etc.
+   */
+  calendar?: CalendarIdentifier;
 }
 
 interface CalendarContext {
@@ -35,7 +40,10 @@ export const CalendarContextKey: InjectionKey<CalendarContext> = Symbol('Calenda
 
 export function useCalendar(_props: Reactivify<CalendarProps, 'onDaySelected'> = {}) {
   const props = normalizeProps(_props, ['onDaySelected']);
-  const { weekInfo, locale, calendar } = useLocale(props.locale);
+  const { weekInfo, locale, calendar } = useLocale(props.locale, {
+    calendar: () => toValue(props.calendar),
+  });
+
   const currentDate = computed(() => toValue(props.currentDate) ?? Temporal.Now.plainDate(calendar.value));
 
   const context: CalendarContext = {

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -2,7 +2,7 @@ import { computed, InjectionKey, MaybeRefOrGetter, nextTick, provide, ref, Ref, 
 import { Temporal } from '@js-temporal/polyfill';
 import { CalendarDay, CalendarIdentifier } from './types';
 import { hasKeyCode, normalizeProps, useUniqId, withRefCapture } from '../utils/common';
-import { Reactivify } from '../types';
+import { Maybe, Reactivify } from '../types';
 import { useDateFormatter, useLocale } from '../i18n';
 import { WeekInfo } from '../i18n/getWeekInfo';
 import { FieldTypePrefixes } from '../constants';
@@ -55,12 +55,12 @@ export interface CalendarProps {
   /**
    * The minimum date to use for the calendar.
    */
-  minDate?: Temporal.ZonedDateTime;
+  minDate?: Maybe<Temporal.ZonedDateTime>;
 
   /**
    * The maximum date to use for the calendar.
    */
-  maxDate?: Temporal.ZonedDateTime;
+  maxDate?: Maybe<Temporal.ZonedDateTime>;
 }
 
 interface CalendarContext {
@@ -68,8 +68,8 @@ interface CalendarContext {
   weekInfo: Ref<WeekInfo>;
   calendar: Ref<CalendarIdentifier>;
   selectedDate: MaybeRefOrGetter<Temporal.ZonedDateTime>;
-  getMinDate: () => Temporal.ZonedDateTime | undefined;
-  getMaxDate: () => Temporal.ZonedDateTime | undefined;
+  getMinDate: () => Maybe<Temporal.ZonedDateTime>;
+  getMaxDate: () => Maybe<Temporal.ZonedDateTime>;
   getFocusedDate: () => Temporal.ZonedDateTime;
   setDay: (date: Temporal.ZonedDateTime) => void;
   setFocusedDay: (date: Temporal.ZonedDateTime) => void;

--- a/packages/core/src/useCalendar/useCalendarCell.ts
+++ b/packages/core/src/useCalendar/useCalendarCell.ts
@@ -10,17 +10,24 @@ export function useCalendarCell(_props: Reactivify<CalendarDay>) {
   const calendarCtx = inject(CalendarContextKey, null);
 
   function handleClick() {
+    if (toValue(props.disabled)) {
+      return;
+    }
+
     calendarCtx?.setDay(toValue(props.value));
   }
 
   const cellProps = computed(() => {
+    const isDisabled = toValue(props.disabled);
+    const isFocused = toValue(props.focused);
+
     return withRefCapture(
       {
         key: toValue(props.value).toString(),
-        onClick: handleClick,
+        onClick: isDisabled ? undefined : handleClick,
         'aria-selected': toValue(props.selected),
-        'aria-disabled': toValue(props.disabled),
-        tabindex: toValue(props.disabled) || !toValue(props.focused) ? '-1' : '0',
+        'aria-disabled': isDisabled,
+        tabindex: isDisabled || !isFocused ? '-1' : '0',
       },
       cellEl,
     );
@@ -32,6 +39,7 @@ export function useCalendarCell(_props: Reactivify<CalendarDay>) {
 }
 
 export const CalendarCell = defineComponent({
+  name: 'CalendarCell',
   props: ['value', 'dayOfMonth', 'isToday', 'selected', 'isOutsideMonth', 'disabled', 'focused'],
   setup(props) {
     const { cellProps } = useCalendarCell(props);

--- a/packages/core/src/useCalendar/useCalendarCell.ts
+++ b/packages/core/src/useCalendar/useCalendarCell.ts
@@ -3,14 +3,16 @@ import { normalizeProps, withRefCapture } from '../utils/common';
 import { computed, defineComponent, h, inject, shallowRef, toValue } from 'vue';
 import { CalendarCellProps, CalendarViewType } from './types';
 import { CalendarContextKey } from './constants';
+import { createDisabledContext } from '../helpers/createDisabledContext';
 
 export function useCalendarCell(_props: Reactivify<CalendarCellProps>) {
   const props = normalizeProps(_props);
   const cellEl = shallowRef<HTMLElement>();
   const calendarCtx = inject(CalendarContextKey, null);
+  const isDisabled = createDisabledContext(props.disabled);
 
   function handleClick() {
-    if (toValue(props.disabled)) {
+    if (isDisabled.value) {
       return;
     }
 
@@ -20,16 +22,15 @@ export function useCalendarCell(_props: Reactivify<CalendarCellProps>) {
   }
 
   const cellProps = computed(() => {
-    const isDisabled = toValue(props.disabled);
     const isFocused = toValue(props.focused);
 
     return withRefCapture(
       {
         key: toValue(props.value).toString(),
-        onClick: isDisabled ? undefined : handleClick,
+        onClick: isDisabled.value ? undefined : handleClick,
         'aria-selected': toValue(props.selected),
         'aria-disabled': isDisabled,
-        tabindex: isDisabled || !isFocused ? '-1' : '0',
+        tabindex: isDisabled.value || !isFocused ? '-1' : '0',
       },
       cellEl,
     );

--- a/packages/core/src/useCalendar/useCalendarCell.ts
+++ b/packages/core/src/useCalendar/useCalendarCell.ts
@@ -1,10 +1,10 @@
 import { Reactivify } from '../types';
 import { normalizeProps, withRefCapture } from '../utils/common';
-import { CalendarContextKey } from './useCalendar';
 import { computed, defineComponent, h, inject, shallowRef, toValue } from 'vue';
-import { CalendarDay } from './types';
+import { CalendarCellProps, CalendarPanelType } from './types';
+import { CalendarContextKey } from './constants';
 
-export function useCalendarCell(_props: Reactivify<CalendarDay>) {
+export function useCalendarCell(_props: Reactivify<CalendarCellProps>) {
   const props = normalizeProps(_props);
   const cellEl = shallowRef<HTMLElement>();
   const calendarCtx = inject(CalendarContextKey, null);
@@ -14,7 +14,9 @@ export function useCalendarCell(_props: Reactivify<CalendarDay>) {
       return;
     }
 
-    calendarCtx?.setDay(toValue(props.value));
+    const type = toValue(props.type);
+    const nextPanel: CalendarPanelType | undefined = type === 'month' ? 'day' : type === 'year' ? 'month' : undefined;
+    calendarCtx?.setDate(toValue(props.value), nextPanel);
   }
 
   const cellProps = computed(() => {
@@ -33,17 +35,21 @@ export function useCalendarCell(_props: Reactivify<CalendarDay>) {
     );
   });
 
+  const label = computed(() => toValue(props.label));
+
   return {
     cellProps,
+    label,
   };
 }
 
 export const CalendarCell = defineComponent({
   name: 'CalendarCell',
-  props: ['value', 'dayOfMonth', 'isToday', 'selected', 'isOutsideMonth', 'disabled', 'focused'],
+  inheritAttrs: true,
+  props: ['value', 'selected', 'disabled', 'focused', 'label', 'type', 'monthOfYear', 'year'],
   setup(props) {
-    const { cellProps } = useCalendarCell(props);
+    const { cellProps, label } = useCalendarCell(props);
 
-    return () => h('span', cellProps.value, String(props.dayOfMonth));
+    return () => h('span', cellProps.value, label.value);
   },
 });

--- a/packages/core/src/useCalendar/useCalendarCell.ts
+++ b/packages/core/src/useCalendar/useCalendarCell.ts
@@ -15,7 +15,8 @@ export function useCalendarCell(_props: Reactivify<CalendarCellProps>) {
     }
 
     const type = toValue(props.type);
-    const nextPanel: CalendarPanelType | undefined = type === 'month' ? 'day' : type === 'year' ? 'month' : undefined;
+    const nextPanel: CalendarPanelType | undefined =
+      type === 'month' ? 'weeks' : type === 'year' ? 'months' : undefined;
     calendarCtx?.setDate(toValue(props.value), nextPanel);
   }
 

--- a/packages/core/src/useCalendar/useCalendarCell.ts
+++ b/packages/core/src/useCalendar/useCalendarCell.ts
@@ -1,7 +1,7 @@
 import { Reactivify } from '../types';
 import { normalizeProps, withRefCapture } from '../utils/common';
 import { computed, defineComponent, h, inject, shallowRef, toValue } from 'vue';
-import { CalendarCellProps, CalendarPanelType } from './types';
+import { CalendarCellProps, CalendarViewType } from './types';
 import { CalendarContextKey } from './constants';
 
 export function useCalendarCell(_props: Reactivify<CalendarCellProps>) {
@@ -15,8 +15,7 @@ export function useCalendarCell(_props: Reactivify<CalendarCellProps>) {
     }
 
     const type = toValue(props.type);
-    const nextPanel: CalendarPanelType | undefined =
-      type === 'month' ? 'weeks' : type === 'year' ? 'months' : undefined;
+    const nextPanel: CalendarViewType | undefined = type === 'month' ? 'weeks' : type === 'year' ? 'months' : undefined;
     calendarCtx?.setDate(toValue(props.value), nextPanel);
   }
 

--- a/packages/core/src/useCalendar/useCalendarCell.ts
+++ b/packages/core/src/useCalendar/useCalendarCell.ts
@@ -1,0 +1,33 @@
+import { Reactivify } from '../types';
+import { normalizeProps } from '../utils/common';
+import { CalendarContextKey } from './useCalendar';
+import { computed, defineComponent, h, inject, toValue } from 'vue';
+import { CalendarDay } from './types';
+
+export function useCalendarCell(_props: Reactivify<CalendarDay>) {
+  const props = normalizeProps(_props);
+  const calendarCtx = inject(CalendarContextKey, null);
+  if (!calendarCtx) {
+    throw new Error('Calendar context not found');
+  }
+
+  const cellProps = computed(() => ({
+    key: toValue(props.value).toString(),
+    onClick() {
+      calendarCtx.setDay(toValue(props.value));
+    },
+  }));
+
+  return {
+    cellProps,
+  };
+}
+
+export const CalendarCell = defineComponent({
+  props: ['value', 'dayOfMonth', 'isToday', 'isSelected', 'isOutsideMonth'],
+  setup(props) {
+    const { cellProps } = useCalendarCell(props);
+
+    return () => h('span', cellProps.value, String(props.dayOfMonth));
+  },
+});

--- a/packages/core/src/useCalendar/useCalendarCell.ts
+++ b/packages/core/src/useCalendar/useCalendarCell.ts
@@ -4,6 +4,7 @@ import { computed, defineComponent, h, inject, shallowRef, toValue } from 'vue';
 import { CalendarCellProps, CalendarViewType } from './types';
 import { CalendarContextKey } from './constants';
 import { createDisabledContext } from '../helpers/createDisabledContext';
+import { blockEvent } from '../utils/events';
 
 export function useCalendarCell(_props: Reactivify<CalendarCellProps>) {
   const props = normalizeProps(_props);
@@ -11,8 +12,16 @@ export function useCalendarCell(_props: Reactivify<CalendarCellProps>) {
   const calendarCtx = inject(CalendarContextKey, null);
   const isDisabled = createDisabledContext(props.disabled);
 
-  function handleClick() {
+  function handlePointerDown(e: PointerEvent) {
     if (isDisabled.value) {
+      blockEvent(e);
+      return;
+    }
+  }
+
+  function handleClick(e: MouseEvent) {
+    if (isDisabled.value) {
+      blockEvent(e);
       return;
     }
 
@@ -27,9 +36,10 @@ export function useCalendarCell(_props: Reactivify<CalendarCellProps>) {
     return withRefCapture(
       {
         key: toValue(props.value).toString(),
-        onClick: isDisabled.value ? undefined : handleClick,
+        onClick: handleClick,
+        onPointerdown: handlePointerDown,
         'aria-selected': toValue(props.selected),
-        'aria-disabled': isDisabled,
+        'aria-disabled': isDisabled.value,
         tabindex: isDisabled.value || !isFocused ? '-1' : '0',
       },
       cellEl,

--- a/packages/core/src/useCalendar/useCalendarPanel.ts
+++ b/packages/core/src/useCalendar/useCalendarPanel.ts
@@ -1,0 +1,235 @@
+import { computed, MaybeRefOrGetter, shallowRef, toValue } from 'vue';
+import { CalendarContext, CalendarDayCell, CalendarMonthCell, CalendarPanelType, CalendarYearCell } from './types';
+import { useDateFormatter } from '../i18n';
+import { Temporal } from '@js-temporal/polyfill';
+import { Reactivify } from '../types';
+import { normalizeProps } from '../utils/common';
+
+export interface CalendarDayPanel {
+  type: 'day';
+  days: CalendarDayCell[];
+  daysOfTheWeek: string[];
+}
+
+export interface CalendarMonthPanel {
+  type: 'month';
+  months: CalendarMonthCell[];
+}
+
+export interface CalendarYearPanel {
+  type: 'year';
+  years: CalendarYearCell[];
+}
+
+export type CalendarPanel = CalendarDayPanel | CalendarMonthPanel | CalendarYearPanel;
+
+export interface CalendarPanelProps {
+  daysOfWeekFormat?: Intl.DateTimeFormatOptions['weekday'];
+  monthFormat?: Intl.DateTimeFormatOptions['month'];
+  yearFormat?: Intl.DateTimeFormatOptions['year'];
+}
+
+export function useCalendarPanel(_props: Reactivify<CalendarPanelProps>, context: CalendarContext) {
+  const props = normalizeProps(_props);
+  const panelType = shallowRef<CalendarPanelType>('day');
+  const { days, daysOfTheWeek } = useCalendarDaysPanel(context, props.daysOfWeekFormat);
+  const { months, monthFormatter } = useCalendarMonthsPanel(context, props.monthFormat);
+  const { years, yearFormatter } = useCalendarYearsPanel(context, props.yearFormat);
+
+  const currentPanel = computed(() => {
+    if (panelType.value === 'day') {
+      return {
+        type: 'day',
+        days: days.value,
+        daysOfTheWeek: daysOfTheWeek.value,
+      } as CalendarDayPanel;
+    }
+
+    if (panelType.value === 'month') {
+      return {
+        type: 'month',
+        months: months.value,
+      } as CalendarMonthPanel;
+    }
+
+    return {
+      type: 'year',
+      years: years.value,
+    } as CalendarYearPanel;
+  });
+
+  function switchPanel(type: CalendarPanelType) {
+    panelType.value = type;
+  }
+
+  const panelLabel = computed(() => {
+    if (panelType.value === 'day') {
+      return monthFormatter.value.format(context.getFocusedDate().toPlainDateTime());
+    }
+
+    if (panelType.value === 'month') {
+      return yearFormatter.value.format(context.getFocusedDate().toPlainDateTime());
+    }
+
+    return `${yearFormatter.value.format(context.getFocusedDate().subtract({ years: 4 }).toPlainDateTime())} - ${yearFormatter.value.format(context.getFocusedDate().add({ years: 4 }).toPlainDateTime())}`;
+  });
+
+  return { currentPanel, switchPanel, panelLabel };
+}
+
+function useCalendarDaysPanel(
+  { weekInfo, getFocusedDate, calendar, selectedDate, locale, getMinDate, getMaxDate }: CalendarContext,
+  daysOfWeekFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['weekday']>,
+) {
+  const dayFormatter = useDateFormatter(locale, () => ({ weekday: toValue(daysOfWeekFormat) ?? 'short' }));
+
+  const days = computed<CalendarDayCell[]>(() => {
+    const current = toValue(selectedDate);
+    const focused = getFocusedDate();
+    const startOfMonth = focused.with({ day: 1 });
+
+    const firstDayOfWeek = weekInfo.value.firstDay;
+    const startDayOfWeek = startOfMonth.dayOfWeek;
+    const daysToSubtract = (startDayOfWeek - firstDayOfWeek + 7) % 7;
+
+    // Move to first day of week
+    const firstDay = startOfMonth.subtract({ days: daysToSubtract });
+
+    // Always use 6 weeks (42 days) for consistent layout
+    const gridDays = 42;
+    const now = Temporal.Now.zonedDateTime(calendar.value);
+    const minDate = getMinDate();
+    const maxDate = getMaxDate();
+
+    return Array.from({ length: gridDays }, (_, i) => {
+      const dayOfMonth = firstDay.add({ days: i });
+      let disabled = false;
+
+      if (minDate && Temporal.ZonedDateTime.compare(dayOfMonth, minDate) < 0) {
+        disabled = true;
+      }
+
+      if (maxDate && Temporal.ZonedDateTime.compare(dayOfMonth, maxDate) > 0) {
+        disabled = true;
+      }
+
+      return {
+        value: dayOfMonth,
+        label: String(dayOfMonth.day),
+        dayOfMonth: dayOfMonth.day,
+        isToday: dayOfMonth.equals(now),
+        selected: current.equals(dayOfMonth),
+        isOutsideMonth: dayOfMonth.monthCode !== focused.monthCode,
+        focused: focused.equals(dayOfMonth),
+        disabled,
+        type: 'day',
+      } as CalendarDayCell;
+    });
+  });
+
+  const daysOfTheWeek = computed(() => {
+    let focused = getFocusedDate();
+    const daysPerWeek = focused.daysInWeek;
+    const firstDayOfWeek = weekInfo.value.firstDay;
+    // Get the current date's day of week (0-6)
+    const currentDayOfWeek = focused.dayOfWeek;
+
+    // Calculate how many days to go back to reach first day of week
+    const daysToSubtract = (currentDayOfWeek - firstDayOfWeek + 7) % 7;
+
+    // Move current date back to first day of week
+    focused = focused.subtract({ days: daysToSubtract });
+
+    const days: string[] = [];
+    for (let i = 0; i < daysPerWeek; i++) {
+      days.push(dayFormatter.value.format(focused.add({ days: i }).toPlainDateTime()));
+    }
+
+    return days;
+  });
+
+  return { days, daysOfTheWeek, dayFormatter };
+}
+
+function useCalendarMonthsPanel(
+  { getFocusedDate, locale, selectedDate, getMinDate, getMaxDate }: CalendarContext,
+  monthFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['month']>,
+) {
+  const monthFormatter = useDateFormatter(locale, () => ({ month: toValue(monthFormat) ?? 'long' }));
+
+  const months = computed<CalendarMonthCell[]>(() => {
+    const focused = getFocusedDate();
+    const current = toValue(selectedDate);
+    const minDate = getMinDate();
+    const maxDate = getMaxDate();
+
+    return Array.from({ length: focused.monthsInYear }, (_, i) => {
+      const date = focused.with({ month: i + 1, day: 1 });
+      let disabled = false;
+
+      if (minDate && minDate.month < date.month) {
+        disabled = true;
+      }
+
+      if (maxDate && maxDate.month > date.month) {
+        disabled = true;
+      }
+
+      const cell: CalendarMonthCell = {
+        type: 'month',
+        label: monthFormatter.value.format(date.toPlainDateTime()),
+        value: date,
+        monthOfYear: date.month,
+        selected: date.month === current.month && date.year === current.year,
+        focused: focused.monthCode === date.monthCode && focused.year === date.year,
+        disabled,
+      };
+
+      return cell;
+    });
+  });
+
+  return { months, monthFormatter };
+}
+
+function useCalendarYearsPanel(
+  { getFocusedDate, locale, selectedDate, getMinDate, getMaxDate }: CalendarContext,
+  yearFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['year']>,
+) {
+  const yearFormatter = useDateFormatter(locale, () => ({ year: toValue(yearFormat) ?? 'numeric' }));
+
+  const years = computed<CalendarYearCell[]>(() => {
+    const focused = getFocusedDate();
+    const current = toValue(selectedDate);
+    const minDate = getMinDate();
+    const maxDate = getMaxDate();
+
+    return Array.from({ length: 9 }, (_, i) => {
+      const startYear = Math.floor(focused.year / 9) * 9;
+      const date = focused.with({ year: startYear + i, month: 1, day: 1 });
+      let disabled = false;
+
+      if (minDate && minDate.year < date.year) {
+        disabled = true;
+      }
+
+      if (maxDate && maxDate.year > date.year) {
+        disabled = true;
+      }
+
+      const cell: CalendarYearCell = {
+        type: 'year',
+        label: yearFormatter.value.format(date.toPlainDateTime()),
+        value: date,
+        year: date.year,
+        selected: date.year === current.year,
+        focused: focused.year === date.year,
+        disabled,
+      };
+
+      return cell;
+    });
+  });
+
+  return { years, yearFormatter };
+}

--- a/packages/core/src/useCalendar/useCalendarPanel.ts
+++ b/packages/core/src/useCalendar/useCalendarPanel.ts
@@ -4,7 +4,7 @@ import { useDateFormatter } from '../i18n';
 import { Reactivify } from '../types';
 import { normalizeProps } from '../utils/common';
 import { YEAR_CELLS_COUNT } from './constants';
-import { now } from '@internationalized/date';
+import { now, toCalendar } from '@internationalized/date';
 
 export interface CalendarDayPanel {
   type: 'day';
@@ -79,7 +79,7 @@ export function useCalendarPanel(_props: Reactivify<CalendarPanelProps>, context
 }
 
 function useCalendarDaysPanel(
-  { weekInfo, getFocusedDate, getSelectedDate, locale, getMinDate, getMaxDate }: CalendarContext,
+  { weekInfo, getFocusedDate, getSelectedDate, locale, timeZone, calendar, getMinDate, getMaxDate }: CalendarContext,
   daysOfWeekFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['weekday']>,
 ) {
   const dayFormatter = useDateFormatter(locale, () => ({ weekday: toValue(daysOfWeekFormat) ?? 'short' }));
@@ -98,7 +98,7 @@ function useCalendarDaysPanel(
 
     // Always use 6 weeks (42 days) for consistent layout
     const gridDays = 42;
-    const rightNow = now(focused.timeZone);
+    const rightNow = toCalendar(now(timeZone.value), calendar.value);
     const minDate = getMinDate();
     const maxDate = getMaxDate();
 

--- a/packages/core/src/useCalendar/useCalendarPanel.ts
+++ b/packages/core/src/useCalendar/useCalendarPanel.ts
@@ -71,7 +71,7 @@ export function useCalendarPanel(_props: Reactivify<CalendarPanelProps>, context
       return yearFormatter.value.format(context.getFocusedDate().toPlainDateTime());
     }
 
-    return `${yearFormatter.value.format(context.getFocusedDate().subtract({ years: 4 }).toPlainDateTime())} - ${yearFormatter.value.format(context.getFocusedDate().add({ years: 4 }).toPlainDateTime())}`;
+    return `${yearFormatter.value.format(years.value[0].value.toPlainDateTime())} - ${yearFormatter.value.format(years.value[years.value.length - 1].value.toPlainDateTime())}`;
   });
 
   return { currentPanel, switchPanel, panelLabel };

--- a/packages/core/src/useCalendar/useCalendarPanel.ts
+++ b/packages/core/src/useCalendar/useCalendarPanel.ts
@@ -4,6 +4,7 @@ import { useDateFormatter } from '../i18n';
 import { Temporal } from '@js-temporal/polyfill';
 import { Reactivify } from '../types';
 import { normalizeProps } from '../utils/common';
+import { YEAR_CELLS_COUNT } from './constants';
 
 export interface CalendarDayPanel {
   type: 'day';
@@ -64,7 +65,7 @@ export function useCalendarPanel(_props: Reactivify<CalendarPanelProps>, context
 
   const panelLabel = computed(() => {
     if (panelType.value === 'day') {
-      return monthFormatter.value.format(context.getFocusedDate().toPlainDateTime());
+      return `${monthFormatter.value.format(context.getFocusedDate().toPlainDateTime())} ${yearFormatter.value.format(context.getFocusedDate().toPlainDateTime())}`;
     }
 
     if (panelType.value === 'month') {
@@ -78,13 +79,13 @@ export function useCalendarPanel(_props: Reactivify<CalendarPanelProps>, context
 }
 
 function useCalendarDaysPanel(
-  { weekInfo, getFocusedDate, calendar, selectedDate, locale, getMinDate, getMaxDate }: CalendarContext,
+  { weekInfo, getFocusedDate, calendar, getSelectedDate, locale, getMinDate, getMaxDate }: CalendarContext,
   daysOfWeekFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['weekday']>,
 ) {
   const dayFormatter = useDateFormatter(locale, () => ({ weekday: toValue(daysOfWeekFormat) ?? 'short' }));
 
   const days = computed<CalendarDayCell[]>(() => {
-    const current = toValue(selectedDate);
+    const current = getSelectedDate();
     const focused = getFocusedDate();
     const startOfMonth = focused.with({ day: 1 });
 
@@ -152,14 +153,14 @@ function useCalendarDaysPanel(
 }
 
 function useCalendarMonthsPanel(
-  { getFocusedDate, locale, selectedDate, getMinDate, getMaxDate }: CalendarContext,
+  { getFocusedDate, locale, getSelectedDate, getMinDate, getMaxDate }: CalendarContext,
   monthFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['month']>,
 ) {
   const monthFormatter = useDateFormatter(locale, () => ({ month: toValue(monthFormat) ?? 'long' }));
 
   const months = computed<CalendarMonthCell[]>(() => {
     const focused = getFocusedDate();
-    const current = toValue(selectedDate);
+    const current = getSelectedDate();
     const minDate = getMinDate();
     const maxDate = getMaxDate();
 
@@ -193,19 +194,19 @@ function useCalendarMonthsPanel(
 }
 
 function useCalendarYearsPanel(
-  { getFocusedDate, locale, selectedDate, getMinDate, getMaxDate }: CalendarContext,
+  { getFocusedDate, locale, getSelectedDate, getMinDate, getMaxDate }: CalendarContext,
   yearFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['year']>,
 ) {
   const yearFormatter = useDateFormatter(locale, () => ({ year: toValue(yearFormat) ?? 'numeric' }));
 
   const years = computed<CalendarYearCell[]>(() => {
     const focused = getFocusedDate();
-    const current = toValue(selectedDate);
+    const current = getSelectedDate();
     const minDate = getMinDate();
     const maxDate = getMaxDate();
 
-    return Array.from({ length: 9 }, (_, i) => {
-      const startYear = Math.floor(focused.year / 9) * 9;
+    return Array.from({ length: YEAR_CELLS_COUNT }, (_, i) => {
+      const startYear = Math.floor(focused.year / YEAR_CELLS_COUNT) * YEAR_CELLS_COUNT;
       const date = focused.with({ year: startYear + i, month: 1, day: 1 });
       let disabled = false;
 

--- a/packages/core/src/useCalendar/useCalendarPanel.ts
+++ b/packages/core/src/useCalendar/useCalendarPanel.ts
@@ -9,7 +9,7 @@ import { now, toCalendar } from '@internationalized/date';
 export interface CalendarDayPanel {
   type: 'day';
   days: CalendarDayCell[];
-  daysOfTheWeek: string[];
+  weekDays: string[];
 }
 
 export interface CalendarMonthPanel {
@@ -33,7 +33,7 @@ export interface CalendarPanelProps {
 export function useCalendarPanel(_props: Reactivify<CalendarPanelProps>, context: CalendarContext) {
   const props = normalizeProps(_props);
   const panelType = shallowRef<CalendarPanelType>('day');
-  const { days, daysOfTheWeek } = useCalendarDaysPanel(context, props.daysOfWeekFormat);
+  const { days, weekDays } = useCalendarDaysPanel(context, props.daysOfWeekFormat);
   const { months, monthFormatter } = useCalendarMonthsPanel(context, props.monthFormat);
   const { years, yearFormatter } = useCalendarYearsPanel(context, props.yearFormat);
 
@@ -42,7 +42,7 @@ export function useCalendarPanel(_props: Reactivify<CalendarPanelProps>, context
       return {
         type: 'day',
         days: days.value,
-        daysOfTheWeek: daysOfTheWeek.value,
+        weekDays: weekDays.value,
       } as CalendarDayPanel;
     }
 
@@ -128,7 +128,7 @@ function useCalendarDaysPanel(
     });
   });
 
-  const daysOfTheWeek = computed(() => {
+  const weekDays = computed(() => {
     let focused = getFocusedDate();
     const daysPerWeek = 7;
     const firstDayOfWeek = weekInfo.value.firstDay;
@@ -149,7 +149,7 @@ function useCalendarDaysPanel(
     return days;
   });
 
-  return { days, daysOfTheWeek, dayFormatter };
+  return { days, weekDays, dayFormatter };
 }
 
 function useCalendarMonthsPanel(

--- a/packages/core/src/useCalendar/useCalendarPanel.ts
+++ b/packages/core/src/useCalendar/useCalendarPanel.ts
@@ -6,57 +6,68 @@ import { normalizeProps } from '../utils/common';
 import { YEAR_CELLS_COUNT } from './constants';
 import { now, toCalendar } from '@internationalized/date';
 
-export interface CalendarDayPanel {
-  type: 'day';
+export interface CalendarWeeksPanel {
+  type: 'weeks';
   days: CalendarDayCell[];
   weekDays: string[];
 }
 
-export interface CalendarMonthPanel {
-  type: 'month';
+export interface CalendarMonthsPanel {
+  type: 'months';
   months: CalendarMonthCell[];
 }
 
-export interface CalendarYearPanel {
-  type: 'year';
+export interface CalendarYearsPanel {
+  type: 'years';
   years: CalendarYearCell[];
 }
 
-export type CalendarPanel = CalendarDayPanel | CalendarMonthPanel | CalendarYearPanel;
+export type CalendarPanel = CalendarWeeksPanel | CalendarMonthsPanel | CalendarYearsPanel;
 
 export interface CalendarPanelProps {
-  daysOfWeekFormat?: Intl.DateTimeFormatOptions['weekday'];
+  /**
+   * The format option for the days of the week.
+   */
+  weekDayFormat?: Intl.DateTimeFormatOptions['weekday'];
+
+  /**
+   * The format option for the month.
+   */
   monthFormat?: Intl.DateTimeFormatOptions['month'];
+
+  /**
+   * The format option for the year.
+   */
   yearFormat?: Intl.DateTimeFormatOptions['year'];
 }
 
 export function useCalendarPanel(_props: Reactivify<CalendarPanelProps>, context: CalendarContext) {
   const props = normalizeProps(_props);
-  const panelType = shallowRef<CalendarPanelType>('day');
-  const { days, weekDays } = useCalendarDaysPanel(context, props.daysOfWeekFormat);
+  const panelType = shallowRef<CalendarPanelType>('weeks');
+  const { days, weekDays } = useCalendarDaysPanel(context, props.weekDayFormat);
   const { months, monthFormatter } = useCalendarMonthsPanel(context, props.monthFormat);
   const { years, yearFormatter } = useCalendarYearsPanel(context, props.yearFormat);
 
   const currentPanel = computed(() => {
-    if (panelType.value === 'day') {
+    if (panelType.value === 'weeks') {
       return {
-        type: 'day',
+        type: 'weeks',
         days: days.value,
         weekDays: weekDays.value,
-      } as CalendarDayPanel;
+      } as CalendarWeeksPanel;
     }
 
-    if (panelType.value === 'month') {
+    if (panelType.value === 'months') {
       return {
-        type: 'month',
+        type: 'months',
         months: months.value,
-      } as CalendarMonthPanel;
+      } as CalendarMonthsPanel;
     }
 
     return {
-      type: 'year',
+      type: 'years',
       years: years.value,
-    } as CalendarYearPanel;
+    } as CalendarYearsPanel;
   });
 
   function switchPanel(type: CalendarPanelType) {
@@ -64,11 +75,11 @@ export function useCalendarPanel(_props: Reactivify<CalendarPanelProps>, context
   }
 
   const panelLabel = computed(() => {
-    if (panelType.value === 'day') {
+    if (panelType.value === 'weeks') {
       return `${monthFormatter.value.format(context.getFocusedDate().toDate())} ${yearFormatter.value.format(context.getFocusedDate().toDate())}`;
     }
 
-    if (panelType.value === 'month') {
+    if (panelType.value === 'months') {
       return yearFormatter.value.format(context.getFocusedDate().toDate());
     }
 

--- a/packages/core/src/useCalendar/useCalendarView.ts
+++ b/packages/core/src/useCalendar/useCalendarView.ts
@@ -94,6 +94,7 @@ function useCalendarDaysView(
   daysOfWeekFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['weekday']>,
 ) {
   const dayFormatter = useDateFormatter(locale, () => ({ weekday: toValue(daysOfWeekFormat) ?? 'short' }));
+  const dayNumberFormatter = useDateFormatter(locale, () => ({ day: 'numeric' }));
 
   const days = computed<CalendarDayCell[]>(() => {
     const current = getSelectedDate();
@@ -133,7 +134,7 @@ function useCalendarDaysView(
 
       return {
         value: dayOfMonth,
-        label: String(dayOfMonth.day),
+        label: dayNumberFormatter.value.format(dayOfMonth.toDate()),
         dayOfMonth: dayOfMonth.day,
         isToday: rightNowDate.compare(domDate) === 0,
         selected: currentDate.compare(domDate) === 0,

--- a/packages/core/src/useCalendar/useCalendarView.ts
+++ b/packages/core/src/useCalendar/useCalendarView.ts
@@ -98,7 +98,7 @@ function useCalendarDaysView(
   const days = computed<CalendarDayCell[]>(() => {
     const current = getSelectedDate();
     const focused = getFocusedDate();
-    const startOfMonth = focused.set({ day: 1 });
+    const startOfMonth = focused.set({ day: 1, hour: 0, minute: 0, second: 0, millisecond: 0 });
 
     const firstDayOfWeek = weekInfo.value.firstDay;
     const startDayOfWeek = startOfMonth.toDate().getDay();
@@ -176,7 +176,7 @@ function useCalendarMonthsView(
     const maxDate = getMaxDate();
 
     return Array.from({ length: focused.calendar.getMonthsInYear(focused) }, (_, i) => {
-      const date = focused.set({ month: i + 1, day: 1 });
+      const date = focused.set({ month: i + 1, day: 1, hour: 0, minute: 0, second: 0, millisecond: 0 });
       let disabled = false;
 
       if (minDate && minDate.month < date.month) {
@@ -218,7 +218,16 @@ function useCalendarYearsView(
 
     return Array.from({ length: YEAR_CELLS_COUNT }, (_, i) => {
       const startYear = Math.floor(focused.year / YEAR_CELLS_COUNT) * YEAR_CELLS_COUNT;
-      const date = focused.set({ year: startYear + i, month: 1, day: 1 });
+      const date = focused.set({
+        year: startYear + i,
+        month: 1,
+        day: 1,
+        hour: 0,
+        minute: 0,
+        second: 0,
+        millisecond: 0,
+      });
+
       let disabled = false;
 
       if (minDate && minDate.year < date.year) {

--- a/packages/core/src/useCalendar/useCalendarView.ts
+++ b/packages/core/src/useCalendar/useCalendarView.ts
@@ -4,7 +4,7 @@ import { useDateFormatter } from '../i18n';
 import { Reactivify } from '../types';
 import { normalizeProps } from '../utils/common';
 import { YEAR_CELLS_COUNT } from './constants';
-import { now, toCalendar } from '@internationalized/date';
+import { now, toCalendar, toCalendarDate } from '@internationalized/date';
 
 export interface CalendarWeeksView {
   type: 'weeks';
@@ -113,6 +113,10 @@ function useCalendarDaysView(
     const minDate = getMinDate();
     const maxDate = getMaxDate();
 
+    const rightNowDate = toCalendarDate(rightNow);
+    const focusedDate = toCalendarDate(focused);
+    const currentDate = toCalendarDate(current);
+
     return Array.from({ length: gridDays }, (_, i) => {
       const dayOfMonth = firstDay.add({ days: i });
       let disabled = false;
@@ -125,14 +129,16 @@ function useCalendarDaysView(
         disabled = true;
       }
 
+      const domDate = toCalendarDate(dayOfMonth);
+
       return {
         value: dayOfMonth,
         label: String(dayOfMonth.day),
         dayOfMonth: dayOfMonth.day,
-        isToday: dayOfMonth.compare(rightNow) === 0,
-        selected: current.compare(dayOfMonth) === 0,
-        isOutsideMonth: dayOfMonth.month !== focused.month,
-        focused: focused.compare(dayOfMonth) === 0,
+        isToday: rightNowDate.compare(domDate) === 0,
+        selected: currentDate.compare(domDate) === 0,
+        isOutsideMonth: domDate.month !== focusedDate.month,
+        focused: focusedDate.compare(domDate) === 0,
         disabled,
         type: 'day',
       } as CalendarDayCell;

--- a/packages/core/src/useCalendar/useCalendarView.ts
+++ b/packages/core/src/useCalendar/useCalendarView.ts
@@ -1,30 +1,30 @@
 import { computed, MaybeRefOrGetter, shallowRef, toValue } from 'vue';
-import { CalendarContext, CalendarDayCell, CalendarMonthCell, CalendarPanelType, CalendarYearCell } from './types';
+import { CalendarContext, CalendarDayCell, CalendarMonthCell, CalendarViewType, CalendarYearCell } from './types';
 import { useDateFormatter } from '../i18n';
 import { Reactivify } from '../types';
 import { normalizeProps } from '../utils/common';
 import { YEAR_CELLS_COUNT } from './constants';
 import { now, toCalendar } from '@internationalized/date';
 
-export interface CalendarWeeksPanel {
+export interface CalendarWeeksView {
   type: 'weeks';
   days: CalendarDayCell[];
   weekDays: string[];
 }
 
-export interface CalendarMonthsPanel {
+export interface CalendarMonthsView {
   type: 'months';
   months: CalendarMonthCell[];
 }
 
-export interface CalendarYearsPanel {
+export interface CalendarYearsView {
   type: 'years';
   years: CalendarYearCell[];
 }
 
-export type CalendarPanel = CalendarWeeksPanel | CalendarMonthsPanel | CalendarYearsPanel;
+export type CalendarView = CalendarWeeksView | CalendarMonthsView | CalendarYearsView;
 
-export interface CalendarPanelProps {
+export interface CalendarViewProps {
   /**
    * The format option for the days of the week.
    */
@@ -41,55 +41,55 @@ export interface CalendarPanelProps {
   yearFormat?: Intl.DateTimeFormatOptions['year'];
 }
 
-export function useCalendarPanel(_props: Reactivify<CalendarPanelProps>, context: CalendarContext) {
+export function useCalendarView(_props: Reactivify<CalendarViewProps>, context: CalendarContext) {
   const props = normalizeProps(_props);
-  const panelType = shallowRef<CalendarPanelType>('weeks');
-  const { days, weekDays } = useCalendarDaysPanel(context, props.weekDayFormat);
-  const { months, monthFormatter } = useCalendarMonthsPanel(context, props.monthFormat);
-  const { years, yearFormatter } = useCalendarYearsPanel(context, props.yearFormat);
+  const viewType = shallowRef<CalendarViewType>('weeks');
+  const { days, weekDays } = useCalendarDaysView(context, props.weekDayFormat);
+  const { months, monthFormatter } = useCalendarMonthsView(context, props.monthFormat);
+  const { years, yearFormatter } = useCalendarYearsView(context, props.yearFormat);
 
-  const currentPanel = computed(() => {
-    if (panelType.value === 'weeks') {
+  const currentView = computed(() => {
+    if (viewType.value === 'weeks') {
       return {
         type: 'weeks',
         days: days.value,
         weekDays: weekDays.value,
-      } as CalendarWeeksPanel;
+      } as CalendarWeeksView;
     }
 
-    if (panelType.value === 'months') {
+    if (viewType.value === 'months') {
       return {
         type: 'months',
         months: months.value,
-      } as CalendarMonthsPanel;
+      } as CalendarMonthsView;
     }
 
     return {
       type: 'years',
       years: years.value,
-    } as CalendarYearsPanel;
+    } as CalendarYearsView;
   });
 
-  function switchPanel(type: CalendarPanelType) {
-    panelType.value = type;
+  function setView(type: CalendarViewType) {
+    viewType.value = type;
   }
 
-  const panelLabel = computed(() => {
-    if (panelType.value === 'weeks') {
+  const viewLabel = computed(() => {
+    if (viewType.value === 'weeks') {
       return `${monthFormatter.value.format(context.getFocusedDate().toDate())} ${yearFormatter.value.format(context.getFocusedDate().toDate())}`;
     }
 
-    if (panelType.value === 'months') {
+    if (viewType.value === 'months') {
       return yearFormatter.value.format(context.getFocusedDate().toDate());
     }
 
     return `${yearFormatter.value.format(years.value[0].value.toDate())} - ${yearFormatter.value.format(years.value[years.value.length - 1].value.toDate())}`;
   });
 
-  return { currentPanel, switchPanel, panelLabel };
+  return { currentView, setView, viewLabel };
 }
 
-function useCalendarDaysPanel(
+function useCalendarDaysView(
   { weekInfo, getFocusedDate, getSelectedDate, locale, timeZone, calendar, getMinDate, getMaxDate }: CalendarContext,
   daysOfWeekFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['weekday']>,
 ) {
@@ -163,7 +163,7 @@ function useCalendarDaysPanel(
   return { days, weekDays, dayFormatter };
 }
 
-function useCalendarMonthsPanel(
+function useCalendarMonthsView(
   { getFocusedDate, locale, getSelectedDate, getMinDate, getMaxDate }: CalendarContext,
   monthFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['month']>,
 ) {
@@ -204,7 +204,7 @@ function useCalendarMonthsPanel(
   return { months, monthFormatter };
 }
 
-function useCalendarYearsPanel(
+function useCalendarYearsView(
   { getFocusedDate, locale, getSelectedDate, getMinDate, getMaxDate }: CalendarContext,
   yearFormat?: MaybeRefOrGetter<Intl.DateTimeFormatOptions['year']>,
 ) {

--- a/packages/core/src/useComboBox/useComboBox.ts
+++ b/packages/core/src/useComboBox/useComboBox.ts
@@ -316,7 +316,7 @@ export function useComboBox<TOption, TValue = TOption>(
     isPopupOpen.value = !isPopupOpen.value;
   }
 
-  const buttonProps = useControlButtonProps({
+  const buttonProps = useControlButtonProps(() => ({
     id: `${inputId}-btn`,
     disabled: isDisabled.value,
     type: 'button' as const,
@@ -325,7 +325,7 @@ export function useComboBox<TOption, TValue = TOption>(
     'aria-activedescendant': findFocusedOption()?.id ?? undefined,
     'aria-controls': listBoxId,
     onClick: onButtonClick,
-  });
+  }));
 
   // https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/#rps_label_textbox
   const inputProps = computed(() => {

--- a/packages/core/src/useComboBox/useComboBox.ts
+++ b/packages/core/src/useComboBox/useComboBox.ts
@@ -18,6 +18,7 @@ import { useListBox } from '../useListBox';
 import { useErrorMessage } from '../a11y/useErrorMessage';
 import { useInputValidity } from '../validation';
 import { FilterFn } from '../collections';
+import { useControlButtonProps } from '../helpers/useControlButtonProps';
 
 export interface ComboBoxProps<TOption, TValue = TOption> {
   /**
@@ -315,24 +316,15 @@ export function useComboBox<TOption, TValue = TOption>(
     isPopupOpen.value = !isPopupOpen.value;
   }
 
-  const buttonProps = computed(() => {
-    const isButton = buttonEl.value?.tagName === 'BUTTON';
-
-    return withRefCapture(
-      {
-        id: inputId,
-        role: isButton ? undefined : 'button',
-        [isButton ? 'disabled' : 'aria-disabled']: isDisabled.value || undefined,
-        tabindex: '-1',
-        type: 'button' as const,
-        'aria-haspopup': 'listbox' as const,
-        'aria-expanded': isPopupOpen.value,
-        'aria-activedescendant': findFocusedOption()?.id ?? undefined,
-        'aria-controls': listBoxId,
-        onClick: onButtonClick,
-      },
-      buttonEl,
-    );
+  const buttonProps = useControlButtonProps({
+    id: `${inputId}-btn`,
+    disabled: isDisabled.value,
+    type: 'button' as const,
+    'aria-haspopup': 'listbox' as const,
+    'aria-expanded': isPopupOpen.value,
+    'aria-activedescendant': findFocusedOption()?.id ?? undefined,
+    'aria-controls': listBoxId,
+    onClick: onButtonClick,
   });
 
   // https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/#rps_label_textbox

--- a/packages/core/src/useDateTimeField/constants.ts
+++ b/packages/core/src/useDateTimeField/constants.ts
@@ -40,3 +40,16 @@ export function getSegmentTypePlaceholder(type: DateTimeSegmentType) {
 
   return map[type];
 }
+
+export function isNumericByDefault(type: DateTimeSegmentType) {
+  const map: Partial<Record<DateTimeSegmentType, boolean>> = {
+    year: true,
+    month: true,
+    day: true,
+    hour: true,
+    minute: true,
+    second: true,
+  };
+
+  return map[type] ?? false;
+}

--- a/packages/core/src/useDateTimeField/constants.ts
+++ b/packages/core/src/useDateTimeField/constants.ts
@@ -5,6 +5,12 @@ export function isEditableSegmentType(type: DateTimeSegmentType) {
   return !['era', 'timeZoneName', 'literal'].includes(type);
 }
 
+export function isOptionalSegmentType(type: DateTimeSegmentType) {
+  const optionalTypes: DateTimeSegmentType[] = ['dayPeriod', 'weekday', 'era'];
+
+  return optionalTypes.includes(type);
+}
+
 export function segmentTypeToDurationLike(type: DateTimeSegmentType): keyof Temporal.DurationLike | undefined {
   const map: Partial<Record<DateTimeSegmentType, keyof Temporal.DurationLike>> = {
     year: 'years',
@@ -15,6 +21,21 @@ export function segmentTypeToDurationLike(type: DateTimeSegmentType): keyof Temp
     second: 'seconds',
     dayPeriod: 'hours',
     weekday: 'days',
+  };
+
+  return map[type];
+}
+
+export function getSegmentTypePlaceholder(type: DateTimeSegmentType) {
+  const map: Partial<Record<DateTimeSegmentType, string>> = {
+    year: 'YYYY',
+    month: 'MM',
+    day: 'DD',
+    hour: 'HH',
+    minute: 'mm',
+    second: 'ss',
+    dayPeriod: 'AM',
+    weekday: 'ddd',
   };
 
   return map[type];

--- a/packages/core/src/useDateTimeField/constants.ts
+++ b/packages/core/src/useDateTimeField/constants.ts
@@ -1,5 +1,5 @@
-import { Temporal } from '@js-temporal/polyfill';
 import { DateTimeSegmentType } from './types';
+import type { DateTimeDuration } from '@internationalized/date';
 
 export function isEditableSegmentType(type: DateTimeSegmentType) {
   return !['era', 'timeZoneName', 'literal'].includes(type);
@@ -11,8 +11,8 @@ export function isOptionalSegmentType(type: DateTimeSegmentType) {
   return optionalTypes.includes(type);
 }
 
-export function segmentTypeToDurationLike(type: DateTimeSegmentType): keyof Temporal.DurationLike | undefined {
-  const map: Partial<Record<DateTimeSegmentType, keyof Temporal.DurationLike>> = {
+export function segmentTypeToDurationLike(type: DateTimeSegmentType): keyof DateTimeDuration | undefined {
+  const map: Partial<Record<DateTimeSegmentType, keyof DateTimeDuration>> = {
     year: 'years',
     month: 'months',
     day: 'days',

--- a/packages/core/src/useDateTimeField/index.ts
+++ b/packages/core/src/useDateTimeField/index.ts
@@ -1,3 +1,4 @@
 export * from './useDateTimeField';
 export * from './useDateTimeSegment';
 export * from './useCalendar';
+export * from './types';

--- a/packages/core/src/useDateTimeField/index.ts
+++ b/packages/core/src/useDateTimeField/index.ts
@@ -1,2 +1,3 @@
 export * from './useDateTimeField';
 export * from './useDateTimeSegment';
+export * from './useCalendar';

--- a/packages/core/src/useDateTimeField/index.ts
+++ b/packages/core/src/useDateTimeField/index.ts
@@ -1,4 +1,4 @@
 export * from './useDateTimeField';
 export * from './useDateTimeSegment';
-export * from './useCalendar';
+export * from '../useCalendar/useCalendar';
 export * from './types';

--- a/packages/core/src/useDateTimeField/index.ts
+++ b/packages/core/src/useDateTimeField/index.ts
@@ -1,4 +1,3 @@
 export * from './useDateTimeField';
 export * from './useDateTimeSegment';
-export * from '../useCalendar/useCalendar';
 export * from './types';

--- a/packages/core/src/useDateTimeField/temporalPartial.spec.ts
+++ b/packages/core/src/useDateTimeField/temporalPartial.spec.ts
@@ -1,0 +1,117 @@
+import { createCalendar, now } from '@internationalized/date';
+import { createTemporalPartial, isTemporalPartial, isTemporalPartSet, toTemporalPartial } from './temporalPartial';
+import { DateTimeSegmentType } from './types';
+
+describe('Temporal Partial', () => {
+  describe('createTemporalPartial', () => {
+    test('creates a temporal partial with empty set parts', () => {
+      const calendar = createCalendar('gregory');
+      const partial = createTemporalPartial(calendar, 'UTC');
+
+      expect(partial['~fw_temporal_partial']).toEqual({});
+      expect(isTemporalPartial(partial)).toBe(true);
+    });
+
+    test('creates temporal partial with different calendar systems', () => {
+      const islamicCalendar = createCalendar('islamic-umalqura');
+      const partial = createTemporalPartial(islamicCalendar, 'UTC');
+
+      expect(partial.calendar.identifier).toBe('islamic-umalqura');
+      expect(isTemporalPartial(partial)).toBe(true);
+    });
+  });
+
+  describe('toTemporalPartial', () => {
+    test('converts ZonedDateTime to temporal partial', () => {
+      const date = now('UTC');
+      const partial = toTemporalPartial(date);
+
+      expect(isTemporalPartial(partial)).toBe(true);
+      expect(partial['~fw_temporal_partial']).toEqual({});
+    });
+
+    test('clones existing temporal partial', () => {
+      const date = now('UTC');
+      const partial1 = toTemporalPartial(date, ['day']);
+      const partial2 = toTemporalPartial(partial1);
+
+      expect(partial2['~fw_temporal_partial']).toEqual(partial1['~fw_temporal_partial']);
+      expect(partial2).not.toBe(partial1); // Should be a new instance
+    });
+
+    test('sets specified parts as true', () => {
+      const date = now('UTC');
+      const parts: DateTimeSegmentType[] = ['year', 'month', 'day'];
+      const partial = toTemporalPartial(date, parts);
+
+      parts.forEach(part => {
+        expect(partial['~fw_temporal_partial'][part]).toBe(true);
+      });
+    });
+
+    test('preserves existing set parts when adding new ones', () => {
+      const date = now('UTC');
+      const partial1 = toTemporalPartial(date, ['year']);
+      const partial2 = toTemporalPartial(partial1, ['month']);
+
+      expect(partial2['~fw_temporal_partial']).toEqual({
+        year: true,
+        month: true,
+      });
+    });
+  });
+
+  describe('isTemporalPartial', () => {
+    test('returns true for temporal partials', () => {
+      const calendar = createCalendar('gregory');
+      const partial = createTemporalPartial(calendar, 'UTC');
+
+      expect(isTemporalPartial(partial)).toBe(true);
+    });
+
+    test('returns false for regular ZonedDateTime', () => {
+      const date = now('UTC');
+
+      expect(isTemporalPartial(date)).toBe(false);
+    });
+  });
+
+  describe('isTemporalPartSet', () => {
+    test('returns true for set parts', () => {
+      const date = now('UTC');
+      const partial = toTemporalPartial(date, ['year', 'month']);
+
+      expect(isTemporalPartSet(partial, 'year')).toBe(true);
+      expect(isTemporalPartSet(partial, 'month')).toBe(true);
+    });
+
+    test('returns false for unset parts', () => {
+      const date = now('UTC');
+      const partial = toTemporalPartial(date, ['year']);
+
+      expect(isTemporalPartSet(partial, 'month')).toBe(false);
+      expect(isTemporalPartSet(partial, 'day')).toBe(false);
+    });
+
+    test('handles multiple operations on the same partial', () => {
+      const date = now('UTC');
+      let partial = toTemporalPartial(date, ['year']);
+      partial = toTemporalPartial(partial, ['month']);
+      partial = toTemporalPartial(partial, ['day']);
+
+      expect(isTemporalPartSet(partial, 'year')).toBe(true);
+      expect(isTemporalPartSet(partial, 'month')).toBe(true);
+      expect(isTemporalPartSet(partial, 'day')).toBe(true);
+      expect(isTemporalPartSet(partial, 'hour')).toBe(false);
+    });
+  });
+
+  test('temporal partial maintains date values', () => {
+    const date = now('UTC');
+    const partial = toTemporalPartial(date, ['year', 'month', 'day']);
+
+    expect(partial.year).toBe(date.year);
+    expect(partial.month).toBe(date.month);
+    expect(partial.day).toBe(date.day);
+  });
+});

--- a/packages/core/src/useDateTimeField/temporalPartial.ts
+++ b/packages/core/src/useDateTimeField/temporalPartial.ts
@@ -1,0 +1,34 @@
+import { Temporal } from '@js-temporal/polyfill';
+import { DateTimeSegmentType, TemporalPartial } from './types';
+import { CalendarIdentifier } from '../useCalendar';
+import { isObject } from '../../../shared/src';
+
+export function createTemporalPartial(calendar: CalendarIdentifier, timeZone: string) {
+  const zonedDateTime = Temporal.Now.zonedDateTime(calendar, timeZone);
+  zonedDateTime['~fw_temporal_partial'] = {};
+
+  return zonedDateTime as TemporalPartial;
+}
+
+export function toTemporalPartial(
+  value: Temporal.ZonedDateTime | TemporalPartial,
+  setParts?: DateTimeSegmentType[],
+): TemporalPartial {
+  const clone = Temporal.ZonedDateTime.from(value);
+  clone['~fw_temporal_partial'] = isTemporalPartial(value) ? value['~fw_temporal_partial'] : {};
+  if (setParts) {
+    setParts.forEach(part => {
+      clone['~fw_temporal_partial'][part] = true;
+    });
+  }
+
+  return clone as TemporalPartial;
+}
+
+export function isTemporalPartial(value: Temporal.ZonedDateTime): value is TemporalPartial {
+  return isObject(value['~fw_temporal_partial']);
+}
+
+export function isTemporalPartSet(value: TemporalPartial, part: DateTimeSegmentType): boolean {
+  return part in value['~fw_temporal_partial'] && value['~fw_temporal_partial'][part] === true;
+}

--- a/packages/core/src/useDateTimeField/temporalPartial.ts
+++ b/packages/core/src/useDateTimeField/temporalPartial.ts
@@ -4,17 +4,17 @@ import { CalendarIdentifier } from '../useCalendar';
 import { isObject } from '../../../shared/src';
 
 export function createTemporalPartial(calendar: CalendarIdentifier, timeZone: string) {
-  const zonedDateTime = Temporal.Now.zonedDateTime(calendar, timeZone);
+  const zonedDateTime = Temporal.Now.zonedDateTime(calendar, timeZone) as TemporalPartial;
   zonedDateTime['~fw_temporal_partial'] = {};
 
-  return zonedDateTime as TemporalPartial;
+  return zonedDateTime;
 }
 
 export function toTemporalPartial(
   value: Temporal.ZonedDateTime | TemporalPartial,
   setParts?: DateTimeSegmentType[],
 ): TemporalPartial {
-  const clone = Temporal.ZonedDateTime.from(value);
+  const clone = Temporal.ZonedDateTime.from(value) as TemporalPartial;
   clone['~fw_temporal_partial'] = isTemporalPartial(value) ? value['~fw_temporal_partial'] : {};
   if (setParts) {
     setParts.forEach(part => {
@@ -22,11 +22,11 @@ export function toTemporalPartial(
     });
   }
 
-  return clone as TemporalPartial;
+  return clone;
 }
 
 export function isTemporalPartial(value: Temporal.ZonedDateTime): value is TemporalPartial {
-  return isObject(value['~fw_temporal_partial']);
+  return isObject((value as TemporalPartial)['~fw_temporal_partial']);
 }
 
 export function isTemporalPartSet(value: TemporalPartial, part: DateTimeSegmentType): boolean {

--- a/packages/core/src/useDateTimeField/temporalPartial.ts
+++ b/packages/core/src/useDateTimeField/temporalPartial.ts
@@ -1,20 +1,19 @@
-import { Temporal } from '@js-temporal/polyfill';
 import { DateTimeSegmentType, TemporalPartial } from './types';
-import { CalendarIdentifier } from '../useCalendar';
 import { isObject } from '../../../shared/src';
+import { Calendar, ZonedDateTime, fromDate, now } from '@internationalized/date';
 
-export function createTemporalPartial(calendar: CalendarIdentifier, timeZone: string) {
-  const zonedDateTime = Temporal.Now.zonedDateTime(calendar, timeZone) as TemporalPartial;
+export function createTemporalPartial(calendar: Calendar, timeZone: string) {
+  const zonedDateTime = now(timeZone) as TemporalPartial;
   zonedDateTime['~fw_temporal_partial'] = {};
 
   return zonedDateTime;
 }
 
 export function toTemporalPartial(
-  value: Temporal.ZonedDateTime | TemporalPartial,
+  value: ZonedDateTime | TemporalPartial,
   setParts?: DateTimeSegmentType[],
 ): TemporalPartial {
-  const clone = Temporal.ZonedDateTime.from(value) as TemporalPartial;
+  const clone = fromDate(value.toDate(), value.timeZone) as TemporalPartial;
   clone['~fw_temporal_partial'] = isTemporalPartial(value) ? value['~fw_temporal_partial'] : {};
   if (setParts) {
     setParts.forEach(part => {
@@ -22,10 +21,10 @@ export function toTemporalPartial(
     });
   }
 
-  return clone;
+  return clone as TemporalPartial;
 }
 
-export function isTemporalPartial(value: Temporal.ZonedDateTime): value is TemporalPartial {
+export function isTemporalPartial(value: ZonedDateTime): value is TemporalPartial {
   return isObject((value as TemporalPartial)['~fw_temporal_partial']);
 }
 

--- a/packages/core/src/useDateTimeField/temporalPartial.ts
+++ b/packages/core/src/useDateTimeField/temporalPartial.ts
@@ -1,9 +1,9 @@
 import { DateTimeSegmentType, TemporalPartial } from './types';
 import { isObject } from '../../../shared/src';
-import { Calendar, ZonedDateTime, fromDate, now } from '@internationalized/date';
+import { Calendar, ZonedDateTime, now, toCalendar } from '@internationalized/date';
 
 export function createTemporalPartial(calendar: Calendar, timeZone: string) {
-  const zonedDateTime = now(timeZone) as TemporalPartial;
+  const zonedDateTime = toCalendar(now(timeZone), calendar) as TemporalPartial;
   zonedDateTime['~fw_temporal_partial'] = {};
 
   return zonedDateTime;
@@ -13,7 +13,7 @@ export function toTemporalPartial(
   value: ZonedDateTime | TemporalPartial,
   setParts?: DateTimeSegmentType[],
 ): TemporalPartial {
-  const clone = fromDate(value.toDate(), value.timeZone) as TemporalPartial;
+  const clone = value.copy() as TemporalPartial;
   clone['~fw_temporal_partial'] = isTemporalPartial(value) ? value['~fw_temporal_partial'] : {};
   if (setParts) {
     setParts.forEach(part => {

--- a/packages/core/src/useDateTimeField/types.ts
+++ b/packages/core/src/useDateTimeField/types.ts
@@ -25,3 +25,23 @@ export type TemporalDate =
   | Temporal.ZonedDateTime;
 
 export type DateValue = Date | TemporalDate;
+
+export type CalendarIdentifier =
+  | 'buddhist'
+  | 'chinese'
+  | 'coptic'
+  | 'dangi'
+  | 'ethioaa'
+  | 'ethiopic'
+  | 'gregory'
+  | 'hebrew'
+  | 'indian'
+  | 'islamic'
+  | 'islamic-umalqura'
+  | 'islamic-tbla'
+  | 'islamic-civil'
+  | 'islamic-rgsa'
+  | 'iso8601'
+  | 'japanese'
+  | 'persian'
+  | 'roc';

--- a/packages/core/src/useDateTimeField/types.ts
+++ b/packages/core/src/useDateTimeField/types.ts
@@ -30,5 +30,4 @@ export type TemporalPartial = Temporal.ZonedDateTime & {
   [`~fw_temporal_partial`]: {
     [key: string]: boolean | undefined;
   };
-  [`~fw_temporal_full_partial`]?: true;
 };

--- a/packages/core/src/useDateTimeField/types.ts
+++ b/packages/core/src/useDateTimeField/types.ts
@@ -16,7 +16,7 @@ export type DateTimeSegmentType =
   | 'weekday'
   | 'year';
 
-export type TemporalDate =
+export type TemporalValue =
   | Temporal.Instant
   | Temporal.PlainDate
   | Temporal.PlainDateTime
@@ -24,24 +24,4 @@ export type TemporalDate =
   | Temporal.PlainYearMonth
   | Temporal.ZonedDateTime;
 
-export type DateValue = Date | TemporalDate;
-
-export type CalendarIdentifier =
-  | 'buddhist'
-  | 'chinese'
-  | 'coptic'
-  | 'dangi'
-  | 'ethioaa'
-  | 'ethiopic'
-  | 'gregory'
-  | 'hebrew'
-  | 'indian'
-  | 'islamic'
-  | 'islamic-umalqura'
-  | 'islamic-tbla'
-  | 'islamic-civil'
-  | 'islamic-rgsa'
-  | 'iso8601'
-  | 'japanese'
-  | 'persian'
-  | 'roc';
+export type DateValue = Date | TemporalValue;

--- a/packages/core/src/useDateTimeField/types.ts
+++ b/packages/core/src/useDateTimeField/types.ts
@@ -1,4 +1,4 @@
-import type { Temporal } from '@js-temporal/polyfill';
+import { ZonedDateTime } from '@internationalized/date';
 
 /**
  * lib.es2017.intl.d.ts
@@ -16,17 +16,9 @@ export type DateTimeSegmentType =
   | 'weekday'
   | 'year';
 
-export type TemporalValue =
-  | Temporal.Instant
-  | Temporal.PlainDate
-  | Temporal.PlainDateTime
-  | Temporal.PlainTime
-  | Temporal.PlainYearMonth
-  | Temporal.ZonedDateTime;
+export type DateValue = Date | ZonedDateTime;
 
-export type DateValue = Date | TemporalValue;
-
-export type TemporalPartial = Temporal.ZonedDateTime & {
+export type TemporalPartial = ZonedDateTime & {
   [`~fw_temporal_partial`]: {
     [key: string]: boolean | undefined;
   };

--- a/packages/core/src/useDateTimeField/types.ts
+++ b/packages/core/src/useDateTimeField/types.ts
@@ -25,3 +25,10 @@ export type TemporalValue =
   | Temporal.ZonedDateTime;
 
 export type DateValue = Date | TemporalValue;
+
+export type TemporalPartial = Temporal.ZonedDateTime & {
+  [`~fw_temporal_partial`]: {
+    [key: string]: boolean | undefined;
+  };
+  [`~fw_temporal_full_partial`]?: true;
+};

--- a/packages/core/src/useDateTimeField/useCalendar.ts
+++ b/packages/core/src/useDateTimeField/useCalendar.ts
@@ -1,0 +1,124 @@
+import { computed, MaybeRefOrGetter, Ref, toValue } from 'vue';
+import { Temporal } from '@js-temporal/polyfill';
+import { CalendarIdentifier } from './types';
+import { normalizeProps } from '../utils/common';
+import { Reactivify } from '../types';
+import { useDateFormatter, useLocale } from '../i18n';
+import { WeekInfo } from '../i18n/getWeekInfo';
+
+interface CalendarProps {
+  locale: string;
+
+  calendar: CalendarIdentifier;
+
+  currentDate: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime;
+}
+
+export interface CalendarDay {
+  value: Temporal.PlainMonthDay;
+  dayOfMonth: number;
+  isToday: boolean;
+  isSelected: boolean;
+  isOutsideMonth: boolean;
+}
+
+interface CalendarContext {
+  locale: Ref<string>;
+  weekInfo: Ref<WeekInfo>;
+  calendar: Ref<Temporal.Calendar>;
+  currentDate: MaybeRefOrGetter<Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime>;
+}
+
+export function useCalendar(_props: Reactivify<CalendarProps>) {
+  const props = normalizeProps(_props);
+  const { weekInfo, locale } = useLocale(props.locale);
+  const calendar = computed(() => new Temporal.Calendar(toValue(props.calendar)));
+  const context: CalendarContext = {
+    weekInfo,
+    locale,
+    calendar,
+    currentDate: props.currentDate,
+  };
+
+  const { daysOfTheWeek } = useDaysOfTheWeek(context);
+  const { days } = useCalendarDays(context);
+
+  return {
+    calendar,
+    days,
+    daysOfTheWeek,
+  };
+}
+
+function useDaysOfTheWeek({ weekInfo, locale, currentDate }: CalendarContext) {
+  const longFormatter = useDateFormatter(locale, { weekday: 'long' });
+  const shortFormatter = useDateFormatter(locale, { weekday: 'short' });
+  const narrowFormatter = useDateFormatter(locale, { weekday: 'narrow' });
+
+  const daysOfTheWeek = computed(() => {
+    let current = toValue(currentDate);
+    const daysPerWeek = current.daysInWeek;
+    const firstDayOfWeek = weekInfo.value.firstDay;
+    // Get the current date's day of week (0-6)
+    const currentDayOfWeek = current.dayOfWeek;
+
+    // Calculate how many days to go back to reach first day of week
+    const daysToSubtract = (currentDayOfWeek - firstDayOfWeek + 7) % 7;
+
+    // Move current date back to first day of week
+    current = current.subtract({ days: daysToSubtract });
+
+    const days: {
+      long: string;
+      short: string;
+      narrow: string;
+    }[] = [];
+    for (let i = 0; i < daysPerWeek; i++) {
+      days.push({
+        long: longFormatter.value.format(current.add({ days: i })),
+        short: shortFormatter.value.format(current.add({ days: i })),
+        narrow: narrowFormatter.value.format(current.add({ days: i })),
+      });
+    }
+
+    return days;
+  });
+
+  return { daysOfTheWeek };
+}
+
+function useCalendarDays({ weekInfo, currentDate, calendar }: CalendarContext) {
+  const days = computed<CalendarDay[]>(() => {
+    const current = toValue(currentDate);
+    const plainCurrent = current.toPlainMonthDay();
+    const startOfMonth = current.with({ day: 1 });
+
+    const firstDayOfWeek = weekInfo.value.firstDay;
+    const startDayOfWeek = startOfMonth.dayOfWeek;
+    const daysToSubtract = (startDayOfWeek - firstDayOfWeek + 7) % 7;
+
+    // Move to first day of week
+    const firstDay = startOfMonth.subtract({ days: daysToSubtract });
+
+    // Calculate total days needed to fill grid
+    const daysInMonth = startOfMonth.daysInMonth;
+    const totalDays = daysInMonth + daysToSubtract;
+    const remainingDays = 7 - (totalDays % 7);
+    const gridDays = totalDays + (remainingDays === 7 ? 0 : remainingDays);
+    const now = Temporal.Now.plainDate(calendar.value);
+
+    return Array.from({ length: gridDays }, (_, i) => {
+      const dayOfMonth = firstDay.add({ days: i }).toPlainMonthDay();
+
+      return {
+        value: dayOfMonth,
+        dayOfMonth: dayOfMonth.day,
+        isToday: dayOfMonth.equals(now),
+        isSelected: plainCurrent.equals(dayOfMonth),
+        isOutsideMonth: dayOfMonth.monthCode !== plainCurrent.monthCode,
+      } as CalendarDay;
+    });
+  });
+
+  return { days };
+}

--- a/packages/core/src/useDateTimeField/useCalendar.ts
+++ b/packages/core/src/useDateTimeField/useCalendar.ts
@@ -7,11 +7,11 @@ import { useDateFormatter, useLocale } from '../i18n';
 import { WeekInfo } from '../i18n/getWeekInfo';
 
 interface CalendarProps {
-  locale: string;
+  locale?: string;
 
-  calendar: CalendarIdentifier;
+  calendar?: CalendarIdentifier;
 
-  currentDate: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime;
+  currentDate?: Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime;
 }
 
 export interface CalendarDay {
@@ -29,15 +29,16 @@ interface CalendarContext {
   currentDate: MaybeRefOrGetter<Temporal.PlainDate | Temporal.PlainDateTime | Temporal.ZonedDateTime>;
 }
 
-export function useCalendar(_props: Reactivify<CalendarProps>) {
+export function useCalendar(_props: Reactivify<CalendarProps> = {}) {
   const props = normalizeProps(_props);
-  const { weekInfo, locale } = useLocale(props.locale);
-  const calendar = computed(() => new Temporal.Calendar(toValue(props.calendar)));
+  const { weekInfo, locale, calendar } = useLocale(props.locale);
+  const currentDate = computed(() => toValue(props.currentDate) ?? Temporal.Now.plainDate(calendar.value));
+
   const context: CalendarContext = {
     weekInfo,
     locale,
     calendar,
-    currentDate: props.currentDate,
+    currentDate,
   };
 
   const { daysOfTheWeek } = useDaysOfTheWeek(context);

--- a/packages/core/src/useDateTimeField/useDateTimeField.spec.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.spec.ts
@@ -1,0 +1,371 @@
+import { render, screen } from '@testing-library/vue';
+import { axe } from 'vitest-axe';
+import { useDateTimeField } from './';
+import { flush } from '@test-utils/flush';
+import { createCalendar, now, toCalendar } from '@internationalized/date';
+import { DateTimeSegment } from './useDateTimeSegment';
+import { ref, toValue } from 'vue';
+import { StandardSchema } from '../types';
+
+describe('useDateTimeField', () => {
+  const currentDate = new Date('2024-03-15T12:00:00Z');
+
+  describe('initialization', () => {
+    test('initializes with value prop', async () => {
+      await render({
+        components: { DateTimeSegment },
+        setup() {
+          const { segments, controlProps, labelProps } = useDateTimeField({
+            label: 'Date',
+            name: 'date',
+            value: currentDate,
+          });
+
+          return {
+            segments,
+            controlProps,
+            labelProps,
+          };
+        },
+        template: `
+          <div>
+            <label v-bind="labelProps">Date</label>
+            <div v-bind="controlProps">
+              <DateTimeSegment
+                v-for="segment in segments"
+                :key="segment.type"
+                v-bind="segment"
+                data-testid="segment"
+              />
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      const segments = screen.getAllByTestId('segment');
+      const monthSegment = segments.find(el => el.dataset.segmentType === 'month');
+      const daySegment = segments.find(el => el.dataset.segmentType === 'day');
+      const yearSegment = segments.find(el => el.dataset.segmentType === 'year');
+
+      expect(monthSegment?.textContent).toBe('3');
+      expect(daySegment?.textContent).toBe('15');
+      expect(yearSegment?.textContent).toBe('2024');
+    });
+
+    test('initializes with modelValue prop', async () => {
+      const modelValue = ref(currentDate);
+
+      await render({
+        components: { DateTimeSegment },
+        setup() {
+          const { segments, controlProps, labelProps } = useDateTimeField({
+            label: 'Date',
+            name: 'date',
+            modelValue,
+          });
+
+          return {
+            segments,
+            controlProps,
+            labelProps,
+          };
+        },
+        template: `
+          <div>
+            <label v-bind="labelProps">Date</label>
+            <div v-bind="controlProps">
+              <DateTimeSegment
+                v-for="segment in segments"
+                :key="segment.type"
+                v-bind="segment"
+                data-testid="segment"
+              />
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      const segments = screen.getAllByTestId('segment');
+      const monthSegment = segments.find(el => el.dataset.segmentType === 'month');
+      expect(monthSegment?.textContent).toBe('3');
+    });
+  });
+
+  describe('calendar systems', () => {
+    test('supports different calendar systems', async () => {
+      const calendar = createCalendar('islamic-umalqura');
+      const date = toCalendar(now('UTC'), calendar).set({ year: 1445, month: 9, day: 5 }); // Islamic date
+
+      await render({
+        components: { DateTimeSegment },
+        setup() {
+          const { segments, controlProps, labelProps } = useDateTimeField({
+            label: 'Date',
+            name: 'date',
+            calendar,
+            value: date.toDate(),
+          });
+
+          return {
+            segments,
+            controlProps,
+            labelProps,
+          };
+        },
+        template: `
+          <div>
+            <label v-bind="labelProps">Date</label>
+            <div v-bind="controlProps">
+              <DateTimeSegment
+                v-for="segment in segments"
+                :key="segment.type"
+                v-bind="segment"
+                data-testid="segment"
+              />
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      const segments = screen.getAllByTestId('segment');
+      const monthSegment = segments.find(el => el.dataset.segmentType === 'month');
+      const yearSegment = segments.find(el => el.dataset.segmentType === 'year');
+
+      expect(monthSegment?.textContent).toBe('9');
+      expect(yearSegment?.textContent).toBe('1445');
+    });
+  });
+
+  describe('accessibility', () => {
+    test('provides accessible label and description', async () => {
+      await render({
+        components: { DateTimeSegment },
+        setup() {
+          const { segments, controlProps, labelProps, descriptionProps } = useDateTimeField({
+            label: 'Birth Date',
+            name: 'birthDate',
+            description: 'Enter your date of birth',
+          });
+
+          return {
+            segments,
+            controlProps,
+            labelProps,
+            descriptionProps,
+          };
+        },
+        template: `
+          <div data-testid="fixture">
+            <span v-bind="labelProps">Birth Date</span>
+            <div v-bind="controlProps">
+              <DateTimeSegment
+                v-for="segment in segments"
+                :key="segment.type"
+                v-bind="segment"
+                data-testid="segment"
+              />
+            </div>
+            <div v-bind="descriptionProps">Enter your date of birth</div>
+          </div>
+        `,
+      });
+
+      await flush();
+      vi.useRealTimers();
+      expect(await axe(screen.getByTestId('fixture'))).toHaveNoViolations();
+      vi.useFakeTimers();
+
+      const control = screen.getByRole('group');
+      expect(control).toHaveAccessibleDescription('Enter your date of birth');
+      expect(control).toHaveAccessibleName('Birth Date');
+    });
+
+    test('shows error message when validation fails', async () => {
+      const schema: StandardSchema<Date, Date> = {
+        '~standard': {
+          vendor: 'formwerk',
+          version: 1,
+          validate: value => {
+            if (!value) {
+              return {
+                issues: [{ path: [], message: 'Date is required' }],
+              };
+            }
+
+            return {
+              value: value as Date,
+            };
+          },
+        },
+      };
+
+      await render({
+        components: { DateTimeSegment },
+        setup() {
+          const { segments, controlProps, labelProps, errorMessageProps, errorMessage } = useDateTimeField({
+            label: 'Date',
+            name: 'date',
+            schema,
+          });
+
+          return {
+            segments,
+            controlProps,
+            labelProps,
+            errorMessageProps,
+            errorMessage,
+          };
+        },
+        template: `
+          <div>
+            <span v-bind="labelProps">Date</span>
+            <div v-bind="controlProps">
+              <DateTimeSegment
+                v-for="segment in segments"
+                :key="segment.type"
+                v-bind="segment"
+                data-testid="segment"
+              />
+            </div>
+            <div v-bind="errorMessageProps" data-testid="error">{{ errorMessage }}</div>
+          </div>
+        `,
+      });
+
+      await flush();
+      const control = screen.getByRole('group');
+      expect(control).toHaveErrorMessage('Date is required');
+    });
+
+    test('updates validation when date changes', async () => {
+      const modelValue = ref<Date | undefined>(undefined);
+      let updateVal!: (value: Date) => void;
+      const schema: StandardSchema<Date, Date> = {
+        '~standard': {
+          vendor: 'formwerk',
+          version: 1,
+          validate: value => {
+            if (!value) {
+              return {
+                issues: [{ path: [], message: 'Date is required' }],
+              };
+            }
+
+            // Date must be in the future
+            if ((value as Date).getTime() < new Date().getTime()) {
+              return {
+                issues: [{ path: [], message: 'Date must be in the future' }],
+              };
+            }
+
+            return {
+              value: value as Date,
+            };
+          },
+        },
+      };
+
+      await render({
+        components: { DateTimeSegment },
+        setup() {
+          const { segments, controlProps, labelProps, errorMessageProps, errorMessage, setValue } = useDateTimeField({
+            label: 'Date',
+            name: 'date',
+            modelValue,
+            schema,
+          });
+          updateVal = (value: Date) => {
+            setValue(value);
+          };
+
+          return {
+            segments,
+            controlProps,
+            labelProps,
+            errorMessageProps,
+            errorMessage,
+          };
+        },
+        template: `
+          <div>
+            <span v-bind="labelProps">Date</span>
+            <div v-bind="controlProps">
+              <DateTimeSegment
+                v-for="segment in segments"
+                :key="segment.type"
+                v-bind="segment"
+                data-testid="segment"
+              />
+            </div>
+            <div v-bind="errorMessageProps" data-testid="error">{{ errorMessage }}</div>
+          </div>
+        `,
+      });
+
+      await flush();
+      const control = screen.getByRole('group');
+
+      // Initially should show required error
+      expect(control).toHaveErrorMessage('Date is required');
+
+      updateVal(new Date('2025-01-01'));
+      await flush();
+      expect(control).toHaveErrorMessage('Date must be in the future');
+
+      // Set to a future date
+      updateVal(new Date());
+      await flush();
+      expect(control).not.toHaveErrorMessage();
+    });
+  });
+
+  describe('constraints', () => {
+    test('respects min and max date constraints', async () => {
+      const minDate = now('UTC');
+      const maxDate = now('UTC').add({ days: 1 });
+
+      await render({
+        components: { DateTimeSegment },
+        setup() {
+          const props = useDateTimeField({
+            label: 'Date',
+            name: 'date',
+            timeZone: 'UTC',
+            min: minDate.toDate(),
+            max: maxDate.toDate(),
+            value: currentDate,
+          });
+
+          const { segments, controlProps, labelProps } = props;
+
+          expect(toValue(props.calendarProps.minDate)).toEqual(minDate);
+          expect(toValue(props.calendarProps.maxDate)).toEqual(maxDate);
+
+          return {
+            segments,
+            controlProps,
+            labelProps,
+          };
+        },
+        template: `
+          <div>
+            <label v-bind="labelProps">Date</label>
+            <div v-bind="controlProps">
+              <DateTimeSegment
+                v-for="segment in segments"
+                :key="segment.type"
+                v-bind="segment"
+                data-testid="segment"
+              />
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+    });
+  });
+});

--- a/packages/core/src/useDateTimeField/useDateTimeField.spec.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.spec.ts
@@ -387,8 +387,8 @@ describe('useDateTimeField', () => {
 
           const { segments, controlProps, labelProps } = props;
 
-          expect(toValue(props.calendarProps.minDate)).toEqual(minDate);
-          expect(toValue(props.calendarProps.maxDate)).toEqual(maxDate);
+          expect(toValue(props.calendarProps.value.min)).toEqual(minDate.toDate());
+          expect(toValue(props.calendarProps.value.max)).toEqual(maxDate.toDate());
 
           return {
             segments,

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -10,6 +10,7 @@ import { useErrorMessage, useLabel } from '../a11y';
 import { fromDateToCalendarZonedDateTime, useTemporalStore } from './useTemporalStore';
 import { ZonedDateTime, Calendar } from '@internationalized/date';
 import { useInputValidity } from '../validation';
+import { createDisabledContext } from '../helpers/createDisabledContext';
 
 export interface DateTimeFieldProps {
   /**
@@ -96,6 +97,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     timeZone: () => toValue(props.timeZone),
   });
 
+  const isDisabled = createDisabledContext(props.disabled);
   const formatter = useDateFormatter(locale, props.formatOptions);
   const controlId = useUniqId(FieldTypePrefixes.DateTimeField);
 
@@ -126,8 +128,10 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     formatter,
     locale,
     formatOptions: props.formatOptions,
+    direction,
     controlEl,
     temporalValue,
+    readonly: props.readonly,
     onValueChange,
     onTouched: () => field.setTouched(true),
     min: computed(() => fromDateToCalendarZonedDateTime(toValue(props.min), calendar.value, timeZone.value)),
@@ -172,6 +176,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
         ...labelledByProps.value,
         ...describedByProps.value,
         ...accessibleErrorProps.value,
+        'aria-disabled': isDisabled.value || undefined,
       },
       controlEl,
     );

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -95,7 +95,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
   const field = useFormField<Maybe<Date>>({
     path: props.name,
     disabled: props.disabled,
-    initialValue: toValue(props.modelValue) ?? toValue(props.value) ?? new Date(),
+    initialValue: toValue(props.modelValue) ?? toValue(props.value),
     schema: props.schema,
   });
 

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -1,5 +1,5 @@
 import { Maybe, Reactivify } from '../types';
-import { CalendarProps } from '../useCalendar';
+import { CalendarIdentifier, CalendarProps } from '../useCalendar';
 import { createDescribedByProps, isNullOrUndefined, normalizeProps, useUniqId, withRefCapture } from '../utils/common';
 import { computed, shallowRef, toValue } from 'vue';
 import { exposeField, useFormField } from '../useFormField';
@@ -29,7 +29,10 @@ export interface DateTimeFieldProps {
 export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'>) {
   const props = normalizeProps(_props, ['schema']);
   const controlEl = shallowRef<HTMLInputElement>();
-  const { locale } = useLocale(props.locale);
+  const { locale, direction } = useLocale(props.locale, {
+    calendar: () => toValue(props.formatOptions)?.calendar as CalendarIdentifier,
+  });
+
   const formatter = useDateFormatter(locale, props.formatOptions);
   const controlId = useUniqId(FieldTypePrefixes.DateTimeField);
 
@@ -101,6 +104,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
       segments,
       errorMessageProps,
       calendarProps,
+      direction,
     },
     field,
   );

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -21,7 +21,7 @@ export interface DateTimeFieldProps {
   /**
    * The name to use for the field.
    */
-  name: string;
+  name?: string;
 
   /**
    * The locale to use for the field.

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -75,12 +75,12 @@ export interface DateTimeFieldProps {
   /**
    * The minimum date to use for the field.
    */
-  minDate?: Date;
+  min?: Date;
 
   /**
    * The maximum date to use for the field.
    */
-  maxDate?: Date;
+  max?: Date;
 }
 
 export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'>) {
@@ -105,7 +105,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     timeZone: timeZone,
     locale: locale,
     model: {
-      get: () => toValue(props.minDate),
+      get: () => toValue(props.min),
     },
   });
 
@@ -114,7 +114,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     timeZone: timeZone,
     locale: locale,
     model: {
-      get: () => toValue(props.maxDate),
+      get: () => toValue(props.max),
     },
   });
 
@@ -160,6 +160,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
   const calendarProps: Reactivify<CalendarProps, 'onDaySelected'> = {
     locale: () => locale.value,
     currentDate: temporalValue,
+    calendar: calendar,
     onDaySelected: onValueChange,
     minDate: () => (isTemporalPartial(minDate.value) ? undefined : minDate.value),
     maxDate: () => (isTemporalPartial(maxDate.value) ? undefined : maxDate.value),

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -1,4 +1,4 @@
-import { Maybe, Reactivify } from '../types';
+import { Maybe, Reactivify, StandardSchema } from '../types';
 import { CalendarIdentifier, CalendarProps } from '../useCalendar';
 import { createDescribedByProps, isNullOrUndefined, normalizeProps, useUniqId, withRefCapture } from '../utils/common';
 import { computed, shallowRef, toValue } from 'vue';
@@ -12,25 +12,72 @@ import { DateValue } from './types';
 import { Temporal, toTemporalInstant } from '@js-temporal/polyfill';
 
 export interface DateTimeFieldProps {
+  /**
+   * The label to use for the field.
+   */
   label: string;
-  locale?: string;
+
+  /**
+   * The name to use for the field.
+   */
   name: string;
+
+  /**
+   * The locale to use for the field.
+   */
+  locale?: string;
+
+  /**
+   * The calendar type to use for the field, e.g. `gregory`, `islamic-umalqura`, etc.
+   */
+  calendar?: CalendarIdentifier;
+
+  /**
+   * The Intl.DateTimeFormatOptions to use for the field, used to format the date value.
+   */
   formatOptions?: Intl.DateTimeFormatOptions;
+
+  /**
+   * The description to use for the field.
+   */
   description?: string;
+
+  /**
+   * The placeholder to use for the field.
+   */
   placeholder?: string;
+
+  /**
+   * Whether the field is readonly.
+   */
   readonly?: boolean;
+
+  /**
+   * Whether the field is disabled.
+   */
   disabled?: boolean;
+
+  /**
+   * The value to use for the field.
+   */
   value?: DateValue;
+
+  /**
+   * The model value to use for the field.
+   */
   modelValue?: DateValue;
 
-  schema?: any;
+  /**
+   * The schema to use for the field.
+   */
+  schema?: StandardSchema<DateValue>;
 }
 
 export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'>) {
   const props = normalizeProps(_props, ['schema']);
   const controlEl = shallowRef<HTMLInputElement>();
   const { locale, direction } = useLocale(props.locale, {
-    calendar: () => toValue(props.formatOptions)?.calendar as CalendarIdentifier,
+    calendar: () => toValue(props.calendar) ?? (toValue(props.formatOptions)?.calendar as CalendarIdentifier),
   });
 
   const formatter = useDateFormatter(locale, props.formatOptions);

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -99,6 +99,24 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     schema: props.schema,
   });
 
+  const minDate = useTemporalStore({
+    calendar: calendar,
+    timeZone: timeZone,
+    locale: locale,
+    model: {
+      get: () => toValue(props.minDate),
+    },
+  });
+
+  const maxDate = useTemporalStore({
+    calendar: calendar,
+    timeZone: timeZone,
+    locale: locale,
+    model: {
+      get: () => toValue(props.maxDate),
+    },
+  });
+
   const temporalValue = useTemporalStore({
     calendar: calendar,
     timeZone: timeZone,
@@ -142,6 +160,8 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     locale: () => locale.value,
     currentDate: temporalValue,
     onDaySelected: onValueChange,
+    minDate,
+    maxDate,
   };
 
   const controlProps = computed(() => {

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -10,6 +10,7 @@ import { useErrorMessage, useLabel } from '../a11y';
 import { useTemporalStore } from './useTemporalStore';
 import { ZonedDateTime, Calendar } from '@internationalized/date';
 import { isTemporalPartial } from './temporalPartial';
+import { useInputValidity } from '../validation';
 
 export interface DateTimeFieldProps {
   /**
@@ -31,6 +32,11 @@ export interface DateTimeFieldProps {
    * The calendar type to use for the field, e.g. `gregory`, `islamic-umalqura`, etc.
    */
   calendar?: Calendar;
+
+  /**
+   * The time zone to use for the field, e.g. `UTC`, `America/New_York`, etc.
+   */
+  timeZone?: string;
 
   /**
    * The Intl.DateTimeFormatOptions to use for the field, used to format the date value.
@@ -88,6 +94,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
   const controlEl = shallowRef<HTMLInputElement>();
   const { locale, direction, timeZone, calendar } = useLocale(props.locale, {
     calendar: () => toValue(props.calendar),
+    timeZone: () => toValue(props.timeZone),
   });
 
   const formatter = useDateFormatter(locale, props.formatOptions);
@@ -99,6 +106,8 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     initialValue: toValue(props.modelValue) ?? toValue(props.value),
     schema: props.schema,
   });
+
+  useInputValidity({ field });
 
   const minDate = useTemporalStore({
     calendar: calendar,
@@ -170,6 +179,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     return withRefCapture(
       {
         id: controlId,
+        role: 'group',
         ...labelledByProps.value,
         ...describedByProps.value,
         ...accessibleErrorProps.value,

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -1,5 +1,5 @@
 import { Maybe, Reactivify, StandardSchema } from '../types';
-import { CalendarProps } from '../useCalendar';
+import type { CalendarProps } from '../useCalendar';
 import { createDescribedByProps, normalizeProps, useUniqId, withRefCapture } from '../utils/common';
 import { computed, shallowRef, toValue } from 'vue';
 import { exposeField, useFormField } from '../useFormField';
@@ -179,13 +179,39 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
 
   return exposeField(
     {
-      controlEl,
+      /**
+       * The props to use for the control element.
+       */
       controlProps,
+
+      /**
+       * The props to use for the description element.
+       */
       descriptionProps,
+
+      /**
+       * The props to use for the label element.
+       */
       labelProps,
-      segments,
+
+      /**
+       * The props to use for the error message element.
+       */
       errorMessageProps,
+
+      /**
+       * The datetime segments, you need to render these with the `DateTimeSegment` component.
+       */
+      segments,
+
+      /**
+       * The props to use for the calendar composable/component.
+       */
       calendarProps,
+
+      /**
+       * The direction of the field.
+       */
       direction,
     },
     field,

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -9,6 +9,7 @@ import { useDateFormatter, useLocale } from '../i18n';
 import { useErrorMessage, useLabel } from '../a11y';
 import { useTemporalStore } from './useTemporalStore';
 import { Temporal } from '@js-temporal/polyfill';
+import { isTemporalPartial } from './temporalPartial';
 
 export interface DateTimeFieldProps {
   /**
@@ -160,8 +161,8 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     locale: () => locale.value,
     currentDate: temporalValue,
     onDaySelected: onValueChange,
-    minDate,
-    maxDate,
+    minDate: () => (isTemporalPartial(minDate.value) ? undefined : minDate.value),
+    maxDate: () => (isTemporalPartial(maxDate.value) ? undefined : maxDate.value),
   };
 
   const controlProps = computed(() => {

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -167,11 +167,13 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     errorMessage: field.errorMessage,
   });
 
-  const calendarProps: Reactivify<CalendarProps, 'onDaySelected'> = {
+  const calendarProps: Reactivify<CalendarProps, 'onUpdateModelValue'> = {
+    label: props.label,
     locale: () => locale.value,
-    currentDate: temporalValue,
+    name: undefined,
+    modelValue: temporalValue,
     calendar: calendar,
-    onDaySelected: onValueChange,
+    onUpdateModelValue: onValueChange,
     minDate: () => (isTemporalPartial(minDate.value) ? undefined : minDate.value),
     maxDate: () => (isTemporalPartial(maxDate.value) ? undefined : maxDate.value),
   };

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -167,15 +167,14 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     errorMessage: field.errorMessage,
   });
 
-  const calendarProps: Reactivify<CalendarProps, 'onUpdateModelValue'> = {
+  const calendarProps: Reactivify<CalendarProps, 'field' | 'schema'> = {
     label: props.label,
     locale: () => locale.value,
     name: undefined,
-    modelValue: temporalValue,
     calendar: calendar,
-    onUpdateModelValue: onValueChange,
     minDate: () => (isTemporalPartial(minDate.value) ? undefined : minDate.value),
     maxDate: () => (isTemporalPartial(maxDate.value) ? undefined : maxDate.value),
+    field,
   };
 
   const controlProps = computed(() => {

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -9,7 +9,6 @@ import { useDateFormatter, useLocale } from '../i18n';
 import { useErrorMessage, useLabel } from '../a11y';
 import { useTemporalStore } from './useTemporalStore';
 import { ZonedDateTime, Calendar } from '@internationalized/date';
-import { isTemporalPartial } from './temporalPartial';
 import { useInputValidity } from '../validation';
 
 export interface DateTimeFieldProps {
@@ -109,24 +108,6 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
 
   useInputValidity({ field });
 
-  const minDate = useTemporalStore({
-    calendar: calendar,
-    timeZone: timeZone,
-    locale: locale,
-    model: {
-      get: () => toValue(props.min),
-    },
-  });
-
-  const maxDate = useTemporalStore({
-    calendar: calendar,
-    timeZone: timeZone,
-    locale: locale,
-    model: {
-      get: () => toValue(props.max),
-    },
-  });
-
   const temporalValue = useTemporalStore({
     calendar: calendar,
     timeZone: timeZone,
@@ -167,15 +148,19 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     errorMessage: field.errorMessage,
   });
 
-  const calendarProps: Reactivify<CalendarProps, 'field' | 'schema'> = {
-    label: props.label,
-    locale: () => locale.value,
-    name: undefined,
-    calendar: calendar,
-    minDate: () => (isTemporalPartial(minDate.value) ? undefined : minDate.value),
-    maxDate: () => (isTemporalPartial(maxDate.value) ? undefined : maxDate.value),
-    field,
-  };
+  const calendarProps = computed(() => {
+    const propsObj: CalendarProps = {
+      label: toValue(props.label),
+      locale: locale.value,
+      name: undefined,
+      calendar: calendar.value,
+      min: toValue(props.min),
+      max: toValue(props.max),
+      field,
+    };
+
+    return propsObj;
+  });
 
   const controlProps = computed(() => {
     return withRefCapture(

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -7,7 +7,7 @@ import { useDateTimeSegmentGroup } from './useDateTimeSegmentGroup';
 import { FieldTypePrefixes } from '../constants';
 import { useDateFormatter, useLocale } from '../i18n';
 import { useErrorMessage, useLabel } from '../a11y';
-import { useTemporalStore } from './useTemporalStore';
+import { fromDateToCalendarZonedDateTime, useTemporalStore } from './useTemporalStore';
 import { ZonedDateTime, Calendar } from '@internationalized/date';
 import { useInputValidity } from '../validation';
 
@@ -130,6 +130,8 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     temporalValue,
     onValueChange,
     onTouched: () => field.setTouched(true),
+    min: computed(() => fromDateToCalendarZonedDateTime(toValue(props.min), calendar.value, timeZone.value)),
+    max: computed(() => fromDateToCalendarZonedDateTime(toValue(props.max), calendar.value, timeZone.value)),
   });
 
   const { labelProps, labelledByProps } = useLabel({

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -1,5 +1,5 @@
 import { Maybe, Reactivify, StandardSchema } from '../types';
-import { CalendarIdentifier, CalendarProps } from '../useCalendar';
+import { CalendarProps } from '../useCalendar';
 import { createDescribedByProps, normalizeProps, useUniqId, withRefCapture } from '../utils/common';
 import { computed, shallowRef, toValue } from 'vue';
 import { exposeField, useFormField } from '../useFormField';
@@ -8,7 +8,7 @@ import { FieldTypePrefixes } from '../constants';
 import { useDateFormatter, useLocale } from '../i18n';
 import { useErrorMessage, useLabel } from '../a11y';
 import { useTemporalStore } from './useTemporalStore';
-import { Temporal } from '@js-temporal/polyfill';
+import { ZonedDateTime, Calendar } from '@internationalized/date';
 import { isTemporalPartial } from './temporalPartial';
 
 export interface DateTimeFieldProps {
@@ -30,7 +30,7 @@ export interface DateTimeFieldProps {
   /**
    * The calendar type to use for the field, e.g. `gregory`, `islamic-umalqura`, etc.
    */
-  calendar?: CalendarIdentifier;
+  calendar?: Calendar;
 
   /**
    * The Intl.DateTimeFormatOptions to use for the field, used to format the date value.
@@ -87,7 +87,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
   const props = normalizeProps(_props, ['schema']);
   const controlEl = shallowRef<HTMLInputElement>();
   const { locale, direction, timeZone, calendar } = useLocale(props.locale, {
-    calendar: () => toValue(props.calendar) ?? (toValue(props.formatOptions)?.calendar as CalendarIdentifier),
+    calendar: () => toValue(props.calendar),
   });
 
   const formatter = useDateFormatter(locale, props.formatOptions);
@@ -128,7 +128,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     },
   });
 
-  function onValueChange(value: Temporal.ZonedDateTime) {
+  function onValueChange(value: ZonedDateTime) {
     temporalValue.value = value;
   }
 

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -148,6 +148,7 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
     controlEl,
     temporalValue,
     onValueChange,
+    onTouched: () => field.setTouched(true),
   });
 
   const { labelProps, labelledByProps } = useLabel({

--- a/packages/core/src/useDateTimeField/useDateTimeField.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeField.ts
@@ -102,6 +102,8 @@ export function useDateTimeField(_props: Reactivify<DateTimeFieldProps, 'schema'
 
   const { segments } = useDateTimeSegmentGroup({
     formatter,
+    locale,
+    formatOptions: props.formatOptions,
     controlEl,
     temporalValue,
     onValueChange,

--- a/packages/core/src/useDateTimeField/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegment.ts
@@ -44,7 +44,7 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
     throw new Error('DateTimeSegmentGroup is not provided');
   }
 
-  const { increment, decrement, setValue, getMetadata, onDone, parser, clear, isPlaceholder } =
+  const { increment, decrement, setValue, getMetadata, onDone, parser, clear, isPlaceholder, onTouched } =
     segmentGroup.useDateSegmentRegistration({
       id,
       getElem: () => segmentEl.value,
@@ -95,8 +95,8 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
       }
     },
     onBlur() {
+      onTouched();
       const { min, max } = getMetadata();
-
       if (isNullOrUndefined(min) || isNullOrUndefined(max)) {
         return;
       }

--- a/packages/core/src/useDateTimeField/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegment.ts
@@ -44,7 +44,7 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
     throw new Error('DateTimeSegmentGroup is not provided');
   }
 
-  const { increment, decrement, setValue, getMetadata, onDone, parser, clear } =
+  const { increment, decrement, setValue, getMetadata, onDone, parser, clear, isPlaceholder } =
     segmentGroup.useDateSegmentRegistration({
       id,
       getElem: () => segmentEl.value,
@@ -67,7 +67,7 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
       }
 
       blockEvent(evt);
-      if (!isNumeric.value) {
+      if (!isNumeric.value && !isPlaceholder()) {
         return;
       }
 

--- a/packages/core/src/useDateTimeField/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegment.ts
@@ -50,6 +50,8 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
     getType: () => toValue(props.type),
   });
 
+  const isNumeric = computed(() => parser.isValidNumberPart(toValue(props.value)));
+
   let currentInput = '';
 
   const handlers = {
@@ -64,6 +66,10 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
       }
 
       blockEvent(evt);
+      if (!isNumeric.value) {
+        return;
+      }
+
       const nextValue = currentInput + evt.data;
       currentInput = nextValue;
 

--- a/packages/core/src/useDateTimeField/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegment.ts
@@ -1,4 +1,4 @@
-import { computed, defineComponent, h, inject, shallowRef, toValue } from 'vue';
+import { computed, CSSProperties, defineComponent, h, inject, shallowRef, toValue } from 'vue';
 import { Reactivify } from '../types';
 import { hasKeyCode, normalizeProps, useUniqId, withRefCapture } from '../utils/common';
 import { DateTimeSegmentGroupKey } from './useDateTimeSegmentGroup';
@@ -24,6 +24,15 @@ export interface DateTimeSegmentProps {
   disabled?: boolean;
 }
 
+interface DateTimeSegmentDomProps {
+  id: string;
+  tabindex: number;
+  contenteditable: string | undefined;
+  'aria-disabled': boolean | undefined;
+  'data-segment-type': DateTimeSegmentType;
+  style?: CSSProperties;
+}
+
 export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
   const props = normalizeProps(_props);
   const id = useUniqId(FieldTypePrefixes.DateTimeSegment);
@@ -42,6 +51,7 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
   });
 
   const handlers = {
+    onFocus() {},
     onKeydown(evt: KeyboardEvent) {
       if (hasKeyCode(evt, 'ArrowUp')) {
         blockEvent(evt);
@@ -62,17 +72,20 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
   };
 
   const segmentProps = computed(() => {
-    return withRefCapture(
-      {
-        id,
-        tabindex: isNonEditable() ? '-1' : '0',
-        contenteditable: isNonEditable() ? undefined : 'plaintext-only',
-        'aria-disabled': toValue(props.disabled),
-        'data-segment-type': toValue(props.type),
-        ...handlers,
-      },
-      segmentEl,
-    );
+    const domProps: DateTimeSegmentDomProps = {
+      id,
+      tabindex: isNonEditable() ? -1 : 0,
+      contenteditable: isNonEditable() ? undefined : 'plaintext-only',
+      'aria-disabled': toValue(props.disabled),
+      'data-segment-type': toValue(props.type),
+      ...handlers,
+    };
+
+    if (isNonEditable()) {
+      domProps.style = { pointerEvents: 'none' };
+    }
+
+    return withRefCapture(domProps, segmentEl);
   });
 
   return {

--- a/packages/core/src/useDateTimeField/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegment.ts
@@ -44,11 +44,12 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
     throw new Error('DateTimeSegmentGroup is not provided');
   }
 
-  const { increment, decrement, setValue, getMetadata, onDone, parser } = segmentGroup.useDateSegmentRegistration({
-    id,
-    getElem: () => segmentEl.value,
-    getType: () => toValue(props.type),
-  });
+  const { increment, decrement, setValue, getMetadata, onDone, parser, clear } =
+    segmentGroup.useDateSegmentRegistration({
+      id,
+      getElem: () => segmentEl.value,
+      getType: () => toValue(props.type),
+    });
 
   const isNumeric = computed(() => parser.isValidNumberPart(toValue(props.value)));
 
@@ -123,6 +124,13 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
           decrement();
         }
         return;
+      }
+
+      if (hasKeyCode(evt, 'Backspace') || hasKeyCode(evt, 'Delete')) {
+        blockEvent(evt);
+        if (!isNonEditable()) {
+          clear();
+        }
       }
     },
   };

--- a/packages/core/src/useDateTimeField/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegment.ts
@@ -27,6 +27,7 @@ export interface DateTimeSegmentProps {
 interface DateTimeSegmentDomProps {
   id: string;
   tabindex: number;
+  role?: string;
   contenteditable: string | undefined;
   'aria-disabled': boolean | undefined;
   'data-segment-type': DateTimeSegmentType;
@@ -36,6 +37,10 @@ interface DateTimeSegmentDomProps {
   inputmode?: string;
   autocorrect?: string;
   enterkeyhint?: string;
+  'aria-valuemin'?: number;
+  'aria-valuemax'?: number;
+  'aria-valuenow'?: number;
+  'aria-valuetext'?: string;
 }
 
 export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
@@ -166,12 +171,23 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
       autocorrect: isNonEditable() ? undefined : 'off',
       spellcheck: isNonEditable() ? undefined : false,
       enterkeyhint: isNonEditable() ? undefined : isLast() ? 'done' : 'next',
-      inputmode: isNonEditable() ? undefined : isNumeric() ? 'numeric' : 'none',
+      inputmode: 'none',
       ...handlers,
       style: {
         caretColor: 'transparent',
       },
     };
+
+    if (isNumeric()) {
+      const { min, max } = getMetadata();
+      const value = parser.parse(toValue(props.value));
+      domProps.role = 'spinbutton';
+      domProps.inputmode = 'numeric';
+      domProps['aria-valuemin'] = min ?? undefined;
+      domProps['aria-valuemax'] = max ?? undefined;
+      domProps['aria-valuenow'] = Number.isNaN(value) ? undefined : value;
+      domProps['aria-valuetext'] = Number.isNaN(value) ? 'Empty' : value.toString();
+    }
 
     if (isNonEditable()) {
       domProps.style.pointerEvents = 'none';

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.spec.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.spec.ts
@@ -1,0 +1,749 @@
+import { DateFormatter, now } from '@internationalized/date';
+import { useDateTimeSegmentGroup } from './useDateTimeSegmentGroup';
+import { ref } from 'vue';
+import { fireEvent, render, screen } from '@testing-library/vue';
+import { flush } from '@test-utils/flush';
+import { DateTimeSegment } from './useDateTimeSegment';
+import { createTemporalPartial, isTemporalPartial } from './temporalPartial';
+
+describe('useDateTimeSegmentGroup', () => {
+  const timeZone = 'UTC';
+  const locale = 'en-US';
+  const currentDate = now(timeZone);
+
+  function createFormatter() {
+    return new DateFormatter(locale, {
+      day: 'numeric',
+      month: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  describe('segment registration', () => {
+    test('registers and unregisters segments', async () => {
+      const formatter = ref(createFormatter());
+      const controlEl = ref<HTMLElement>();
+      const onValueChange = vi.fn();
+
+      await render({
+        setup() {
+          const { segments, useDateSegmentRegistration } = useDateTimeSegmentGroup({
+            formatter,
+            temporalValue: currentDate,
+            formatOptions: {},
+            locale,
+            controlEl,
+            onValueChange,
+          });
+
+          // Register a segment
+          const segment = {
+            id: 'test-segment',
+            getType: () => 'day' as const,
+            getElem: () => document.createElement('div'),
+          };
+
+          const registration = useDateSegmentRegistration(segment);
+
+          return {
+            segments,
+            registration,
+          };
+        },
+        template: `
+          <div ref="controlEl">
+            <div v-for="segment in segments" :key="segment.type">
+              {{ segment.value }}
+            </div>
+          </div>
+        `,
+      });
+
+      await flush();
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('segment navigation', () => {
+    test('handles keyboard navigation between segments', async () => {
+      const formatter = ref(createFormatter());
+      const controlEl = ref<HTMLElement>();
+      const onValueChange = vi.fn();
+
+      await render({
+        components: {
+          DateTimeSegment,
+        },
+        setup() {
+          const { segments } = useDateTimeSegmentGroup({
+            formatter,
+            temporalValue: currentDate,
+            formatOptions: {},
+            locale,
+            controlEl,
+            onValueChange,
+          });
+
+          return {
+            segments,
+            controlEl,
+          };
+        },
+        template: `
+          <div ref="controlEl">
+            <DateTimeSegment
+              v-for="segment in segments"
+              :key="segment.type"
+              :data-segment-type="segment.type"
+              data-testid="segment"
+              v-bind="segment"
+            />
+          </div>
+        `,
+      });
+
+      await flush();
+      const segments = screen.getAllByTestId('segment').filter(el => el.dataset.segmentType !== 'literal');
+      segments[0].focus();
+
+      // Test right arrow navigation
+      await fireEvent.keyDown(segments[0], { code: 'ArrowRight' });
+      expect(document.activeElement).toBe(segments[1]);
+
+      // Test left arrow navigation
+      await fireEvent.keyDown(segments[1], { code: 'ArrowLeft' });
+      expect(document.activeElement).toBe(segments[0]);
+    });
+
+    test('respects RTL direction', async () => {
+      const formatter = ref(createFormatter());
+      const controlEl = ref<HTMLElement>();
+      const onValueChange = vi.fn();
+
+      await render({
+        components: {
+          DateTimeSegment,
+        },
+        setup() {
+          const { segments } = useDateTimeSegmentGroup({
+            formatter,
+            temporalValue: currentDate,
+            formatOptions: {},
+            locale,
+            controlEl,
+            onValueChange,
+            direction: 'rtl',
+          });
+
+          return {
+            segments,
+            controlEl,
+          };
+        },
+        template: `
+          <div ref="controlEl">
+            <DateTimeSegment
+              v-for="segment in segments"
+              :key="segment.type"
+              :data-segment-type="segment.type"
+              data-testid="segment"
+              v-bind="segment"
+            />
+          </div>
+        `,
+      });
+
+      await flush();
+      const segments = screen.getAllByTestId('segment').filter(el => el.dataset.segmentType !== 'literal');
+      segments[0].focus();
+
+      // Test right arrow navigation (should go left in RTL)
+      await fireEvent.keyDown(segments[1], { code: 'ArrowRight' });
+      expect(document.activeElement).toBe(segments[0]);
+
+      // Test left arrow navigation (should go right in RTL)
+      await fireEvent.keyDown(segments[0], { code: 'ArrowLeft' });
+      expect(document.activeElement).toBe(segments[1]);
+    });
+  });
+
+  describe('value updates', () => {
+    test('increments segment values', async () => {
+      const formatter = ref(createFormatter());
+      const controlEl = ref<HTMLElement>();
+      const onValueChange = vi.fn();
+      let monthRegistration!: ReturnType<ReturnType<typeof useDateTimeSegmentGroup>['useDateSegmentRegistration']>;
+
+      await render({
+        setup() {
+          const { useDateSegmentRegistration } = useDateTimeSegmentGroup({
+            formatter,
+            temporalValue: currentDate,
+            formatOptions: {},
+            locale,
+            controlEl,
+            onValueChange,
+          });
+
+          const segment = {
+            id: 'month-segment',
+            getType: () => 'month' as const,
+            getElem: () => document.createElement('div'),
+          };
+
+          monthRegistration = useDateSegmentRegistration(segment) as any;
+
+          return {};
+        },
+        template: '<div></div>',
+      });
+
+      monthRegistration.increment();
+      expect(onValueChange).toHaveBeenCalledWith(currentDate.add({ months: 1 }));
+    });
+
+    test('decrements segment values', async () => {
+      const formatter = ref(createFormatter());
+      const controlEl = ref<HTMLElement>();
+      const onValueChange = vi.fn();
+      let monthRegistration!: ReturnType<ReturnType<typeof useDateTimeSegmentGroup>['useDateSegmentRegistration']>;
+
+      await render({
+        setup() {
+          const { useDateSegmentRegistration } = useDateTimeSegmentGroup({
+            formatter,
+            temporalValue: currentDate,
+            formatOptions: {},
+            locale,
+            controlEl,
+            onValueChange,
+          });
+
+          const segment = {
+            id: 'month-segment',
+            getType: () => 'month' as const,
+            getElem: () => document.createElement('div'),
+          };
+
+          monthRegistration = useDateSegmentRegistration(segment) as any;
+
+          return {};
+        },
+        template: '<div></div>',
+      });
+
+      monthRegistration.decrement();
+      expect(onValueChange).toHaveBeenCalledWith(currentDate.subtract({ months: 1 }));
+    });
+
+    test('sets specific segment values', async () => {
+      const formatter = ref(createFormatter());
+      const controlEl = ref<HTMLElement>();
+      const onValueChange = vi.fn();
+      let monthRegistration!: ReturnType<ReturnType<typeof useDateTimeSegmentGroup>['useDateSegmentRegistration']>;
+
+      await render({
+        setup() {
+          const { useDateSegmentRegistration } = useDateTimeSegmentGroup({
+            formatter,
+            temporalValue: currentDate,
+            formatOptions: {},
+            locale,
+            controlEl,
+            onValueChange,
+          });
+
+          const segment = {
+            id: 'month-segment',
+            getType: () => 'month' as const,
+            getElem: () => document.createElement('div'),
+          };
+
+          monthRegistration = useDateSegmentRegistration(segment) as any;
+
+          return {};
+        },
+        template: '<div></div>',
+      });
+
+      monthRegistration.setValue(6);
+      expect(onValueChange).toHaveBeenCalledWith(currentDate.set({ month: 6 }));
+    });
+
+    test('clears segment values', async () => {
+      const formatter = ref(createFormatter());
+      const controlEl = ref<HTMLElement>();
+      const onValueChange = vi.fn();
+      let monthRegistration!: ReturnType<ReturnType<typeof useDateTimeSegmentGroup>['useDateSegmentRegistration']>;
+
+      await render({
+        setup() {
+          const { useDateSegmentRegistration } = useDateTimeSegmentGroup({
+            formatter,
+            temporalValue: currentDate,
+            formatOptions: {},
+            locale,
+            controlEl,
+            onValueChange,
+          });
+
+          const segment = {
+            id: 'month-segment',
+            getType: () => 'month' as const,
+            getElem: () => document.createElement('div'),
+          };
+
+          monthRegistration = useDateSegmentRegistration(segment) as any;
+
+          return {};
+        },
+        template: '<div></div>',
+      });
+
+      monthRegistration.clear() as any;
+      const lastCall = onValueChange.mock.lastCall?.[0];
+      expect(lastCall['~fw_temporal_partial'].month).toBe(false);
+    });
+  });
+
+  describe('formatting', () => {
+    test('formats segments according to locale', async () => {
+      const formatter = ref(createFormatter());
+      const controlEl = ref<HTMLElement>();
+      const onValueChange = vi.fn();
+
+      await render({
+        setup() {
+          const { segments } = useDateTimeSegmentGroup({
+            formatter,
+            temporalValue: currentDate,
+            formatOptions: {},
+            locale: 'de-DE',
+            controlEl,
+            onValueChange,
+          });
+
+          return {
+            segments,
+          };
+        },
+        template: `
+          <div>
+            <span v-for="segment in segments" :key="segment.type" :data-testid="segment.type">
+              {{ segment.value }}
+            </span>
+          </div>
+        `,
+      });
+
+      await flush();
+      const monthSegment = document.querySelector('[data-testid="month"]');
+      expect(monthSegment?.textContent?.trim()).toBe(currentDate.month.toString());
+    });
+  });
+
+  describe('segment input handling', () => {
+    test('handles numeric input', async () => {
+      const formatter = ref(createFormatter());
+      const controlEl = ref<HTMLElement>();
+      const onValueChange = vi.fn();
+
+      await render({
+        components: {
+          DateTimeSegment,
+        },
+        setup() {
+          const { segments } = useDateTimeSegmentGroup({
+            formatter,
+            temporalValue: currentDate,
+            formatOptions: {},
+            locale,
+            controlEl,
+            onValueChange,
+          });
+
+          return {
+            segments,
+            controlEl,
+          };
+        },
+        template: `
+          <div ref="controlEl">
+            <DateTimeSegment
+              v-for="segment in segments"
+              :key="segment.type"
+              :data-segment-type="segment.type"
+              data-testid="segment"
+              v-bind="segment"
+            />
+          </div>
+        `,
+      });
+
+      await flush();
+      const segments = screen.getAllByTestId('segment');
+      const monthSegment = segments.find(el => el.dataset.segmentType === 'month')!;
+      fireEvent.focus(monthSegment);
+
+      // Test valid numeric input
+      const inputEvent = new InputEvent('beforeinput', { data: '1', cancelable: true });
+      fireEvent(monthSegment, inputEvent);
+      expect(monthSegment.textContent).toBe('1');
+
+      // Test input completion on max length
+      const secondInputEvent = new InputEvent('beforeinput', { data: '2', cancelable: true });
+      fireEvent(monthSegment, secondInputEvent);
+      expect(monthSegment.textContent).toBe('12');
+      expect(document.activeElement).not.toBe(monthSegment); // Should move to next segment
+
+      // Test invalid input (out of range)
+      fireEvent.focus(monthSegment);
+      const invalidInputEvent = new InputEvent('beforeinput', { data: '13', cancelable: true });
+      fireEvent(monthSegment, invalidInputEvent);
+      expect(monthSegment.textContent).not.toBe('13');
+    });
+
+    test('handles keyboard navigation and actions', async () => {
+      const formatter = ref(createFormatter());
+      const controlEl = ref<HTMLElement>();
+      const onValueChange = vi.fn();
+
+      await render({
+        components: {
+          DateTimeSegment,
+        },
+        setup() {
+          const { segments } = useDateTimeSegmentGroup({
+            formatter,
+            temporalValue: currentDate,
+            formatOptions: {},
+            locale,
+            controlEl,
+            onValueChange,
+          });
+
+          return {
+            segments,
+            controlEl,
+          };
+        },
+        template: `
+          <div ref="controlEl">
+            <DateTimeSegment
+              v-for="segment in segments"
+              :key="segment.type"
+              :data-segment-type="segment.type"
+              data-testid="segment"
+              v-bind="segment"
+            />
+          </div>
+        `,
+      });
+
+      await flush();
+      const segments = screen.getAllByTestId('segment');
+      const monthSegment = segments.find(el => el.dataset.segmentType === 'month')!;
+      monthSegment.focus();
+
+      // Test increment with arrow up
+      await fireEvent.keyDown(monthSegment, { code: 'ArrowUp' });
+      expect(onValueChange).toHaveBeenCalledWith(currentDate.add({ months: 1 }));
+
+      // Test decrement with arrow down
+      await fireEvent.keyDown(monthSegment, { code: 'ArrowDown' });
+      expect(onValueChange).toHaveBeenCalledWith(currentDate.subtract({ months: 1 }));
+
+      // Test clearing with backspace
+      await fireEvent.keyDown(monthSegment, { code: 'Backspace' });
+      const lastCall = onValueChange.mock.lastCall?.[0];
+      expect(lastCall['~fw_temporal_partial'].month).toBe(false);
+
+      // Test clearing with delete
+      await fireEvent.keyDown(monthSegment, { code: 'Delete' });
+      const finalCall = onValueChange.mock.lastCall?.[0];
+      expect(finalCall['~fw_temporal_partial'].month).toBe(false);
+    });
+
+    test('handles non-numeric input', async () => {
+      const formatter = ref(createFormatter());
+      const controlEl = ref<HTMLElement>();
+      const onValueChange = vi.fn();
+
+      await render({
+        components: {
+          DateTimeSegment,
+        },
+        setup() {
+          const { segments } = useDateTimeSegmentGroup({
+            formatter,
+            temporalValue: currentDate,
+            formatOptions: {},
+            locale,
+            controlEl,
+            onValueChange,
+          });
+
+          return {
+            segments,
+            controlEl,
+          };
+        },
+        template: `
+          <div ref="controlEl">
+            <DateTimeSegment
+              v-for="segment in segments"
+              :key="segment.type"
+              :data-segment-type="segment.type"
+              data-testid="segment"
+              v-bind="segment"
+            />
+          </div>
+        `,
+      });
+
+      await flush();
+      const segments = screen.getAllByTestId('segment');
+      const monthSegment = segments.find(el => el.dataset.segmentType === 'month')!;
+      monthSegment.focus();
+
+      // Test non-numeric input
+      const nonNumericEvent = new InputEvent('beforeinput', { data: 'a', cancelable: true });
+      fireEvent(monthSegment, nonNumericEvent);
+      expect(nonNumericEvent.defaultPrevented).toBe(true);
+      expect(monthSegment.textContent).not.toBe('a');
+    });
+
+    test('handles non-numeric segments (dayPeriod)', async () => {
+      const formatter = ref(
+        new DateFormatter(locale, {
+          hour: 'numeric',
+          hour12: true,
+          dayPeriod: 'short',
+        }),
+      );
+      const controlEl = ref<HTMLElement>();
+      const onValueChange = vi.fn();
+
+      await render({
+        components: {
+          DateTimeSegment,
+        },
+        setup() {
+          const { segments } = useDateTimeSegmentGroup({
+            formatter,
+            temporalValue: currentDate,
+            formatOptions: { hour12: true },
+            locale,
+            controlEl,
+            onValueChange,
+          });
+
+          return {
+            segments,
+            controlEl,
+          };
+        },
+        template: `
+          <div ref="controlEl">
+            <DateTimeSegment
+              v-for="segment in segments"
+              :key="segment.type"
+              :data-segment-type="segment.type"
+              data-testid="segment"
+              v-bind="segment"
+            />
+          </div>
+        `,
+      });
+
+      await flush();
+      const segments = screen.getAllByTestId('segment');
+      const dayPeriodSegment = segments.find(el => el.dataset.segmentType === 'dayPeriod')!;
+      dayPeriodSegment.focus();
+
+      // Test numeric input is blocked
+      const inputEvent = new InputEvent('beforeinput', { data: '1', cancelable: true });
+      fireEvent(dayPeriodSegment, inputEvent);
+      expect(inputEvent.defaultPrevented).toBe(true);
+      expect(dayPeriodSegment.textContent).not.toBe('1');
+
+      // Test arrow up changes period (AM -> PM)
+      await fireEvent.keyDown(dayPeriodSegment, { code: 'ArrowUp' });
+      expect(onValueChange).toHaveBeenCalledWith(currentDate.add({ hours: 12 }).set({ day: currentDate.day }));
+
+      // Test arrow down changes period (PM -> AM)
+      await fireEvent.keyDown(dayPeriodSegment, { code: 'ArrowDown' });
+      expect(onValueChange).toHaveBeenCalledWith(currentDate.subtract({ hours: 12 }).set({ day: currentDate.day }));
+
+      // Test clearing with backspace
+      await fireEvent.keyDown(dayPeriodSegment, { code: 'Backspace' });
+      const lastCall = onValueChange.mock.lastCall?.[0];
+      expect(lastCall['~fw_temporal_partial'].dayPeriod).toBe(false);
+
+      // Test clearing with delete
+      await fireEvent.keyDown(dayPeriodSegment, { code: 'Delete' });
+      const finalCall = onValueChange.mock.lastCall?.[0];
+      expect(finalCall['~fw_temporal_partial'].dayPeriod).toBe(false);
+    });
+
+    test.fails('converts to non-partial when all segments are filled', async () => {
+      const formatter = ref(createFormatter());
+      const controlEl = ref<HTMLElement>();
+      const onValueChange = vi.fn();
+      const initialDate = currentDate.set({ year: 2024, month: 1, day: 1 });
+
+      await render({
+        components: {
+          DateTimeSegment,
+        },
+        setup() {
+          const { segments } = useDateTimeSegmentGroup({
+            formatter,
+            temporalValue: createTemporalPartial(initialDate.calendar, initialDate.timeZone),
+            formatOptions: {
+              day: 'numeric',
+              month: 'numeric',
+              year: 'numeric',
+            },
+            locale,
+            controlEl,
+            onValueChange,
+          });
+
+          return {
+            segments,
+            controlEl,
+          };
+        },
+        template: `
+          <div ref="controlEl">
+            <DateTimeSegment
+              v-for="segment in segments"
+              :key="segment.type"
+              :data-segment-type="segment.type"
+              data-testid="segment"
+              v-bind="segment"
+            />
+          </div>
+        `,
+      });
+
+      await flush();
+      const segments = screen.getAllByTestId('segment');
+
+      // Fill in month segment
+      const monthSegment = segments.find(el => el.dataset.segmentType === 'month')!;
+      fireEvent.focus(monthSegment);
+      const monthInput = new InputEvent('beforeinput', { data: '3', cancelable: true });
+      fireEvent(monthSegment, monthInput);
+      fireEvent.blur(monthSegment);
+      await flush();
+      expect(onValueChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          '~fw_temporal_partial': {
+            month: true,
+          },
+        }),
+      );
+
+      // Fill in day segment
+      const daySegment = segments.find(el => el.dataset.segmentType === 'day')!;
+      fireEvent.focus(daySegment);
+      fireEvent.keyDown(daySegment, { code: 'ArrowUp' });
+      await flush();
+      expect(onValueChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          '~fw_temporal_partial': {
+            month: true,
+            day: true,
+          },
+        }),
+      );
+
+      // Fill in year segment
+      const yearSegment = segments.find(el => el.dataset.segmentType === 'year')!;
+      fireEvent.focus(yearSegment);
+      const yearInput = new InputEvent('beforeinput', { data: '2024', cancelable: true });
+      fireEvent(yearSegment, yearInput);
+      fireEvent.blur(yearSegment);
+      await flush();
+      expect(onValueChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          '~fw_temporal_partial': {
+            month: true,
+            day: true,
+            year: true,
+          },
+        }),
+      );
+      // Verify final call is not a partial
+      const finalCall = onValueChange.mock.lastCall?.[0];
+      expect(isTemporalPartial(finalCall)).toBe(false);
+      expect(finalCall.toString()).toBe(initialDate.set({ month: 3, day: 5 }).toString());
+    });
+
+    test('preserves partial state when not all segments are filled', async () => {
+      const formatter = ref(createFormatter());
+      const controlEl = ref<HTMLElement>();
+      const onValueChange = vi.fn();
+      const initialDate = currentDate.set({ year: 2024, month: 1, day: 1 });
+
+      await render({
+        components: {
+          DateTimeSegment,
+        },
+        setup() {
+          const { segments } = useDateTimeSegmentGroup({
+            formatter,
+            temporalValue: createTemporalPartial(initialDate.calendar, initialDate.timeZone),
+            formatOptions: {
+              day: 'numeric',
+              month: 'numeric',
+              year: 'numeric',
+            },
+            locale,
+            controlEl,
+            onValueChange,
+          });
+
+          return {
+            segments,
+            controlEl,
+          };
+        },
+        template: `
+          <div ref="controlEl">
+            <DateTimeSegment
+              v-for="segment in segments"
+              :key="segment.type"
+              :data-segment-type="segment.type"
+              data-testid="segment"
+              v-bind="segment"
+            />
+          </div>
+        `,
+      });
+
+      await flush();
+      const segments = screen.getAllByTestId('segment');
+
+      // Fill in only month and day segments
+      const monthSegment = segments.find(el => el.dataset.segmentType === 'month')!;
+      monthSegment.focus();
+      const monthInput = new InputEvent('beforeinput', { data: '3', cancelable: true });
+      monthSegment.dispatchEvent(monthInput);
+
+      const daySegment = segments.find(el => el.dataset.segmentType === 'day')!;
+      daySegment.focus();
+      const dayInput = new InputEvent('beforeinput', { data: '5', cancelable: true });
+      daySegment.dispatchEvent(dayInput);
+
+      // Verify the value is still a partial since year is not set
+      const lastCall = onValueChange.mock.lastCall?.[0];
+      expect(isTemporalPartial(lastCall)).toBe(true);
+      expect(lastCall['~fw_temporal_partial']).toEqual({
+        day: true,
+      });
+    });
+  });
+});

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.spec.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.spec.ts
@@ -34,6 +34,7 @@ describe('useDateTimeSegmentGroup', () => {
             locale,
             controlEl,
             onValueChange,
+            onTouched: () => {},
           });
 
           // Register a segment
@@ -82,6 +83,7 @@ describe('useDateTimeSegmentGroup', () => {
             locale,
             controlEl,
             onValueChange,
+            onTouched: () => {},
           });
 
           return {
@@ -132,6 +134,7 @@ describe('useDateTimeSegmentGroup', () => {
             locale,
             controlEl,
             onValueChange,
+            onTouched: () => {},
             direction: 'rtl',
           });
 
@@ -183,6 +186,7 @@ describe('useDateTimeSegmentGroup', () => {
             locale,
             controlEl,
             onValueChange,
+            onTouched: () => {},
           });
 
           const segment = {
@@ -217,6 +221,7 @@ describe('useDateTimeSegmentGroup', () => {
             locale,
             controlEl,
             onValueChange,
+            onTouched: () => {},
           });
 
           const segment = {
@@ -251,6 +256,7 @@ describe('useDateTimeSegmentGroup', () => {
             locale,
             controlEl,
             onValueChange,
+            onTouched: () => {},
           });
 
           const segment = {
@@ -285,6 +291,7 @@ describe('useDateTimeSegmentGroup', () => {
             locale,
             controlEl,
             onValueChange,
+            onTouched: () => {},
           });
 
           const segment = {
@@ -321,6 +328,7 @@ describe('useDateTimeSegmentGroup', () => {
             locale: 'de-DE',
             controlEl,
             onValueChange,
+            onTouched: () => {},
           });
 
           return {
@@ -360,6 +368,7 @@ describe('useDateTimeSegmentGroup', () => {
             locale,
             controlEl,
             onValueChange,
+            onTouched: () => {},
           });
 
           return {
@@ -420,6 +429,7 @@ describe('useDateTimeSegmentGroup', () => {
             locale,
             controlEl,
             onValueChange,
+            onTouched: () => {},
           });
 
           return {
@@ -481,6 +491,7 @@ describe('useDateTimeSegmentGroup', () => {
             locale,
             controlEl,
             onValueChange,
+            onTouched: () => {},
           });
 
           return {
@@ -536,6 +547,7 @@ describe('useDateTimeSegmentGroup', () => {
             locale,
             controlEl,
             onValueChange,
+            onTouched: () => {},
           });
 
           return {
@@ -608,6 +620,7 @@ describe('useDateTimeSegmentGroup', () => {
             locale,
             controlEl,
             onValueChange,
+            onTouched: () => {},
           });
 
           return {
@@ -704,6 +717,7 @@ describe('useDateTimeSegmentGroup', () => {
             locale,
             controlEl,
             onValueChange,
+            onTouched: () => {},
           });
 
           return {

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -331,11 +331,11 @@ function useDateArithmetic({ currentDate, min, max }: ArithmeticInit) {
     const maxDate = toValue(max);
 
     if (minDate && date.compare(minDate) < 0) {
-      return minDate;
+      return toValue(currentDate);
     }
 
     if (maxDate && date.compare(maxDate) > 0) {
-      return maxDate;
+      return toValue(currentDate);
     }
 
     return date;

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -30,6 +30,7 @@ export interface DateTimeSegmentGroupContext {
     onDone(): void;
     clear(): void;
     isPlaceholder(): boolean;
+    onTouched(): void;
   };
 }
 
@@ -43,6 +44,7 @@ export interface DateTimeSegmentGroupProps {
   direction?: MaybeRefOrGetter<Direction>;
   controlEl: Ref<HTMLElement | undefined>;
   onValueChange: (value: ZonedDateTime) => void;
+  onTouched: () => void;
 }
 
 export function useDateTimeSegmentGroup({
@@ -53,6 +55,7 @@ export function useDateTimeSegmentGroup({
   locale,
   controlEl,
   onValueChange,
+  onTouched,
 }: DateTimeSegmentGroupProps) {
   const renderedSegments = ref<DateTimeSegmentRegistration[]>([]);
   const parser = useNumberParser(locale, {
@@ -206,6 +209,7 @@ export function useDateTimeSegmentGroup({
       onDone: onSegmentDone,
       clear,
       isPlaceholder,
+      onTouched,
     };
   }
 

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -198,6 +198,10 @@ export function useDateTimeSegmentGroup({
     function isNumeric() {
       const type = segment.getType();
       const options = toValue(formatOptions);
+      if (type === 'literal') {
+        return false;
+      }
+
       const optionFormat = options?.[type];
       if (!optionFormat) {
         return isNumericByDefault(type);

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -1,6 +1,6 @@
 import { InjectionKey, MaybeRefOrGetter, provide, ref, toValue, Ref, onBeforeUnmount, computed } from 'vue';
 import { Temporal, Intl as TemporalIntl } from '@js-temporal/polyfill';
-import { DateTimeSegmentType, TemporalDate } from './types';
+import { DateTimeSegmentType, TemporalValue } from './types';
 import { hasKeyCode } from '../utils/common';
 import { blockEvent } from '../utils/events';
 import { Direction } from '../types';
@@ -24,10 +24,10 @@ export const DateTimeSegmentGroupKey: InjectionKey<DateTimeSegmentGroupContext> 
 
 export interface DateTimeSegmentGroupProps {
   formatter: Ref<TemporalIntl.DateTimeFormat>;
-  dateValue: MaybeRefOrGetter<TemporalDate>;
+  dateValue: MaybeRefOrGetter<TemporalValue>;
   direction?: MaybeRefOrGetter<Direction>;
   controlEl: Ref<HTMLElement | undefined>;
-  onValueChange: (value: TemporalDate) => void;
+  onValueChange: (value: TemporalValue) => void;
 }
 
 export function useDateTimeSegmentGroup({
@@ -148,7 +148,7 @@ export function useDateTimeSegmentGroup({
   };
 }
 
-function addToPart(part: DateTimeSegmentType, currentDate: TemporalDate, diff: number) {
+function addToPart(part: DateTimeSegmentType, currentDate: TemporalValue, diff: number) {
   if (!isEditableSegmentType(part)) {
     return currentDate;
   }

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -20,9 +20,8 @@ export interface DateTimeSegmentGroupContext {
     increment(): void;
     decrement(): void;
     setValue(value: number): void;
-
-    maxValue(): number | null;
-    minValue(): number | null;
+    getMetadata(): { min: number | null; max: number | null; maxLength: number | null };
+    onDone(): void;
   };
 }
 
@@ -63,6 +62,10 @@ export function useDateTimeSegmentGroup({
     return formatter.value.formatToParts(date.toPlainDateTime()) as { type: DateTimeSegmentType; value: string }[];
   });
 
+  function onSegmentDone() {
+    focusNextSegment();
+  }
+
   function useDateSegmentRegistration(segment: DateTimeSegmentRegistration) {
     renderedSegments.value.push(segment);
     onBeforeUnmount(() => {
@@ -90,7 +93,7 @@ export function useDateTimeSegmentGroup({
       onValueChange(date);
     }
 
-    function maxValue() {
+    function getMetadata() {
       const type = segment.getType();
       const date = toValue(temporalValue);
       const maxPartsRecord: Partial<Record<DateTimeSegmentType, number>> = {
@@ -102,11 +105,6 @@ export function useDateTimeSegmentGroup({
         second: 59,
       };
 
-      return maxPartsRecord[type] ?? null;
-    }
-
-    function minValue() {
-      const type = segment.getType();
       const minPartsRecord: Partial<Record<DateTimeSegmentType, number>> = {
         day: 1,
         month: 1,
@@ -116,7 +114,20 @@ export function useDateTimeSegmentGroup({
         second: 0,
       };
 
-      return minPartsRecord[type] ?? null;
+      const maxLengths: Partial<Record<DateTimeSegmentType, number>> = {
+        day: 2,
+        month: 2,
+        year: 4,
+        hour: 2,
+        minute: 2,
+        second: 2,
+      };
+
+      return {
+        min: minPartsRecord[type] ?? null,
+        max: maxPartsRecord[type] ?? null,
+        maxLength: maxLengths[type] ?? null,
+      };
     }
 
     return {
@@ -124,8 +135,9 @@ export function useDateTimeSegmentGroup({
       decrement,
       setValue,
       parser,
-      maxValue,
-      minValue,
+      onSegmentDone,
+      getMetadata,
+      onDone: onSegmentDone,
     };
   }
 

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -295,7 +295,7 @@ function useDateArithmetic({ currentDate }: ArithmeticInit) {
     });
 
     if (isTemporalPartial(date)) {
-      newDate['~fw_temporal_partial'] = {
+      (newDate as TemporalPartial)['~fw_temporal_partial'] = {
         ...date['~fw_temporal_partial'],
         [part]: true,
       };
@@ -334,7 +334,7 @@ function useDateArithmetic({ currentDate }: ArithmeticInit) {
               });
       }
 
-      newDate['~fw_temporal_partial'] = {
+      (newDate as TemporalPartial)['~fw_temporal_partial'] = {
         ...date['~fw_temporal_partial'],
         [part]: true,
       };

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -12,7 +12,7 @@ import {
 } from './constants';
 import { NumberParserContext, useNumberParser } from '../i18n';
 import { isTemporalPartial, isTemporalPartSet, toTemporalPartial } from './temporalPartial';
-import { ZonedDateTime, DateFormatter, fromDate } from '@internationalized/date';
+import { ZonedDateTime, DateFormatter } from '@internationalized/date';
 
 export interface DateTimeSegmentRegistration {
   id: string;
@@ -105,7 +105,7 @@ export function useDateTimeSegmentGroup({
 
   function withAllPartsSet(value: ZonedDateTime) {
     if (isTemporalPartial(value) && isAllPartsSet(value)) {
-      return fromDate(value.toDate(), value.timeZone); // clones the value and drops the partial flag
+      return value.copy(); // clones the value and drops the partial flag
     }
 
     return value;

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -7,6 +7,7 @@ import { useEventListener } from '../helpers/useEventListener';
 import {
   getSegmentTypePlaceholder,
   isEditableSegmentType,
+  isNumericByDefault,
   isOptionalSegmentType,
   segmentTypeToDurationLike,
 } from './constants';
@@ -29,8 +30,10 @@ export interface DateTimeSegmentGroupContext {
     getMetadata(): { min: number | null; max: number | null; maxLength: number | null };
     onDone(): void;
     clear(): void;
-    isPlaceholder(): boolean;
+    isNumeric(): boolean;
     onTouched(): void;
+    isLast(): boolean;
+    focusNext(): void;
   };
 }
 
@@ -192,11 +195,27 @@ export function useDateTimeSegmentGroup({
       onValueChange(next);
     }
 
-    function isPlaceholder() {
+    function isNumeric() {
       const type = segment.getType();
-      const date = toValue(temporalValue);
+      const options = toValue(formatOptions);
+      const optionFormat = options?.[type];
+      if (!optionFormat) {
+        return isNumericByDefault(type);
+      }
 
-      return isTemporalPartial(date) && !isTemporalPartSet(date, type);
+      return optionFormat === 'numeric' || optionFormat === '2-digit';
+    }
+
+    function isLast() {
+      return renderedSegments.value.at(-1)?.id === segment.id;
+    }
+
+    function focusNext() {
+      if (isLast()) {
+        return;
+      }
+
+      focusNextSegment();
     }
 
     return {
@@ -208,8 +227,10 @@ export function useDateTimeSegmentGroup({
       getMetadata,
       onDone: onSegmentDone,
       clear,
-      isPlaceholder,
       onTouched,
+      isLast,
+      focusNext,
+      isNumeric,
     };
   }
 

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -46,6 +46,7 @@ export interface DateTimeSegmentGroupProps {
   temporalValue: MaybeRefOrGetter<ZonedDateTime | TemporalPartial>;
   direction?: MaybeRefOrGetter<Direction>;
   controlEl: Ref<HTMLElement | undefined>;
+  readonly?: MaybeRefOrGetter<boolean | undefined>;
   min?: MaybeRefOrGetter<Maybe<ZonedDateTime>>;
   max?: MaybeRefOrGetter<Maybe<ZonedDateTime>>;
   onValueChange: (value: ZonedDateTime) => void;
@@ -59,6 +60,7 @@ export function useDateTimeSegmentGroup({
   direction,
   locale,
   controlEl,
+  readonly,
   min,
   max,
   onValueChange,
@@ -78,7 +80,7 @@ export function useDateTimeSegmentGroup({
 
   const segments = computed(() => {
     const date = toValue(temporalValue);
-    const parts = formatter.value.formatToParts(date.toDate()) as {
+    let parts = formatter.value.formatToParts(date.toDate()) as {
       type: DateTimeSegmentType;
       value: string;
     }[];
@@ -93,6 +95,15 @@ export function useDateTimeSegmentGroup({
           part.value = getSegmentTypePlaceholder(part.type) ?? part.value;
         }
       }
+    }
+
+    if (toValue(readonly)) {
+      parts = parts.map(part => {
+        return {
+          ...part,
+          readonly: true,
+        };
+      });
     }
 
     return parts;

--- a/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTimeField/useDateTimeSegmentGroup.ts
@@ -29,6 +29,7 @@ export interface DateTimeSegmentGroupContext {
     getMetadata(): { min: number | null; max: number | null; maxLength: number | null };
     onDone(): void;
     clear(): void;
+    isPlaceholder(): boolean;
   };
 }
 
@@ -188,6 +189,13 @@ export function useDateTimeSegmentGroup({
       onValueChange(next);
     }
 
+    function isPlaceholder() {
+      const type = segment.getType();
+      const date = toValue(temporalValue);
+
+      return isTemporalPartial(date) && !isTemporalPartSet(date, type);
+    }
+
     return {
       increment,
       decrement,
@@ -197,6 +205,7 @@ export function useDateTimeSegmentGroup({
       getMetadata,
       onDone: onSegmentDone,
       clear,
+      isPlaceholder,
     };
   }
 

--- a/packages/core/src/useDateTimeField/useTemporalStore.spec.ts
+++ b/packages/core/src/useDateTimeField/useTemporalStore.spec.ts
@@ -1,0 +1,259 @@
+import { createCalendar, fromDate, now } from '@internationalized/date';
+import { useTemporalStore } from './useTemporalStore';
+import { createTemporalPartial, isTemporalPartial } from './temporalPartial';
+import { ref } from 'vue';
+import { Maybe } from '../types';
+import { flush } from '@test-utils/flush';
+import { vi } from 'vitest';
+
+describe('useTemporalStore', () => {
+  const calendar = createCalendar('gregory');
+  const timeZone = 'UTC';
+  const locale = 'en-US';
+
+  describe('initialization', () => {
+    test('initializes with Date value', () => {
+      const date = new Date();
+      const store = useTemporalStore({
+        model: {
+          get: () => date,
+        },
+        calendar,
+        timeZone,
+        locale,
+      });
+
+      expect(store.value.toDate()).toEqual(date);
+      expect(isTemporalPartial(store.value)).toBe(false);
+    });
+
+    test('initializes with ZonedDateTime value', () => {
+      const date = now(timeZone);
+      const store = useTemporalStore({
+        model: {
+          get: () => date.toDate(),
+        },
+        calendar,
+        timeZone,
+        locale,
+      });
+
+      expect(store.value.toString()).toBe(date.toString());
+      expect(isTemporalPartial(store.value)).toBe(false);
+    });
+
+    test('initializes with null value as temporal partial', () => {
+      const store = useTemporalStore({
+        model: {
+          get: () => null,
+        },
+        calendar,
+        timeZone,
+        locale,
+      });
+
+      expect(isTemporalPartial(store.value)).toBe(true);
+      expect(store.value.timeZone).toBe(timeZone);
+      expect(store.value.calendar.identifier).toBe(calendar.identifier);
+    });
+  });
+
+  describe('model updates', () => {
+    test('updates when model value changes', async () => {
+      const modelValue = ref<Maybe<Date>>(null);
+      const store = useTemporalStore({
+        model: {
+          get: () => modelValue.value,
+          set: value => (modelValue.value = value),
+        },
+        calendar,
+        timeZone,
+        locale,
+      });
+
+      const newDate = new Date();
+      modelValue.value = newDate;
+      await flush();
+
+      expect(store.value.toDate()).toEqual(newDate);
+      expect(isTemporalPartial(store.value)).toBe(false);
+    });
+
+    test('preserves temporal partial when model is null', async () => {
+      const modelValue = ref<Maybe<Date>>(null);
+      const store = useTemporalStore({
+        model: {
+          get: () => modelValue.value,
+          set: value => (modelValue.value = value),
+        },
+        calendar,
+        timeZone,
+        locale,
+      });
+
+      // Initial state is temporal partial
+      expect(isTemporalPartial(store.value)).toBe(true);
+
+      // Update model to null
+      modelValue.value = null;
+      await flush();
+
+      // Should still be temporal partial
+      expect(isTemporalPartial(store.value)).toBe(true);
+    });
+
+    test('updates model when store value changes', () => {
+      const modelValue = ref<Maybe<Date>>(null);
+      const store = useTemporalStore({
+        model: {
+          get: () => modelValue.value,
+          set: value => (modelValue.value = value),
+        },
+        calendar,
+        timeZone,
+        locale,
+      });
+
+      const newDate = now(timeZone);
+      store.value = newDate;
+
+      expect(modelValue.value).toEqual(newDate.toDate());
+    });
+
+    test('sets model to undefined when store value is temporal partial', () => {
+      const modelValue = ref<Maybe<Date>>(new Date());
+      const store = useTemporalStore({
+        model: {
+          get: () => modelValue.value,
+          set: value => (modelValue.value = value),
+        },
+        calendar,
+        timeZone,
+        locale,
+      });
+
+      // Change to temporal partial
+      store.value = createTemporalPartial(calendar, timeZone);
+
+      expect(modelValue.value).toBeUndefined();
+    });
+  });
+
+  describe('date conversion', () => {
+    test('converts between Date and ZonedDateTime', () => {
+      const date = new Date();
+      const store = useTemporalStore({
+        model: {
+          get: () => date,
+        },
+        calendar,
+        timeZone,
+        locale,
+      });
+
+      const expectedZonedDateTime = fromDate(date, timeZone);
+      expect(store.value.toString()).toBe(expectedZonedDateTime.toString());
+    });
+
+    test('handles different calendar systems', () => {
+      const islamicCalendar = createCalendar('islamic-umalqura');
+      const date = new Date();
+      const store = useTemporalStore({
+        model: {
+          get: () => date,
+        },
+        calendar: islamicCalendar,
+        timeZone,
+        locale,
+      });
+
+      expect(store.value.calendar.identifier).toBe('islamic-umalqura');
+      expect(store.value.toDate()).toEqual(date);
+    });
+
+    test('updates model with correct date when temporal value changes', () => {
+      const modelValue = ref<Maybe<Date>>(new Date('2024-01-01T00:00:00Z'));
+      const onModelSet = vi.fn();
+
+      const store = useTemporalStore({
+        model: {
+          get: () => modelValue.value,
+          set: value => {
+            modelValue.value = value;
+            onModelSet(value);
+          },
+        },
+        calendar,
+        timeZone,
+        locale,
+      });
+
+      // Change year
+      store.value = store.value.set({ year: 2025 });
+      expect(onModelSet).toHaveBeenLastCalledWith(new Date('2025-01-01T00:00:00Z'));
+
+      // Change month
+      store.value = store.value.set({ month: 6 });
+      expect(onModelSet).toHaveBeenLastCalledWith(new Date('2025-06-01T00:00:00Z'));
+
+      // Change day
+      store.value = store.value.set({ day: 15 });
+      expect(onModelSet).toHaveBeenLastCalledWith(new Date('2025-06-15T00:00:00Z'));
+    });
+
+    test('preserves time when updating date parts', () => {
+      const modelValue = ref<Maybe<Date>>(new Date('2024-01-01T14:30:45Z'));
+      const onModelSet = vi.fn();
+
+      const store = useTemporalStore({
+        model: {
+          get: () => modelValue.value,
+          set: value => {
+            modelValue.value = value;
+            onModelSet(value);
+          },
+        },
+        calendar,
+        timeZone,
+        locale,
+      });
+
+      // Change date parts
+      store.value = store.value.set({ year: 2025, month: 6, day: 15 });
+
+      // Verify time components are preserved
+      const expectedDate = new Date('2025-06-15T14:30:45Z');
+      expect(onModelSet).toHaveBeenLastCalledWith(expectedDate);
+      expect(modelValue.value?.getUTCHours()).toBe(14);
+      expect(modelValue.value?.getUTCMinutes()).toBe(30);
+      expect(modelValue.value?.getUTCSeconds()).toBe(45);
+    });
+
+    test('handles timezone conversions correctly', () => {
+      const modelValue = ref<Maybe<Date>>(new Date('2024-01-01T00:00:00Z'));
+      const onModelSet = vi.fn();
+      const timeZoneRef = ref('UTC');
+
+      const store = useTemporalStore({
+        model: {
+          get: () => modelValue.value,
+          set: value => {
+            modelValue.value = value;
+            onModelSet(value);
+          },
+        },
+        calendar,
+        timeZone: timeZoneRef,
+        locale,
+      });
+
+      // Change timezone
+      timeZoneRef.value = 'America/New_York';
+      store.value = store.value.set({ hour: 12 }); // Set to noon NY time
+
+      // Verify the UTC time in the model is correctly adjusted
+      const lastSetDate = onModelSet.mock.lastCall?.[0] as Date;
+      expect(lastSetDate.getUTCHours()).toBe(12); // noon NY = 5pm UTC
+    });
+  });
+});

--- a/packages/core/src/useDateTimeField/useTemporalStore.ts
+++ b/packages/core/src/useDateTimeField/useTemporalStore.ts
@@ -15,6 +15,7 @@ interface TemporalValueStoreInit {
   locale: MaybeRefOrGetter<string>;
   timeZone: MaybeRefOrGetter<string>;
   calendar: MaybeRefOrGetter<CalendarIdentifier>;
+  allowPartial?: boolean;
 }
 
 export function useTemporalStore(init: TemporalValueStoreInit) {

--- a/packages/core/src/useDateTimeField/useTemporalStore.ts
+++ b/packages/core/src/useDateTimeField/useTemporalStore.ts
@@ -1,0 +1,85 @@
+import { MaybeRefOrGetter, ref, computed, toValue } from 'vue';
+import { CalendarIdentifier } from '../useCalendar';
+import { DateValue } from './types';
+import { toTemporalInstant } from '@js-temporal/polyfill';
+import { Maybe } from '../types';
+import { Temporal } from '@js-temporal/polyfill';
+import { isNullOrUndefined } from '../utils/common';
+
+interface TemporalValueStoreInit {
+  initialValue: Maybe<DateValue>;
+  locale: MaybeRefOrGetter<string>;
+  timeZone: MaybeRefOrGetter<string>;
+  calendar: MaybeRefOrGetter<CalendarIdentifier>;
+}
+
+export function useTemporalStore(init: TemporalValueStoreInit) {
+  const dateValue = ref<Date>(toDate(init.initialValue));
+
+  function toZonedDateTime(value: Maybe<DateValue>): Temporal.ZonedDateTime {
+    if (isNullOrUndefined(value)) {
+      return Temporal.Now.zonedDateTime(toValue(init.calendar), toValue(init.timeZone));
+    }
+
+    if (value instanceof Date) {
+      value = toTemporalInstant.call(value);
+    }
+
+    if (value instanceof Temporal.Instant) {
+      return value.toZonedDateTime({
+        timeZone: toValue(init.timeZone),
+        calendar: toValue(init.calendar),
+      });
+    }
+
+    if (value instanceof Temporal.PlainDate) {
+      return value.toZonedDateTime({
+        timeZone: toValue(init.timeZone),
+      });
+    }
+
+    if (value instanceof Temporal.PlainDateTime) {
+      return value.toZonedDateTime(toValue(init.timeZone));
+    }
+
+    if (value instanceof Temporal.PlainTime) {
+      return value.toZonedDateTime({
+        plainDate: Temporal.Now.plainDate(toValue(init.calendar)),
+        timeZone: toValue(init.timeZone),
+      });
+    }
+
+    if (value instanceof Temporal.PlainYearMonth) {
+      return Temporal.Now.zonedDateTime(toValue(init.calendar), toValue(init.timeZone)).with({
+        year: value.year,
+        month: value.month,
+      });
+    }
+
+    return value;
+  }
+
+  function toDate(value: Maybe<DateValue>): Date {
+    if (isNullOrUndefined(value)) {
+      return new Date();
+    }
+
+    if (value instanceof Date) {
+      return value;
+    }
+
+    return new Date(toZonedDateTime(value).epochMilliseconds);
+  }
+
+  const temporalValue = computed({
+    get: () => toZonedDateTime(dateValue.value),
+    set: value => {
+      dateValue.value = toDate(value);
+    },
+  });
+
+  return {
+    dateValue,
+    temporalValue,
+  };
+}

--- a/packages/core/src/useDateTimeField/useTemporalStore.ts
+++ b/packages/core/src/useDateTimeField/useTemporalStore.ts
@@ -1,4 +1,4 @@
-import { MaybeRefOrGetter, ref, computed, toValue } from 'vue';
+import { MaybeRefOrGetter, computed, toValue } from 'vue';
 import { CalendarIdentifier } from '../useCalendar';
 import { DateValue } from './types';
 import { toTemporalInstant } from '@js-temporal/polyfill';
@@ -7,14 +7,17 @@ import { Temporal } from '@js-temporal/polyfill';
 import { isNullOrUndefined } from '../utils/common';
 
 interface TemporalValueStoreInit {
-  initialValue: Maybe<DateValue>;
+  model: {
+    get: () => Maybe<Date>;
+    set: (value: Maybe<Date>) => void;
+  };
   locale: MaybeRefOrGetter<string>;
   timeZone: MaybeRefOrGetter<string>;
   calendar: MaybeRefOrGetter<CalendarIdentifier>;
 }
 
 export function useTemporalStore(init: TemporalValueStoreInit) {
-  const dateValue = ref<Date>(toDate(init.initialValue));
+  const model = init.model;
 
   function toZonedDateTime(value: Maybe<DateValue>): Temporal.ZonedDateTime {
     if (isNullOrUndefined(value)) {
@@ -72,14 +75,11 @@ export function useTemporalStore(init: TemporalValueStoreInit) {
   }
 
   const temporalValue = computed({
-    get: () => toZonedDateTime(dateValue.value),
+    get: () => toZonedDateTime(model.get()),
     set: value => {
-      dateValue.value = toDate(value);
+      model.set(toDate(value));
     },
   });
 
-  return {
-    dateValue,
-    temporalValue,
-  };
+  return temporalValue;
 }

--- a/packages/core/src/useDateTimeField/useTemporalStore.ts
+++ b/packages/core/src/useDateTimeField/useTemporalStore.ts
@@ -9,7 +9,7 @@ import { isNullOrUndefined } from '../utils/common';
 interface TemporalValueStoreInit {
   model: {
     get: () => Maybe<Date>;
-    set: (value: Maybe<Date>) => void;
+    set?: (value: Maybe<Date>) => void;
   };
   locale: MaybeRefOrGetter<string>;
   timeZone: MaybeRefOrGetter<string>;
@@ -77,7 +77,7 @@ export function useTemporalStore(init: TemporalValueStoreInit) {
   const temporalValue = computed({
     get: () => toZonedDateTime(model.get()),
     set: value => {
-      model.set(toDate(value));
+      model.set?.(toDate(value));
     },
   });
 

--- a/packages/core/src/useDateTimeField/useTemporalStore.ts
+++ b/packages/core/src/useDateTimeField/useTemporalStore.ts
@@ -24,6 +24,10 @@ export function useTemporalStore(init: TemporalValueStoreInit) {
   );
 
   watch(model.get, value => {
+    if (!value && isTemporalPartial(temporalVal.value)) {
+      return;
+    }
+
     temporalVal.value = toZonedDateTime(value) ?? createTemporalPartial(toValue(init.calendar), toValue(init.timeZone));
   });
 
@@ -91,9 +95,7 @@ export function useTemporalStore(init: TemporalValueStoreInit) {
     get: () => temporalVal.value,
     set: value => {
       temporalVal.value = value;
-      if (!isTemporalPartial(value)) {
-        model.set?.(toDate(value));
-      }
+      model.set?.(isTemporalPartial(value) ? undefined : toDate(value));
     },
   });
 

--- a/packages/core/src/useNumberField/useNumberField.ts
+++ b/packages/core/src/useNumberField/useNumberField.ts
@@ -1,4 +1,4 @@
-import { Ref, computed, nextTick, shallowRef, toValue } from 'vue';
+import { Ref, computed, nextTick, shallowRef, toValue, watch } from 'vue';
 import {
   createDescribedByProps,
   fromNumberish,
@@ -154,19 +154,28 @@ export function useNumberField(
     schema: props.schema,
   });
 
+  const formattedText = shallowRef<string>('');
   const { validityDetails, updateValidity } = useInputValidity({
     inputEl,
     field,
     disableHtmlValidation: props.disableHtmlValidation,
   });
-  const { fieldValue, setValue, setTouched, errorMessage, isDisabled } = field;
-  const formattedText = computed<string>(() => {
-    if (Number.isNaN(fieldValue.value) || isEmpty(fieldValue.value)) {
-      return '';
-    }
 
-    return parser.format(fieldValue.value);
-  });
+  const { fieldValue, setValue, setTouched, errorMessage, isDisabled } = field;
+
+  watch(
+    [locale, () => toValue(props.formatOptions), fieldValue],
+    () => {
+      if (Number.isNaN(fieldValue.value) || isEmpty(fieldValue.value)) {
+        formattedText.value = '';
+
+        return;
+      }
+
+      formattedText.value = parser.format(fieldValue.value);
+    },
+    { immediate: true },
+  );
 
   const { labelProps, labelledByProps } = useLabel({
     for: inputId,

--- a/packages/core/src/usePicker/index.ts
+++ b/packages/core/src/usePicker/index.ts
@@ -1,0 +1,1 @@
+export * from './usePicker';

--- a/packages/core/src/usePicker/usePicker.ts
+++ b/packages/core/src/usePicker/usePicker.ts
@@ -1,0 +1,70 @@
+import { computed, InjectionKey, provide, ref } from 'vue';
+import { usePopoverController } from '../helpers/usePopoverController';
+import { createDisabledContext } from '../helpers/createDisabledContext';
+import { normalizeProps, withRefCapture } from '../utils/common';
+import { Reactivify } from '../types';
+import { useControlButtonProps } from '../helpers/useControlButtonProps';
+
+export interface PickerProps {
+  /**
+   * Whether the picker is disabled.
+   */
+  disabled?: boolean;
+}
+
+export interface PickerContext {
+  isOpen: () => boolean;
+  close: () => void;
+}
+
+export const PickerContextKey: InjectionKey<PickerContext> = Symbol('PickerContext');
+
+export function usePicker(_props: Reactivify<PickerProps>) {
+  const props = normalizeProps(_props);
+  const pickerEl = ref<HTMLElement>();
+  const disabled = createDisabledContext(props.disabled);
+
+  const { isOpen } = usePopoverController(pickerEl, { disabled });
+
+  const pickerProps = computed(() => {
+    return withRefCapture(
+      {
+        role: 'dialog',
+      },
+      pickerEl,
+    );
+  });
+
+  function onOpen() {
+    isOpen.value = true;
+  }
+
+  const pickerTriggerProps = useControlButtonProps(() => {
+    return {
+      disabled: disabled.value,
+      onClick: onOpen,
+    };
+  });
+
+  provide(PickerContextKey, {
+    isOpen: () => isOpen.value,
+    close: () => (isOpen.value = false),
+  });
+
+  return {
+    /**
+     * Whether the picker should be open.
+     */
+    isOpen,
+
+    /**
+     * The props for the picker element.
+     */
+    pickerProps,
+
+    /**
+     * The props for the picker trigger element.
+     */
+    pickerTriggerProps,
+  };
+}

--- a/packages/core/src/usePicker/usePicker.ts
+++ b/packages/core/src/usePicker/usePicker.ts
@@ -35,7 +35,7 @@ export function usePicker(_props: Reactivify<PickerProps>) {
     return withRefCapture(
       {
         role: 'dialog',
-        'aria-modal': 'true',
+        'aria-modal': 'true' as const,
         'aria-label': toValue(props.label),
       },
       pickerEl,

--- a/packages/core/src/usePicker/usePicker.ts
+++ b/packages/core/src/usePicker/usePicker.ts
@@ -1,4 +1,4 @@
-import { computed, InjectionKey, provide, ref } from 'vue';
+import { computed, InjectionKey, provide, ref, toValue } from 'vue';
 import { usePopoverController } from '../helpers/usePopoverController';
 import { createDisabledContext } from '../helpers/createDisabledContext';
 import { normalizeProps, withRefCapture } from '../utils/common';
@@ -10,6 +10,11 @@ export interface PickerProps {
    * Whether the picker is disabled.
    */
   disabled?: boolean;
+
+  /**
+   * The label for the picker.
+   */
+  label: string;
 }
 
 export interface PickerContext {
@@ -30,6 +35,8 @@ export function usePicker(_props: Reactivify<PickerProps>) {
     return withRefCapture(
       {
         role: 'dialog',
+        'aria-modal': 'true',
+        'aria-label': toValue(props.label),
       },
       pickerEl,
     );
@@ -41,6 +48,7 @@ export function usePicker(_props: Reactivify<PickerProps>) {
 
   const pickerTriggerProps = useControlButtonProps(() => {
     return {
+      'aria-label': toValue(props.label),
       disabled: disabled.value,
       onClick: onOpen,
     };

--- a/packages/core/src/validation/useInputValidity.ts
+++ b/packages/core/src/validation/useInputValidity.ts
@@ -128,6 +128,11 @@ export function useInputValidity(opts: InputValidityOptions) {
     useEventListener(opts.inputEl, opts?.events || ['invalid'], () => validateNative(true));
   }
 
+  // TODO: is this the best approach?
+  if (!opts.inputEl) {
+    watch(opts.field.fieldValue, updateValidity);
+  }
+
   /**
    * Validity is always updated on mount.
    */

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.1",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "vue-tsc && vite build",
     "preview": "vite preview"
   },

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -12,6 +12,7 @@
     "@tailwindcss/postcss": "^4.0.6",
     "fuse.js": "^7.1.0",
     "tailwindcss": "^4.0.6",
+    "@internationalized/date": "^3.7.0",
     "vue": "^3.5.13",
     "vue-i18n": "^11.1.1",
     "yup": "^1.6.1",

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -2,6 +2,7 @@
 import DateField from '@/components/DateField.vue';
 import { createCalendar } from '@internationalized/date';
 
+const today = new Date();
 const minDate = new Date('2025-01-01');
 const maxDate = new Date('2025-01-31');
 </script>
@@ -11,10 +12,12 @@ const maxDate = new Date('2025-01-31');
     <DateField
       name="date"
       label="Date"
+      :value="today"
+      locale="ar"
       :calendar="createCalendar('islamic-umalqura')"
       :format-options="{
         day: '2-digit',
-        month: '2-digit',
+        month: 'long',
         year: 'numeric',
         hour: '2-digit',
         hour12: true,

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import DateField from '@/components/DateField.vue';
+
+const minDate = new Date('2025-01-01');
+const maxDate = new Date('2025-01-31');
 </script>
 
 <template>
@@ -7,6 +10,8 @@ import DateField from '@/components/DateField.vue';
     <DateField
       name="date"
       label="Date"
+      :min-date="minDate"
+      :max-date="maxDate"
       :format-options="{
         day: '2-digit',
         month: '2-digit',

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -7,13 +7,13 @@ import DateField from '@/components/DateField.vue';
     <DateField
       name="date"
       label="Date"
+      locale="ar-EG"
       :format-options="{
+        calendar: 'islamic-umalqura',
         day: '2-digit',
-        month: '2-digit',
+        month: 'long',
+        weekday: 'long',
         year: 'numeric',
-        hour: 'numeric',
-        minute: 'numeric',
-        hour12: true,
       }"
     />
   </div>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -9,7 +9,7 @@ const maxDate = new Date(2025, 1, 18, 0, 0, 0, 0);
 
 <template>
   <div class="flex flex-col gap-4">
-    <DateField
+    <!-- <DateField
       name="date"
       label="Date"
       :format-options="{
@@ -21,6 +21,8 @@ const maxDate = new Date(2025, 1, 18, 0, 0, 0, 0);
         minute: '2-digit',
         second: '2-digit',
       }"
-    />
+    /> -->
+
+    <Calendar label="Pick a date" :model-value="new Date('2025-09-16')" />
   </div>
 </template>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -9,7 +9,7 @@ import DateField from '@/components/DateField.vue';
       label="Date"
       :format-options="{
         day: '2-digit',
-        month: '2-digit',
+        month: 'long',
         year: 'numeric',
         hour: '2-digit',
         hour12: true,

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -10,8 +10,6 @@ const maxDate = new Date('2025-01-31');
     <DateField
       name="date"
       label="Date"
-      :min-date="minDate"
-      :max-date="maxDate"
       :format-options="{
         day: '2-digit',
         month: '2-digit',

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import DateField from '@/components/DateField.vue';
 import Calendar from './components/Calendar.vue';
-// import { createCalendar } from '@internationalized/date';
+import { createCalendar } from '@internationalized/date';
 
 const minDate = new Date(2025, 1, 14, 0, 0, 0, 0);
 const maxDate = new Date(2025, 1, 18, 0, 0, 0, 0);
+
+const islamic = createCalendar('islamic-umalqura');
 </script>
 
 <template>
@@ -23,6 +25,6 @@ const maxDate = new Date(2025, 1, 18, 0, 0, 0, 0);
       }"
     /> -->
 
-    <Calendar label="Pick a date" :model-value="new Date('2025-09-16')" />
+    <Calendar label="Pick a date" locale="ar-EG" :calendar="islamic" />
   </div>
 </template>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import DateField from '@/components/DateField.vue';
+import { createCalendar } from '@internationalized/date';
 
 const minDate = new Date('2025-01-01');
 const maxDate = new Date('2025-01-31');
@@ -10,6 +11,7 @@ const maxDate = new Date('2025-01-31');
     <DateField
       name="date"
       label="Date"
+      :calendar="createCalendar('islamic-umalqura')"
       :format-options="{
         day: '2-digit',
         month: '2-digit',

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -8,7 +8,7 @@ const maxDate = new Date('2025-01-31');
 </script>
 
 <template>
-  <div class="flex flex-col w-1/2 gap-4">
+  <div class="flex flex-col gap-4">
     <DateField
       name="date"
       label="Date"

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -11,6 +11,10 @@ import DateField from '@/components/DateField.vue';
         day: '2-digit',
         month: '2-digit',
         year: 'numeric',
+        hour: '2-digit',
+        hour12: true,
+        minute: '2-digit',
+        second: '2-digit',
       }"
     />
   </div>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import DateField from '@/components/DateField.vue';
 import Calendar from '@/components/Calendar.vue';
+import { createCalendar, IslamicUmalquraCalendar } from '@internationalized/date';
+const calendar = createCalendar('islamic-umalqura');
 
 // You need to be careful with the time component of the date object.
 // JS date objects fills the date time with the current time component.
@@ -11,20 +13,6 @@ const max = new Date('2025-01-20');
 
 <template>
   <div class="flex flex-col gap-4">
-    <!-- <DateField
-      name="date"
-      label="Date"
-      :format-options="{
-        day: '2-digit',
-        month: 'numeric',
-        year: 'numeric',
-        hour: '2-digit',
-        hour12: true,
-        minute: '2-digit',
-        second: '2-digit',
-      }"
-    /> -->
-
-    <Calendar label="Calendar" :value="value" readonly />
+    <DateField label="Hijri Date" :value="new Date('2025-02-11')" :calendar="calendar" locale="ar-EG" />
   </div>
 </template>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -3,11 +3,7 @@ import { Temporal } from '@js-temporal/polyfill';
 import { useCalendar } from '@formwerk/core';
 import DateField from '@/components/DateField.vue';
 
-const { days, daysOfTheWeek } = useCalendar({
-  currentDate: Temporal.Now.plainDate('islamic'),
-  locale: 'en-EG-u-ca-islamic',
-  calendar: 'islamic',
-});
+const { days, daysOfTheWeek } = useCalendar();
 </script>
 
 <template>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,11 +1,35 @@
 <script setup lang="ts">
 import { Temporal } from '@js-temporal/polyfill';
-import { useForm } from '@formwerk/core';
+import { useCalendar } from '@formwerk/core';
 import DateField from '@/components/DateField.vue';
+
+const { days, daysOfTheWeek } = useCalendar({
+  currentDate: Temporal.Now.plainDate('islamic'),
+  locale: 'en-EG-u-ca-islamic',
+  calendar: 'islamic',
+});
 </script>
 
 <template>
   <div class="flex flex-col w-1/2 gap-4">
+    <div class="grid grid-cols-7">
+      <div v-for="day in daysOfTheWeek" :key="day.long" class="flex flex-col items-center justify-center">
+        {{ day.short }}
+      </div>
+
+      <div
+        v-for="day in days"
+        :key="day.dayOfMonth"
+        :aria-checked="day.isToday"
+        class="flex flex-col items-center justify-center aria-checked:bg-blue-600 aria-checked:text-white aria-checked:font-medium"
+        :class="{
+          'text-zinc-500': day.isOutsideMonth,
+        }"
+      >
+        {{ day.dayOfMonth }}
+      </div>
+    </div>
+
     <DateField
       name="date"
       label="Date"

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -9,7 +9,7 @@ import DateField from '@/components/DateField.vue';
       label="Date"
       :format-options="{
         day: '2-digit',
-        month: 'long',
+        month: '2-digit',
         year: 'numeric',
         hour: '2-digit',
         hour12: true,

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -25,6 +25,6 @@ const islamic = createCalendar('islamic-umalqura');
       }"
     /> -->
 
-    <Calendar label="Pick a date" locale="ar-EG" :calendar="islamic" />
+    <Calendar label="Pick a date" :min="minDate" :max="maxDate" />
   </div>
 </template>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import DateField from '@/components/DateField.vue';
-import Calendar from './components/Calendar.vue';
-import { createCalendar } from '@internationalized/date';
+import Calendar from '@/components/Calendar.vue';
 
-const minDate = new Date(2025, 1, 14, 0, 0, 0, 0);
-const maxDate = new Date(2025, 1, 18, 0, 0, 0, 0);
-
-const islamic = createCalendar('islamic-umalqura');
+// You need to be careful with the time component of the date object.
+// JS date objects fills the date time with the current time component.
+const min = new Date(2025, 0, 4, 0, 0, 0, 0);
+const value = new Date('2025-01-15');
+const max = new Date('2025-01-20');
 </script>
 
 <template>
@@ -25,6 +25,6 @@ const islamic = createCalendar('islamic-umalqura');
       }"
     /> -->
 
-    <Calendar label="Pick a date" :min="minDate" :max="maxDate" />
+    <Calendar label="Calendar" :value="value" readonly />
   </div>
 </template>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -24,7 +24,5 @@ const maxDate = new Date('2025-02-18');
         second: '2-digit',
       }"
     />
-
-    <Calendar name="date" label="select a date" :min="minDate" :max="maxDate" />
   </div>
 </template>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,38 +1,15 @@
 <script setup lang="ts">
-import { Temporal } from '@js-temporal/polyfill';
-import { useCalendar } from '@formwerk/core';
 import DateField from '@/components/DateField.vue';
-
-const { days, daysOfTheWeek } = useCalendar();
 </script>
 
 <template>
   <div class="flex flex-col w-1/2 gap-4">
-    <div class="grid grid-cols-7">
-      <div v-for="day in daysOfTheWeek" :key="day.long" class="flex flex-col items-center justify-center">
-        {{ day.short }}
-      </div>
-
-      <div
-        v-for="day in days"
-        :key="day.dayOfMonth"
-        :aria-checked="day.isToday"
-        class="flex flex-col items-center justify-center aria-checked:bg-blue-600 aria-checked:text-white aria-checked:font-medium"
-        :class="{
-          'text-zinc-500': day.isOutsideMonth,
-        }"
-      >
-        {{ day.dayOfMonth }}
-      </div>
-    </div>
-
     <DateField
       name="date"
       label="Date"
       :format-options="{
-        weekday: 'long',
-        day: 'numeric',
-        month: 'long',
+        day: '2-digit',
+        month: '2-digit',
         year: 'numeric',
         hour: 'numeric',
         minute: 'numeric',

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import DateField from '@/components/DateField.vue';
-import { createCalendar } from '@internationalized/date';
+// import { createCalendar } from '@internationalized/date';
 
 const today = new Date();
 const minDate = new Date('2025-01-01');
@@ -14,7 +14,6 @@ const maxDate = new Date('2025-01-31');
       label="Date"
       :value="today"
       locale="ar"
-      :calendar="createCalendar('islamic-umalqura')"
       :format-options="{
         day: '2-digit',
         month: 'long',

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -12,11 +12,9 @@ const maxDate = new Date('2025-01-31');
     <DateField
       name="date"
       label="Date"
-      :value="today"
-      locale="ar"
       :format-options="{
         day: '2-digit',
-        month: 'long',
+        month: 'numeric',
         year: 'numeric',
         hour: '2-digit',
         hour12: true,

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -3,8 +3,8 @@ import DateField from '@/components/DateField.vue';
 import Calendar from './components/Calendar.vue';
 // import { createCalendar } from '@internationalized/date';
 
-const minDate = new Date('2025-02-14');
-const maxDate = new Date('2025-02-18');
+const minDate = new Date(2025, 1, 14, 0, 0, 0, 0);
+const maxDate = new Date(2025, 1, 18, 0, 0, 0, 0);
 </script>
 
 <template>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -12,8 +12,6 @@ const maxDate = new Date(2025, 1, 18, 0, 0, 0, 0);
     <DateField
       name="date"
       label="Date"
-      :min="minDate"
-      :max="maxDate"
       :format-options="{
         day: '2-digit',
         month: 'numeric',

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import DateField from '@/components/DateField.vue';
+import Calendar from './components/Calendar.vue';
 // import { createCalendar } from '@internationalized/date';
 
-const today = new Date();
-const minDate = new Date('2025-01-01');
-const maxDate = new Date('2025-01-31');
+const minDate = new Date('2025-02-14');
+const maxDate = new Date('2025-02-18');
 </script>
 
 <template>
@@ -12,6 +12,8 @@ const maxDate = new Date('2025-01-31');
     <DateField
       name="date"
       label="Date"
+      :min="minDate"
+      :max="maxDate"
       :format-options="{
         day: '2-digit',
         month: 'numeric',
@@ -22,5 +24,7 @@ const maxDate = new Date('2025-01-31');
         second: '2-digit',
       }"
     />
+
+    <Calendar name="date" label="select a date" :min="minDate" :max="maxDate" />
   </div>
 </template>

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -7,12 +7,9 @@ import DateField from '@/components/DateField.vue';
     <DateField
       name="date"
       label="Date"
-      locale="ar-EG"
       :format-options="{
-        calendar: 'islamic-umalqura',
         day: '2-digit',
-        month: 'long',
-        weekday: 'long',
+        month: '2-digit',
         year: 'numeric',
       }"
     />

--- a/packages/playground/src/components/Calendar.vue
+++ b/packages/playground/src/components/Calendar.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { useCalendar, type CalendarProps, CalendarCell } from '@formwerk/core';
+
+const props = defineProps<CalendarProps>();
+
+const { calendarProps, gridProps, nextButtonProps, previousButtonProps, gridLabelProps, gridLabel, currentView } =
+  useCalendar(props);
+</script>
+
+<template>
+  <div class="bg-zinc-800 px-4 py-4" v-bind="calendarProps">
+    <div class="flex items-center justify-between text-white my-4">
+      <button v-bind="previousButtonProps">⬆️</button>
+
+      <span v-bind="gridLabelProps">
+        {{ gridLabel }}
+      </span>
+
+      <button v-bind="nextButtonProps">⬇️</button>
+    </div>
+
+    <div v-if="currentView.type === 'weeks'" v-bind="gridProps" class="grid grid-cols-7 gap-4">
+      <div
+        v-for="day in currentView.weekDays"
+        :key="day"
+        class="flex flex-col items-center justify-center text-white font-bold"
+      >
+        {{ day }}
+      </div>
+
+      <CalendarCell
+        v-for="day in currentView.days"
+        v-bind="day"
+        class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+        :class="{
+          'text-zinc-500': day.isOutsideMonth,
+          'text-white': !day.isOutsideMonth,
+          'border-transparent': !day.isToday,
+          'border-emerald-600': day.isToday,
+        }"
+      >
+        {{ day.label }}
+      </CalendarCell>
+    </div>
+
+    <div v-if="currentView.type === 'months'" v-bind="gridProps" class="grid grid-cols-4 gap-4">
+      <CalendarCell
+        v-for="month in currentView.months"
+        v-bind="month"
+        class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+      >
+        {{ month.label }}
+      </CalendarCell>
+    </div>
+
+    <div v-if="currentView.type === 'years'" v-bind="gridProps" class="grid grid-cols-4 gap-4">
+      <CalendarCell
+        v-for="year in currentView.years"
+        v-bind="year"
+        class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+      >
+        {{ year.label }}
+      </CalendarCell>
+    </div>
+  </div>
+</template>

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -17,14 +17,14 @@ const {
 
 const {
   pickerProps,
-  panelGridProps,
+  gridProps,
   buttonProps,
-  nextPanelButtonProps,
-  previousPanelButtonProps,
-  panelLabelProps,
-  panelLabel,
+  nextButtonProps,
+  previousButtonProps,
+  gridLabelProps,
+  gridLabel,
   currentPanel,
-} = useCalendar(calendarProps);
+} = useCalendar({ ...calendarProps, allowedPanels: ['weeks', 'months', 'years'] });
 </script>
 
 <template>
@@ -43,59 +43,57 @@ const {
 
     <div popover class="bg-zinc-800 px-4 py-4" v-bind="pickerProps">
       <div class="flex items-center justify-between text-white my-4">
-        <button v-bind="previousPanelButtonProps">⬆️</button>
+        <button v-bind="previousButtonProps">⬆️</button>
 
-        <span v-bind="panelLabelProps">
-          {{ panelLabel }}
+        <span v-bind="gridLabelProps">
+          {{ gridLabel }}
         </span>
 
-        <button v-bind="nextPanelButtonProps">⬇️</button>
+        <button v-bind="nextButtonProps">⬇️</button>
       </div>
 
-      <div class="gap-4" :dir="direction" v-bind="panelGridProps">
-        <template v-if="currentPanel.type === 'day'">
-          <div
-            v-for="day in currentPanel.daysOfTheWeek"
-            :key="day"
-            class="flex flex-col items-center justify-center text-white font-bold"
-          >
-            {{ day }}
-          </div>
+      <div v-if="currentPanel.type === 'weeks'" v-bind="gridProps" class="grid grid-cols-7 gap-4">
+        <div
+          v-for="day in currentPanel.weekDays"
+          :key="day"
+          class="flex flex-col items-center justify-center text-white font-bold"
+        >
+          {{ day }}
+        </div>
 
-          <CalendarCell
-            v-for="day in currentPanel.days"
-            v-bind="day"
-            class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
-            :class="{
-              'text-zinc-500': day.isOutsideMonth,
-              'text-white': !day.isOutsideMonth,
-              'border-transparent': !day.isToday,
-              'border-emerald-600': day.isToday,
-            }"
-          >
-            {{ day.label }}
-          </CalendarCell>
-        </template>
+        <CalendarCell
+          v-for="day in currentPanel.days"
+          v-bind="day"
+          class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+          :class="{
+            'text-zinc-500': day.isOutsideMonth,
+            'text-white': !day.isOutsideMonth,
+            'border-transparent': !day.isToday,
+            'border-emerald-600': day.isToday,
+          }"
+        >
+          {{ day.label }}
+        </CalendarCell>
+      </div>
 
-        <template v-if="currentPanel.type === 'month'">
-          <CalendarCell
-            v-for="month in currentPanel.months"
-            v-bind="month"
-            class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
-          >
-            {{ month.label }}
-          </CalendarCell>
-        </template>
+      <div v-if="currentPanel.type === 'months'" v-bind="gridProps" class="grid grid-cols-4 gap-4">
+        <CalendarCell
+          v-for="month in currentPanel.months"
+          v-bind="month"
+          class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+        >
+          {{ month.label }}
+        </CalendarCell>
+      </div>
 
-        <template v-if="currentPanel.type === 'year'">
-          <CalendarCell
-            v-for="year in currentPanel.years"
-            v-bind="year"
-            class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
-          >
-            {{ year.label }}
-          </CalendarCell>
-        </template>
+      <div v-if="currentPanel.type === 'years'" v-bind="gridProps" class="grid grid-cols-4 gap-4">
+        <CalendarCell
+          v-for="year in currentPanel.years"
+          v-bind="year"
+          class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+        >
+          {{ year.label }}
+        </CalendarCell>
       </div>
     </div>
 

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { useDateTimeField, DateTimeFieldProps, DateTimeSegment, useCalendar, CalendarCell } from '@formwerk/core';
+import { useDateTimeField, DateTimeFieldProps, DateTimeSegment } from '@formwerk/core';
+import Calendar from './Calendar.vue';
 
 const props = defineProps<DateTimeFieldProps>();
 
@@ -14,17 +15,6 @@ const {
   calendarProps,
   direction,
 } = useDateTimeField(props);
-
-const {
-  pickerProps,
-  gridProps,
-  buttonProps,
-  nextButtonProps,
-  previousButtonProps,
-  gridLabelProps,
-  gridLabel,
-  currentPanel,
-} = useCalendar({ ...calendarProps, allowedPanels: ['weeks', 'months', 'years'] });
 </script>
 
 <template>
@@ -41,61 +31,7 @@ const {
       <button v-bind="buttonProps">📅</button>
     </div>
 
-    <div popover class="bg-zinc-800 px-4 py-4" v-bind="pickerProps">
-      <div class="flex items-center justify-between text-white my-4">
-        <button v-bind="previousButtonProps">⬆️</button>
-
-        <span v-bind="gridLabelProps">
-          {{ gridLabel }}
-        </span>
-
-        <button v-bind="nextButtonProps">⬇️</button>
-      </div>
-
-      <div v-if="currentPanel.type === 'weeks'" v-bind="gridProps" class="grid grid-cols-7 gap-4">
-        <div
-          v-for="day in currentPanel.weekDays"
-          :key="day"
-          class="flex flex-col items-center justify-center text-white font-bold"
-        >
-          {{ day }}
-        </div>
-
-        <CalendarCell
-          v-for="day in currentPanel.days"
-          v-bind="day"
-          class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
-          :class="{
-            'text-zinc-500': day.isOutsideMonth,
-            'text-white': !day.isOutsideMonth,
-            'border-transparent': !day.isToday,
-            'border-emerald-600': day.isToday,
-          }"
-        >
-          {{ day.label }}
-        </CalendarCell>
-      </div>
-
-      <div v-if="currentPanel.type === 'months'" v-bind="gridProps" class="grid grid-cols-4 gap-4">
-        <CalendarCell
-          v-for="month in currentPanel.months"
-          v-bind="month"
-          class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
-        >
-          {{ month.label }}
-        </CalendarCell>
-      </div>
-
-      <div v-if="currentPanel.type === 'years'" v-bind="gridProps" class="grid grid-cols-4 gap-4">
-        <CalendarCell
-          v-for="year in currentPanel.years"
-          v-bind="year"
-          class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
-        >
-          {{ year.label }}
-        </CalendarCell>
-      </div>
-    </div>
+    <Calendar v-bind="calendarProps" />
 
     <span v-bind="errorMessageProps" class="w-full truncate error-message">
       {{ errorMessage }}

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -16,8 +16,6 @@ const {
 } = useDateTimeField(props);
 
 const {
-  days,
-  daysOfTheWeek,
   pickerProps,
   gridProps,
   buttonProps,
@@ -25,6 +23,7 @@ const {
   previousMonthButtonProps,
   monthYearLabelProps: calendarLabelProps,
   monthYearLabel,
+  currentPanel,
 } = useCalendar(calendarProps);
 </script>
 
@@ -53,28 +52,50 @@ const {
         <button v-bind="nextMonthButtonProps">⬇️</button>
       </div>
 
-      <div class="grid grid-cols-7 gap-4" :dir="direction" v-bind="gridProps">
-        <div
-          v-for="day in daysOfTheWeek"
-          :key="day.long"
-          class="flex flex-col items-center justify-center text-white font-bold"
-        >
-          {{ day.short }}
-        </div>
+      <div class="gap-4" :dir="direction" v-bind="gridProps">
+        <template v-if="currentPanel.type === 'day'">
+          <div
+            v-for="day in currentPanel.daysOfTheWeek"
+            :key="day"
+            class="flex flex-col items-center justify-center text-white font-bold"
+          >
+            {{ day }}
+          </div>
 
-        <CalendarCell
-          v-for="day in days"
-          v-bind="day"
-          class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
-          :class="{
-            'text-zinc-500': day.isOutsideMonth,
-            'text-white': !day.isOutsideMonth,
-            'border-transparent': !day.isToday,
-            'border-emerald-600': day.isToday,
-          }"
-        >
-          {{ day.dayOfMonth }}
-        </CalendarCell>
+          <CalendarCell
+            v-for="day in currentPanel.days"
+            v-bind="day"
+            class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+            :class="{
+              'text-zinc-500': day.isOutsideMonth,
+              'text-white': !day.isOutsideMonth,
+              'border-transparent': !day.isToday,
+              'border-emerald-600': day.isToday,
+            }"
+          >
+            {{ day.label }}
+          </CalendarCell>
+        </template>
+
+        <template v-if="currentPanel.type === 'month'">
+          <CalendarCell
+            v-for="month in currentPanel.months"
+            v-bind="month"
+            class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+          >
+            {{ month.label }}
+          </CalendarCell>
+        </template>
+
+        <template v-if="currentPanel.type === 'year'">
+          <CalendarCell
+            v-for="year in currentPanel.years"
+            v-bind="year"
+            class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+          >
+            {{ year.label }}
+          </CalendarCell>
+        </template>
       </div>
     </div>
 

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -46,6 +46,8 @@ const { pickerProps, pickerTriggerProps } = usePicker({
 </template>
 
 <style scoped lang="postcss">
+@reference "../style.css";
+
 .InputDate {
   font-family: 'Monaspace Neon Var';
   @apply relative w-full;

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useDateTimeField, DateTimeFieldProps, DateTimeSegment } from '@formwerk/core';
+import { useDateTimeField, DateTimeFieldProps, DateTimeSegment, usePicker } from '@formwerk/core';
 import Calendar from './Calendar.vue';
 
 const props = defineProps<DateTimeFieldProps>();
@@ -15,6 +15,8 @@ const {
   calendarProps,
   direction,
 } = useDateTimeField(props);
+
+const { pickerProps, pickerTriggerProps } = usePicker({});
 </script>
 
 <template>
@@ -28,10 +30,12 @@ const {
         <DateTimeSegment v-for="segment in segments" v-bind="segment" class="segment" />
       </div>
 
-      <button v-bind="buttonProps">📅</button>
+      <button v-bind="pickerTriggerProps">📅</button>
     </div>
 
-    <Calendar v-bind="calendarProps" />
+    <div v-bind="pickerProps" popover>
+      <Calendar v-bind="calendarProps" />
+    </div>
 
     <span v-bind="errorMessageProps" class="w-full truncate error-message">
       {{ errorMessage }}

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -17,12 +17,12 @@ const {
 
 const {
   pickerProps,
-  gridProps,
+  panelGridProps,
   buttonProps,
-  nextMonthButtonProps,
-  previousMonthButtonProps,
-  monthYearLabelProps: calendarLabelProps,
-  monthYearLabel,
+  nextPanelButtonProps,
+  previousPanelButtonProps,
+  panelLabelProps,
+  panelLabel,
   currentPanel,
 } = useCalendar(calendarProps);
 </script>
@@ -43,16 +43,16 @@ const {
 
     <div popover class="bg-zinc-800 px-4 py-4" v-bind="pickerProps">
       <div class="flex items-center justify-between text-white my-4">
-        <button v-bind="previousMonthButtonProps">⬆️</button>
+        <button v-bind="previousPanelButtonProps">⬆️</button>
 
-        <span v-bind="calendarLabelProps">
-          {{ monthYearLabel }}
+        <span v-bind="panelLabelProps">
+          {{ panelLabel }}
         </span>
 
-        <button v-bind="nextMonthButtonProps">⬇️</button>
+        <button v-bind="nextPanelButtonProps">⬇️</button>
       </div>
 
-      <div class="gap-4" :dir="direction" v-bind="gridProps">
+      <div class="gap-4" :dir="direction" v-bind="panelGridProps">
         <template v-if="currentPanel.type === 'day'">
           <div
             v-for="day in currentPanel.daysOfTheWeek"

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -80,7 +80,7 @@ const { days, daysOfTheWeek } = useCalendar(calendarProps);
   }
 
   .segment {
-    @apply p-0.5 rounded focus:outline-none focus:bg-blue-600;
+    @apply p-0.5 rounded focus:outline-none focus:bg-blue-600 caret-transparent;
   }
 
   .error-message {

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -15,7 +15,7 @@ const {
   direction,
 } = useDateTimeField(props);
 
-const { days, daysOfTheWeek } = useCalendar(calendarProps);
+const { days, daysOfTheWeek, pickerProps, gridProps, buttonProps } = useCalendar(calendarProps);
 </script>
 
 <template>
@@ -29,11 +29,11 @@ const { days, daysOfTheWeek } = useCalendar(calendarProps);
         <DateTimeSegment v-for="segment in segments" v-bind="segment" class="segment" />
       </div>
 
-      <button type="button" popovertarget="calendar">📅</button>
+      <button v-bind="buttonProps">📅</button>
     </div>
 
-    <div id="calendar" popover class="bg-zinc-800 px-4 py-4">
-      <div class="grid grid-cols-7 gap-4" :dir="direction">
+    <div popover class="bg-zinc-800 px-4 py-4" v-bind="pickerProps">
+      <div class="grid grid-cols-7 gap-4" :dir="direction" v-bind="gridProps">
         <div
           v-for="day in daysOfTheWeek"
           :key="day.long"
@@ -45,8 +45,7 @@ const { days, daysOfTheWeek } = useCalendar(calendarProps);
         <CalendarCell
           v-for="day in days"
           v-bind="day"
-          :aria-checked="day.isSelected"
-          class="flex flex-col items-center justify-center aria-checked:bg-emerald-600 aria-checked:text-white aria-checked:font-medium border-2"
+          class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none"
           :class="{
             'text-zinc-500': day.isOutsideMonth,
             'text-white': !day.isOutsideMonth,

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -3,14 +3,23 @@ import { useDateTimeField, DateTimeFieldProps, DateTimeSegment, useCalendar, Cal
 
 const props = defineProps<DateTimeFieldProps>();
 
-const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, segments, fieldValue, calendarProps } =
-  useDateTimeField(props);
+const {
+  controlProps,
+  isTouched,
+  labelProps,
+  errorMessageProps,
+  errorMessage,
+  segments,
+  fieldValue,
+  calendarProps,
+  direction,
+} = useDateTimeField(props);
 
 const { days, daysOfTheWeek } = useCalendar(calendarProps);
 </script>
 
 <template>
-  <div class="InputDate" :class="{ touched: isTouched }">
+  <div class="InputDate" :class="{ touched: isTouched }" :dir="direction">
     <span class="label" v-bind="labelProps">{{ label }}</span>
 
     {{ fieldValue }}
@@ -24,7 +33,7 @@ const { days, daysOfTheWeek } = useCalendar(calendarProps);
     </div>
 
     <div id="calendar" popover class="bg-zinc-800 px-4 py-4">
-      <div class="grid grid-cols-7 gap-4">
+      <div class="grid grid-cols-7 gap-4" :dir="direction">
         <div
           v-for="day in daysOfTheWeek"
           :key="day.long"
@@ -36,11 +45,13 @@ const { days, daysOfTheWeek } = useCalendar(calendarProps);
         <CalendarCell
           v-for="day in days"
           v-bind="day"
-          :aria-checked="day.isToday"
-          class="flex flex-col items-center justify-center aria-checked:bg-blue-600 aria-checked:text-white aria-checked:font-medium"
+          :aria-checked="day.isSelected"
+          class="flex flex-col items-center justify-center aria-checked:bg-emerald-600 aria-checked:text-white aria-checked:font-medium border-2"
           :class="{
             'text-zinc-500': day.isOutsideMonth,
             'text-white': !day.isOutsideMonth,
+            'border-transparent': !day.isToday,
+            'border-emerald-600': day.isToday,
           }"
         >
           {{ day.dayOfMonth }}

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -16,7 +16,9 @@ const {
   direction,
 } = useDateTimeField(props);
 
-const { pickerProps, pickerTriggerProps } = usePicker({});
+const { pickerProps, pickerTriggerProps } = usePicker({
+  label: 'Pick a date',
+});
 </script>
 
 <template>

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { useDateTimeField, DateTimeFieldProps, DateTimeSegment } from '@formwerk/core';
+import { useDateTimeField, DateTimeFieldProps, DateTimeSegment, useCalendar, CalendarCell } from '@formwerk/core';
 
 const props = defineProps<DateTimeFieldProps>();
 
-const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, segments, fieldValue } =
+const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, segments, fieldValue, calendarProps } =
   useDateTimeField(props);
+
+const { days, daysOfTheWeek } = useCalendar(calendarProps);
 </script>
 
 <template>
@@ -13,8 +15,37 @@ const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, se
 
     {{ fieldValue }}
 
-    <div v-bind="controlProps" class="control">
-      <DateTimeSegment v-for="segment in segments" v-bind="segment" class="segment" />
+    <div class="flex items-center gap-1 control">
+      <div v-bind="controlProps">
+        <DateTimeSegment v-for="segment in segments" v-bind="segment" class="segment" />
+      </div>
+
+      <button type="button" popovertarget="calendar">📅</button>
+    </div>
+
+    <div id="calendar" popover class="bg-zinc-800 px-4 py-4">
+      <div class="grid grid-cols-7 gap-4">
+        <div
+          v-for="day in daysOfTheWeek"
+          :key="day.long"
+          class="flex flex-col items-center justify-center text-white font-bold"
+        >
+          {{ day.short }}
+        </div>
+
+        <CalendarCell
+          v-for="day in days"
+          v-bind="day"
+          :aria-checked="day.isToday"
+          class="flex flex-col items-center justify-center aria-checked:bg-blue-600 aria-checked:text-white aria-checked:font-medium"
+          :class="{
+            'text-zinc-500': day.isOutsideMonth,
+            'text-white': !day.isOutsideMonth,
+          }"
+        >
+          {{ day.dayOfMonth }}
+        </CalendarCell>
+      </div>
     </div>
 
     <span v-bind="errorMessageProps" class="w-full truncate error-message">
@@ -34,7 +65,7 @@ const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, se
   }
 
   .control {
-    @apply max-w-xs rounded-md border-2 border-transparent py-3 px-4 w-full bg-zinc-800 focus:bg-zinc-900 focus:outline-none transition-colors duration-200 focus:border-emerald-500 disabled:cursor-not-allowed text-white font-medium;
+    @apply max-w-lg rounded-md border-2 border-transparent py-3 px-4 w-full bg-zinc-800 focus:bg-zinc-900 focus:outline-none transition-colors duration-200 focus:border-emerald-500 disabled:cursor-not-allowed text-white font-medium;
   }
 
   .segment {

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -65,7 +65,7 @@ const {
         <CalendarCell
           v-for="day in days"
           v-bind="day"
-          class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none"
+          class="flex flex-col items-center justify-center aria-selected:bg-emerald-600 aria-selected:text-white aria-selected:font-medium border-2 focus:border-emerald-600 focus:outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
           :class="{
             'text-zinc-500': day.isOutsideMonth,
             'text-white': !day.isOutsideMonth,

--- a/packages/playground/src/components/DateField.vue
+++ b/packages/playground/src/components/DateField.vue
@@ -15,7 +15,17 @@ const {
   direction,
 } = useDateTimeField(props);
 
-const { days, daysOfTheWeek, pickerProps, gridProps, buttonProps } = useCalendar(calendarProps);
+const {
+  days,
+  daysOfTheWeek,
+  pickerProps,
+  gridProps,
+  buttonProps,
+  nextMonthButtonProps,
+  previousMonthButtonProps,
+  monthYearLabelProps: calendarLabelProps,
+  monthYearLabel,
+} = useCalendar(calendarProps);
 </script>
 
 <template>
@@ -33,6 +43,16 @@ const { days, daysOfTheWeek, pickerProps, gridProps, buttonProps } = useCalendar
     </div>
 
     <div popover class="bg-zinc-800 px-4 py-4" v-bind="pickerProps">
+      <div class="flex items-center justify-between text-white my-4">
+        <button v-bind="previousMonthButtonProps">⬆️</button>
+
+        <span v-bind="calendarLabelProps">
+          {{ monthYearLabel }}
+        </span>
+
+        <button v-bind="nextMonthButtonProps">⬇️</button>
+      </div>
+
       <div class="grid grid-cols-7 gap-4" :dir="direction" v-bind="gridProps">
         <div
           v-for="day in daysOfTheWeek"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,9 +149,9 @@ importers:
 
   packages/core:
     dependencies:
-      '@js-temporal/polyfill':
-        specifier: ^0.4.4
-        version: 0.4.4
+      '@internationalized/date':
+        specifier: ^3.7.0
+        version: 3.7.0
       '@standard-schema/spec':
         specifier: 1.0.0
         version: 1.0.0
@@ -188,15 +188,12 @@ importers:
       '@formwerk/core':
         specifier: workspace:*
         version: link:../core
-<<<<<<< HEAD
+      '@internationalized/date':
+        specifier: ^3.7.0
+        version: 3.7.0
       '@tailwindcss/postcss':
         specifier: ^4.0.6
         version: 4.0.6
-=======
-      '@js-temporal/polyfill':
-        specifier: ^0.4.4
-        version: 0.4.4
->>>>>>> fd43bf9 (feat: add temporals)
       fuse.js:
         specifier: ^7.1.0
         version: 7.1.0
@@ -818,6 +815,9 @@ packages:
     resolution: {integrity: sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==}
     engines: {node: '>=18.18'}
 
+  '@internationalized/date@3.7.0':
+    resolution: {integrity: sha512-VJ5WS3fcVx0bejE/YHfbDKR/yawZgKqn/if+oEeLqNwBtPzVB06olkfcnojTmEMX+gTpH+FlQ69SHNitJ8/erQ==}
+
   '@intlify/core-base@11.1.1':
     resolution: {integrity: sha512-bb8gZvoeKExCI2r/NVCK9E4YyOkvYGaSCPxVZe8T0jz8aX+dHEOZWxK06Z/Y9mWRkJfBiCH4aOhDF1yr1t5J8Q==}
     engines: {node: '>= 16'}
@@ -861,10 +861,6 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
-
-  '@js-temporal/polyfill@0.4.4':
-    resolution: {integrity: sha512-2X6bvghJ/JAoZO52lbgyAPFj8uCflhTo2g7nkFzEQdXd/D8rEeD4HtmTEpmtGCva260fcd66YNXBOYdnmHqSOg==}
-    engines: {node: '>=12'}
 
   '@jsdevtools/ez-spawn@3.0.4':
     resolution: {integrity: sha512-f5DRIOZf7wxogefH03RjMPMdBF7ADTWUMoOs9kaJo06EfwF+aFhMZMDZxHg/Xe12hptN9xoZjGso2fdjapBRIA==}
@@ -1137,6 +1133,9 @@ packages:
 
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
   '@tailwindcss/node@4.0.6':
     resolution: {integrity: sha512-jb6E0WeSq7OQbVYcIJ6LxnZTeC4HjMvbzFBMCrQff4R50HBlo/obmYNk6V2GCUXDeqiXtvtrQgcIbT+/boB03Q==}
@@ -2596,9 +2595,6 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
-
-  jsbi@4.3.0:
-    resolution: {integrity: sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g==}
 
   jsdom@26.0.0:
     resolution: {integrity: sha512-BZYDGVAIriBWTpIxYzrXjv3E/4u8+/pSG5bQdIYCbNCGOvsPkDQfTVLAIXAf9ETdCpduCVTkDe2NNZ8NIwUVzw==}
@@ -4422,6 +4418,10 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.1': {}
 
+  '@internationalized/date@3.7.0':
+    dependencies:
+      '@swc/helpers': 0.5.15
+
   '@intlify/core-base@11.1.1':
     dependencies:
       '@intlify/message-compiler': 11.1.1
@@ -4468,11 +4468,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
-
-  '@js-temporal/polyfill@0.4.4':
-    dependencies:
-      jsbi: 4.3.0
-      tslib: 2.8.1
 
   '@jsdevtools/ez-spawn@3.0.4':
     dependencies:
@@ -4720,6 +4715,10 @@ snapshots:
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/utils@0.3.0': {}
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
 
   '@tailwindcss/node@4.0.6':
     dependencies:
@@ -6381,8 +6380,6 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
-
-  jsbi@4.3.0: {}
 
   jsdom@26.0.0:
     dependencies:

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -75,7 +75,7 @@ async function createConfig(pkg: keyof typeof pkgNameMap, format: ModuleFormat) 
         'klona',
         '@standard-schema/utils',
         '@standard-schema/spec',
-        '@js-temporal/polyfill',
+        '@internationalized/date',
       ].filter(Boolean) as string[],
       plugins: createPlugins({ version, pkg, format }),
     },


### PR DESCRIPTION
# What

Swaps out the temporal implementation in #115 for [@internationalized/date](https://react-spectrum.adobe.com/internationalized/date/index.html).

# Why

While I loved working with temporals, the fact that they are not widely supported yet is not encouraging. I would have proceeded with them if they were at least Baseline supported.

My main reasons are:

- Existing polyfill sizes are too much to justify the investment
  - `@js-temporal/polyfill` is `56.7kb` gzipped.
  - `temporal-polyfill` is `20.5kb` gzipped.
  - `@internationalized/date` is `10.9kb` gzipped.
- The question of what value type to use is muddied further.
  - Temporals while are great in serializing values, they cannot be used anywhere else. They need to be supported in Node.js and to be more common in the ecosystem as a whole.
  - Temporals won't probably be used by any developer today, so we are asking them to add a huge bundle size for little reason, especially those who are not interested in our i18n offering.
  - `@internationalized/date` is a little more common in the ecosystem and has utility outside formwerk use.

I think once temporals hit baseline, we will make that switch, its such a shame because it is a great API imo. Another alternative, is we find or fork or build a minimal version of the temporal spec and use it internally.