### PR TITLE
fix(file-field): reset isDragging on file drop

### DIFF
--- a/.changeset/fast-fans-own.md
+++ b/.changeset/fast-fans-own.md
@@ -2,4 +2,4 @@
 '@formwerk/core': patch
 ---
 
-fix useFileField, change isDragging variable to false on file drop
+fix: useFileField, change isDragging variable to false on file drop

--- a/.changeset/fast-fans-own.md
+++ b/.changeset/fast-fans-own.md
@@ -1,0 +1,5 @@
+---
+'@formwerk/core': patch
+---
+
+fix useFileField, change isDragging variable to false on file drop

--- a/.changeset/fast-fans-own.md
+++ b/.changeset/fast-fans-own.md
@@ -2,4 +2,4 @@
 '@formwerk/core': patch
 ---
 
-fix: useFileField, change isDragging variable to false on file drop
+fix(useFileField): reset isDragging on file drop

--- a/packages/core/src/useFileField/useFileField.ts
+++ b/packages/core/src/useFileField/useFileField.ts
@@ -294,10 +294,11 @@ export function useFileField(_props: Reactivify<FileFieldProps, 'schema' | 'onUp
     },
     onDrop(evt: DragEvent) {
       blockEvent(evt);
+      isDragging.value = false;
       if (field.isDisabled.value) {
         return;
       }
-
+      
       processFiles(Array.from(evt.dataTransfer?.files ?? []));
     },
     onClick(e: MouseEvent) {


### PR DESCRIPTION
fixing bug where the isDragging variable is not reset after the item dropped