### PR TITLE
feat: set touched for OTP field closes #162

### DIFF
--- a/.changeset/tidy-crews-open.md
+++ b/.changeset/tidy-crews-open.md
@@ -1,0 +1,5 @@
+---
+'@formwerk/core': patch
+---
+
+fix: set touched for otp fields #162

--- a/packages/core/src/useOtpField/types.ts
+++ b/packages/core/src/useOtpField/types.ts
@@ -14,6 +14,7 @@ export interface OtpSlotRegistration {
 export interface OtpContext {
   useSlotRegistration(): OtpSlotRegistration;
   getMaskCharacter(): string;
+  onBlur(): void;
 }
 
 export const OtpContextKey: InjectionKey<OtpContext> = Symbol('otp-context');

--- a/packages/core/src/useOtpField/useOtpField.spec.ts
+++ b/packages/core/src/useOtpField/useOtpField.spec.ts
@@ -14,6 +14,7 @@ const InputBase: string = `
     <label v-bind="labelProps">{{ label }}</label>
     <span v-bind="errorMessageProps">{{ errorMessage }}</span>
     <span data-testid="value">{{ fieldValue }}</span>
+    <span data-testid="touched">{{ isTouched }}</span>
   </div>
 `;
 
@@ -139,6 +140,24 @@ describe('useOtpField', () => {
       expect(fieldSlots.value[0].masked).toBe(false);
       expect(fieldSlots.value[1].masked).toBe(false);
       expect(fieldSlots.value[2].masked).toBe(true);
+    });
+  });
+
+  describe('blur behavior', () => {
+    test('sets touched state to true when a slot is blurred', async () => {
+      const OtpField = createOtpField({ label: 'OTP Code', length: 4 });
+
+      await render({
+        components: { OtpField },
+        template: `<OtpField />`,
+      });
+
+      // Find the first slot and trigger blur
+      const slot = screen.getAllByTestId('slot')[0];
+      await fireEvent.blur(slot);
+
+      // Verify that the slot has the touched state by checking its aria attributes
+      expect(screen.getByTestId('touched')).toHaveTextContent('true');
     });
   });
 

--- a/packages/core/src/useOtpField/useOtpField.ts
+++ b/packages/core/src/useOtpField/useOtpField.ts
@@ -349,6 +349,9 @@ export function useOtpField(_props: Reactivify<OtpFieldProps, 'schema' | 'onComp
         setValue: fillSlots,
       };
     },
+    onBlur() {
+      field.setTouched(true);
+    },
   });
 
   if (__DEV__) {

--- a/packages/core/src/useOtpField/useOtpSlot.ts
+++ b/packages/core/src/useOtpField/useOtpSlot.ts
@@ -74,6 +74,9 @@ export function useOtpSlot(_props: Reactivify<OtpSlotProps>) {
     onPaste(e: ClipboardEvent) {
       registration?.handlePaste(e);
     },
+    onBlur() {
+      context?.onBlur();
+    },
     onKeydown(e: KeyboardEvent) {
       if (hasKeyCode(e, 'Backspace') || hasKeyCode(e, 'Delete')) {
         blockEvent(e);


### PR DESCRIPTION
# What

OTP fields never set the touched state, we should add a blur handler on each slot element and call the setTouched for the field.