### PR TITLE
feat(date/time field): change step to 10 if shift is pressed

### DIFF
--- a/packages/core/src/useDateTime/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTime/useDateTimeSegment.ts
@@ -174,7 +174,7 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
       if (hasKeyCode(evt, 'ArrowUp')) {
         blockEvent(evt);
         if (!isNonEditable()) {
-          increment();
+          increment(evt.shiftKey ? 10 : 1);
         }
         return;
       }
@@ -182,7 +182,7 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
       if (hasKeyCode(evt, 'ArrowDown')) {
         blockEvent(evt);
         if (!isNonEditable()) {
-          decrement();
+          decrement(evt.shiftKey ? -10 : -1);
         }
         return;
       }

--- a/packages/core/src/useDateTime/useDateTimeSegmentGroup.ts
+++ b/packages/core/src/useDateTime/useDateTimeSegmentGroup.ts
@@ -25,8 +25,8 @@ export interface DateTimeSegmentRegistration {
 export interface DateTimeSegmentGroupContext {
   useDateSegmentRegistration(segment: DateTimeSegmentRegistration): {
     parser: NumberParserContext;
-    increment(): void;
-    decrement(): void;
+    increment(step: number): void;
+    decrement(step: number): void;
     setValue(value: number): void;
     getMetadata(): { min: number | null; max: number | null; maxLength: number | null };
     onDone(): void;
@@ -150,16 +150,16 @@ export function useDateTimeSegmentGroup({
       renderedSegments.value = renderedSegments.value.filter(s => s.id !== segment.id);
     });
 
-    function increment() {
+    function increment(step: number = 1) {
       const type = segment.getType();
-      const date = addToPart(type, 1);
+      const date = addToPart(type, step);
 
       onValueChange(withAllPartsSet(date));
     }
 
-    function decrement() {
+    function decrement(step: number = -1) {
       const type = segment.getType();
-      const date = addToPart(type, -1);
+      const date = addToPart(type, step);
 
       onValueChange(withAllPartsSet(date));
     }

--- a/packages/playground/src/components/TimeField.vue
+++ b/packages/playground/src/components/TimeField.vue
@@ -27,7 +27,7 @@ const { controlProps, isTouched, labelProps, errorMessageProps, errorMessage, se
 @reference "../style.css";
 
 .InputDate {
-  font-family: 'Monaspace Neon Var';
+  font-family: 'Monaspace Neon Var', monospace;
   @apply relative w-max;
   margin-bottom: calc(1em * 1.5);
 


### PR DESCRIPTION
Is it wise to merge `increment` and `decrement` into one function, since their implementation is exactly the same?

Or maybe let the step be `10` and change the `decrement` implementation to be like:

```ts
    function decrement(step: number = 1) {
      const type = segment.getType();
      const date = addToPart(type, -step);

      onValueChange(withAllPartsSet(date));
    }
```

Also, I believe the current tests are flaky and gives different results based on the time of the year when the tests are run. For example, current tests will fail if you run it in December because the increment will increase both the month and the year.

I didn't update the tests because this issue needs to be resolved first. I tried setting the date to an absolute value then I stopped because I'd like to know what you think first.

closes #156