### PR TITLE
fix: correct type for initialValues in FormProps interface

### DIFF
--- a/.changeset/fine-garlics-appear.md
+++ b/.changeset/fine-garlics-appear.md
@@ -1,0 +1,5 @@
+---
+'@formwerk/core': patch
+---
+
+revert - fix(types): should be able to infer values from initial values

--- a/packages/core/src/useForm/useForm.ts
+++ b/packages/core/src/useForm/useForm.ts
@@ -16,30 +16,24 @@ import {
   GenericFormSchema,
   StandardSchema,
   DirtySchema,
+  IssueCollection,
+  PathValue,
 } from '../types';
-import { createFormContext, BaseFormContext } from './formContext';
+import { createFormContext, BaseFormContext, SetValueOptions } from './formContext';
 import { FormTransactionManager, useFormTransactions } from './useFormTransactions';
-import { FormActions, useFormActions } from './useFormActions';
+import { ConsumableData, FormActions, ResetState, useFormActions } from './useFormActions';
 import { useFormSnapshots } from './formSnapshot';
 import { getConfig } from '../config';
 import { FieldTypePrefixes } from '../constants';
 import { appendToFormData, clearFormData } from '../utils/formData';
-import { PartialDeep, Simplify } from 'type-fest';
+import { Arrayable, PartialDeep } from 'type-fest';
 import { createDisabledContext } from '../helpers/createDisabledContext';
 
-export interface FormProps<
-  TSchema extends GenericFormSchema,
-  TInput extends FormObject = StandardSchemaV1.InferInput<TSchema>,
-> {
+interface _FormProps<TInput extends FormObject> {
   /**
    * The form's unique identifier.
    */
   id?: string;
-
-  /**
-   * The initial values for the form fields.
-   */
-  initialValues?: MaybeGetter<MaybeAsync<PartialDeep<StandardSchemaV1.InferInput<TSchema>>>>;
 
   /**
    * The initial touched state for form fields.
@@ -50,11 +44,6 @@ export interface FormProps<
    * The initial dirty state for form fields.
    */
   initialDirty?: DirtySchema<TInput>;
-
-  /**
-   * The validation schema for the form.
-   */
-  schema?: TSchema;
 
   /**
    * Whether HTML5 validation should be disabled for this form.
@@ -70,6 +59,169 @@ export interface FormProps<
    * Whether the form should scroll to the first invalid field on invalid submission.
    */
   scrollToInvalidFieldOnSubmit?: ScrollIntoViewOptions | boolean;
+}
+
+interface NoSchemaFormProps<TInput extends FormObject> extends _FormProps<TInput> {
+  initialValues?: MaybeGetter<MaybeAsync<PartialDeep<TInput>>>;
+}
+
+interface SchemaFormProps<TSchema extends GenericFormSchema> extends _FormProps<StandardSchemaV1.InferInput<TSchema>> {
+  /**
+   * The validation schema for the form.
+   */
+  schema: TSchema;
+
+  initialValues?: MaybeGetter<MaybeAsync<PartialDeep<StandardSchemaV1.InferInput<TSchema>>>>;
+}
+
+export interface FormReturns<TInput extends FormObject = FormObject, TOutput extends FormObject = TInput> {
+  /**
+   * The current values of the form.
+   */
+  values: PartialDeep<TInput>;
+
+  /**
+   * The form context object, for internal use.
+   * @private
+   */
+  context: FormContext<TInput, TOutput>;
+
+  /**
+   * Whether the form is submitting.
+   */
+  isSubmitting: Ref<boolean>;
+
+  /**
+   * Checks if the form is valid, or if a form path is valid. Validity is defined as the absence of errors.
+   * @param path - The path to check. If not provided, the form as a whole will be checked.
+   */
+  isValid(path?: Path<TInput>): boolean;
+
+  /**
+   * Whether the form is disabled.
+   */
+  isDisabled: Ref<boolean>;
+
+  /**
+   * The number of times the form has been submitted, regardless of the form's validity.
+   */
+  submitAttemptsCount: Ref<number>;
+
+  /**
+   * Whether the form was submitted, which is true if the form was submitted and the submission was successful.
+   */
+  wasSubmitted: Ref<boolean>;
+
+  /**
+   * Whether the form was submitted, wether the validity or the submission was successful or not.
+   */
+  isSubmitAttempted: Ref<boolean>;
+
+  /**
+   * Checks if the form is dirty, which is true if any field's value has changed from the initial values. Accepts an optional path to check if a specific form path is dirty.
+   * @param path - The path to check. If not provided, the form as a whole will be checked.
+   */
+  isDirty(path?: Path<TInput>): boolean;
+
+  /**
+   * Set a form field value by name.
+   */
+  setValue<TPath extends Path<TInput>>(path: TPath, value: PathValue<TInput, TPath>): void;
+
+  /**
+   * Gets the value of a field or a path.
+   */
+  getValue<TPath extends Path<TInput>>(path: TPath): PathValue<TInput, TPath>;
+
+  /**
+   * Checks if the form is touched, which is true if any field has been touched. Accepts an optional path to check if a specific form path is touched.
+   * @param path - The path to check. If not provided, the form as a whole will be checked.
+   */
+  isTouched(path?: Path<TInput>): boolean;
+
+  /**
+   * Sets the touched state of the form. Alternatively, pass a path to set the touched state of a specific form path.
+   * @param path - The path to set the touched state of. If a boolean is passed, the touched state of all form fields will be set to that value.
+   * @param value - The value to set the touched state to.
+   */
+  setTouched(value: boolean): void;
+  setTouched<TPath extends Path<TInput>>(path: TPath, value: boolean): void;
+
+  /**
+   * Get the errors for a form field, or the
+   */
+  getErrors: (path?: Path<TInput>) => string[];
+
+  /**
+   * Displays the errors for a form field.
+   * @param path - The path to display the errors for.
+   */
+  displayError(path: Path<TInput>): string | undefined;
+
+  /**
+   * Get the issues for a form field.
+   */
+  getIssues: (path?: Path<TInput>) => IssueCollection[];
+
+  /**
+   * Get the submit errors for a form field.
+   */
+  getSubmitErrors: (path?: Path<TInput>) => IssueCollection[]; // TODO: Inconsistent naming with return type.
+
+  /**
+   * Sets the errors for a form path.
+   * @param path - The path to set the errors for.
+   * @param message - The message to set the errors to.
+   */
+  setErrors<TPath extends Path<TInput>>(path: TPath, message: Arrayable<string>): void;
+  setErrors<TPath extends Path<TInput>>(issues: IssueCollection<TPath>[]): void;
+
+  /**
+   * Handle form submission.
+   */
+  handleSubmit: (onSubmit: (values: ConsumableData<TOutput>) => void | Promise<void>) => (e?: Event) => Promise<void>;
+
+  /**
+   * Reset the form to its initial values
+   */
+  reset(): Promise<void>;
+  reset(state: Partial<ResetState<TInput>>, opts?: SetValueOptions): Promise<void>;
+  reset<TPath extends Path<TInput>>(path: TPath): Promise<void>;
+  reset<TPath extends Path<TInput>>(
+    path: TPath,
+    state: Partial<ResetState<PathValue<TInput, TPath>>>,
+    opts?: SetValueOptions,
+  ): Promise<void>;
+
+  /**
+   * Validate the form.
+   */
+  validate: () => Promise<FormValidationResult<TOutput>>;
+
+  /**
+   * Get the error for a form field.
+   */
+  getError: (path: Path<TInput>) => string | undefined;
+
+  /**
+   * Get the submit error for a form field.
+   */
+  getSubmitError: (path: Path<TInput>) => string | undefined;
+
+  /**
+   * Handle form reset.
+   */
+  handleReset: (afterReset?: () => MaybeAsync<void>) => (e?: Event) => Promise<void>;
+
+  /**
+   * Set the value for a form field.
+   */
+  setValues: (values: PartialDeep<TInput>, opts?: SetValueOptions) => void;
+
+  /**
+   * The form props.
+   */
+  formProps: FormDomProps;
 }
 
 export interface FormContext<TInput extends FormObject = FormObject, TOutput extends FormObject = TInput>
@@ -93,35 +245,42 @@ export const FormKey: InjectionKey<FormContext<any>> = Symbol('Formwerk FormKey'
 
 export const FormContextKey: InjectionKey<FormReturns & FormActions<any, any>> = Symbol('Formwerk FormContextKey');
 
+export function useForm<TInput extends FormObject>(props?: NoSchemaFormProps<TInput>): FormReturns<TInput>;
+export function useForm<TSchema extends GenericFormSchema>(
+  props?: SchemaFormProps<TSchema>,
+): FormReturns<StandardSchemaV1.InferInput<TSchema>, StandardSchemaV1.InferOutput<TSchema>>;
 export function useForm<
   TSchema extends GenericFormSchema,
   TInput extends FormObject = StandardSchemaV1.InferInput<TSchema>,
   TOutput extends FormObject = StandardSchemaV1.InferOutput<TSchema>,
->(props?: Partial<FormProps<TSchema, TInput>>) {
+>(props?: NoSchemaFormProps<TInput> | SchemaFormProps<TSchema>): FormReturns<TInput, TOutput> {
+  type TResolvedInput = typeof props extends NoSchemaFormProps<TInput> ? TInput : StandardSchemaV1.InferInput<TSchema>;
+
+  const schemaProps = props as SchemaFormProps<TSchema> | undefined;
   const touchedSnapshot = useFormSnapshots(props?.initialTouched);
   const dirtySnapshot = useFormSnapshots(props?.initialDirty);
   const valuesSnapshot = useFormSnapshots<TInput, TOutput>(props?.initialValues as TInput, {
     onAsyncInit,
-    schema: props?.schema as StandardSchema<TInput, TOutput>,
+    schema: schemaProps?.schema as StandardSchema<TInput, TOutput>,
   });
 
   const id = props?.id || useUniqId(FieldTypePrefixes.Form);
   const isDisabled = createDisabledContext(props?.disabled);
   const isHtmlValidationDisabled = () => props?.disableHtmlValidation ?? getConfig().disableHtmlValidation;
-  const values = reactive(cloneDeep(valuesSnapshot.originals.value)) as PartialDeep<TInput>;
-  const touched = reactive(cloneDeep(touchedSnapshot.originals.value)) as TouchedSchema<TInput>;
-  const dirty = reactive(cloneDeep(dirtySnapshot.originals.value)) as DirtySchema<TInput>;
-  const disabled = reactive({}) as DisabledSchema<TInput>;
-  const errors = ref({}) as Ref<ErrorsSchema<TInput>>;
-  const submitErrors = ref({}) as Ref<ErrorsSchema<TInput>>;
+  const values = reactive(cloneDeep(valuesSnapshot.originals.value)) as PartialDeep<TResolvedInput>;
+  const touched = reactive(cloneDeep(touchedSnapshot.originals.value)) as TouchedSchema<TResolvedInput>;
+  const dirty = reactive(cloneDeep(dirtySnapshot.originals.value)) as DirtySchema<TResolvedInput>;
+  const disabled = reactive({}) as DisabledSchema<TResolvedInput>;
+  const errors = ref({}) as Ref<ErrorsSchema<TResolvedInput>>;
+  const submitErrors = ref({}) as Ref<ErrorsSchema<TResolvedInput>>;
 
-  const ctx = createFormContext<TInput, TOutput>({
+  const ctx = createFormContext<TResolvedInput, TOutput>({
     id,
-    values: values as TInput,
+    values: values as TResolvedInput,
     touched,
     disabled,
     dirty,
-    schema: props?.schema as StandardSchema<TInput, TOutput>,
+    schema: schemaProps?.schema as StandardSchema<TInput, TOutput>,
     errors,
     submitErrors,
     snapshots: {
@@ -131,7 +290,7 @@ export function useForm<
     },
   });
 
-  function isValid<TPath extends Path<TInput>>(path?: TPath) {
+  function isValid<TPath extends Path<TResolvedInput>>(path?: TPath) {
     const pathErrors = ctx.getErrors(path);
 
     return pathErrors.length === 0;
@@ -143,21 +302,21 @@ export function useForm<
 
   const transactionsManager = useFormTransactions(ctx);
   const { actions, isSubmitting, submitAttemptsCount, wasSubmitted, isSubmitAttempted, ...privateActions } =
-    useFormActions<TInput, TOutput>(ctx, {
+    useFormActions<TResolvedInput, TOutput>(ctx, {
       disabled,
-      schema: props?.schema as StandardSchema<TInput, TOutput>,
+      schema: schemaProps?.schema as StandardSchema<TResolvedInput, TOutput>,
       scrollToInvalidFieldOnSubmit: props?.scrollToInvalidFieldOnSubmit ?? true,
     });
 
-  function getError<TPath extends Path<TInput>>(path: TPath): string | undefined {
+  function getError<TPath extends Path<TResolvedInput>>(path: TPath): string | undefined {
     return ctx.isPathDisabled(path) ? undefined : ctx.getErrors(path)[0];
   }
 
-  function getSubmitError<TPath extends Path<TInput>>(path: TPath): string | undefined {
+  function getSubmitError<TPath extends Path<TResolvedInput>>(path: TPath): string | undefined {
     return ctx.isPathDisabled(path) ? undefined : ctx.getFieldSubmitErrors(path)[0];
   }
 
-  function displayError(path: Path<TInput>) {
+  function displayError(path: Path<TResolvedInput>) {
     return ctx.isTouched(path) && !ctx.isPathDisabled(path) ? getError(path) : undefined;
   }
 
@@ -193,110 +352,34 @@ export function useForm<
   };
 
   const baseReturns = {
-    /**
-     * The current values of the form.
-     */
     values: readonly(values),
-    /**
-     * The form context object, for internal use.
-     * @private
-     */
-    context: ctx,
-    /**
-     * Whether the form is submitting.
-     */
+    context: ctx as FormContext<TInput, TOutput>,
     isSubmitting,
-    /**
-     * Checks if the form is valid, or if a form path is valid. Validity is defined as the absence of errors.
-     * @param path - The path to check. If not provided, the form as a whole will be checked.
-     */
     isValid,
-    /**
-     * Whether the form is disabled.
-     */
     isDisabled,
-    /**
-     * The number of times the form has been submitted, regardless of the form's validity.
-     */
     submitAttemptsCount,
-    /**
-     * Whether the form was submitted, which is true if the form was submitted and the submission was successful.
-     */
     wasSubmitted,
-    /**
-     * Whether the form was submitted, wether the validity or the submission was successful or not.
-     */
     isSubmitAttempted,
-    /**
-     * Checks if the form is dirty, which is true if any field's value has changed from the initial values. Accepts an optional path to check if a specific form path is dirty.
-     * @param path - The path to check. If not provided, the form as a whole will be checked.
-     */
     isDirty: ctx.isDirty,
-    /**
-     * Sets the value of a field.
-     */
     setValue: ctx.setValue,
-    /**
-     * Gets the value of a field.
-     */
     getValue: ctx.getValue,
-    /**
-     * Checks if the form is touched, which is true if any field has been touched. Accepts an optional path to check if a specific form path is touched.
-     * @param path - The path to check. If not provided, the form as a whole will be checked.
-     */
     isTouched: ctx.isTouched,
-    /**
-     * Sets the touched state of the form. Alternatively, pass a path to set the touched state of a specific form path.
-     * @param path - The path to set the touched state of. If a boolean is passed, the touched state of all form fields will be set to that value.
-     * @param value - The value to set the touched state to.
-     */
     setTouched: ctx.setTouched,
-    /**
-     * Sets the errors for a form path.
-     * @param path - The path to set the errors for.
-     * @param message - The message to set the errors to.
-     */
     setErrors: ctx.setErrors,
-    /**
-     * Sets the values of the form.
-     */
     setValues: ctx.setValues,
-    /**
-     * Gets the errors for a field.
-     */
     getError,
-    /**
-     * Displays an error for a field.
-     */
     displayError,
-    /**
-     * Gets all the errors for the form.
-     */
     getErrors: ctx.getErrors,
-
-    /**
-     * Gets all the issues for the form. Issues are more detailed than errors, they contain the path and all the messages for a path.
-     */
     getIssues: ctx.getIssues,
-
-    /**
-     * Gets the submit errors for a field.
-     */
     getSubmitError,
-    /**
-     * Gets all the submit errors for the form.
-     */
     getSubmitErrors: ctx.getSubmitErrors,
-    /**
-     * Props for the form element.
-     */
     formProps,
   };
 
-  const form = {
+  const form: FormReturns<TInput, TOutput> = {
     ...baseReturns,
     ...actions,
-  };
+  } as FormReturns<TInput, TOutput>;
 
   if (__DEV__) {
     // using any until we can figure out how to type this properly
@@ -306,13 +389,8 @@ export function useForm<
 
   provide(FormContextKey, form as any);
 
-  return form as typeof baseReturns & FormActions<TInput, TOutput>;
+  return form;
 }
-
-/**
- * Just a utility type helper to get the return type of the useForm composable.
- */
-export type FormReturns = Simplify<ReturnType<typeof useForm>>;
 
 export function useFormContext<TInput extends FormObject = FormObject, TOutput extends FormObject = TInput>() {
   const ctx = inject(FormContextKey, null);
@@ -323,5 +401,5 @@ export function useFormContext<TInput extends FormObject = FormObject, TOutput e
     }
   }
 
-  return ctx as FormReturns & FormActions<TInput, TOutput>;
+  return ctx as FormReturns<TInput, TOutput>;
 }

--- a/packages/core/src/useForm/useForm.ts
+++ b/packages/core/src/useForm/useForm.ts
@@ -39,8 +39,7 @@ export interface FormProps<
   /**
    * The initial values for the form fields.
    */
-  initialValues?: MaybeGetter<MaybeAsync<PartialDeep<TInput>>>;
-
+  initialValues?: MaybeGetter<MaybeAsync<PartialDeep<StandardSchemaV1.InferInput<TSchema>>>>;
   /**
    * The initial touched state for form fields.
    */

--- a/packages/core/src/useForm/useForm.ts
+++ b/packages/core/src/useForm/useForm.ts
@@ -40,6 +40,7 @@ export interface FormProps<
    * The initial values for the form fields.
    */
   initialValues?: MaybeGetter<MaybeAsync<PartialDeep<StandardSchemaV1.InferInput<TSchema>>>>;
+
   /**
    * The initial touched state for form fields.
    */

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,27 +1,28 @@
 <script setup lang="ts">
-import { FileUploadContext, useForm } from '@formwerk/core';
-import TimeInput from './components/TimeField.vue';
-import Dropzone from './components/Dropzone.vue';
+import { useForm } from '@formwerk/core';
 
-const form = useForm();
+import z from 'zod';
+import InputText from './components/InputText.vue';
 
-function handleUpload({ file, signal }: FileUploadContext) {
-  return new Promise<string>(resolve => {
-    setTimeout(() => {
-      resolve('https://example.com/file.png');
-    }, 1000);
-  });
-}
+const schema = z.object({
+  firstName: z.string().min(1, 'First name is required'),
+  lastName: z.string().min(1, 'Last name is required'),
+});
 
-const formatOptions = {
-  hour: '2-digit',
-  minute: '2-digit',
-  second: '2-digit',
-};
+const { values, getValue } = useForm({
+  schema,
+  initialValues: {
+    firstName: 'john',
+  },
+});
 </script>
 
 <template>
   <div class="w-full h-full flex flex-col items-center justify-center`">
-    <TimeInput label="Time" name="time" :format-options="formatOptions" />
+    <InputText name="firstName" label="First Name" />
+    <InputText name="lastName" label="Last Name" />
+    <pre>last name: {{ values.lastName }}</pre>
+    <pre>get last name: {{ getValue('lastName') }}</pre>
+    <pre>{{ values }}</pre>
   </div>
 </template>


### PR DESCRIPTION
Builds on top of the work done in #176 to address both cases.

In this PR we use function overloading for `useForm` to steer it towards inferring the values from the `schema` or the `initialValues` depending on whichever is present or if both are, with preference to the `schema`.