### PR TITLE
fix: fixes global/form-wide HTML validation disable

### DIFF
--- a/.changeset/tidy-maps-beg.md
+++ b/.changeset/tidy-maps-beg.md
@@ -1,0 +1,5 @@
+---
+'@formwerk/core': minor
+---
+
+Fixes global disable of HTML validation by working around a Vue quirk

--- a/packages/core/src/useCheckbox/useCheckbox.ts
+++ b/packages/core/src/useCheckbox/useCheckbox.ts
@@ -79,7 +79,8 @@ export interface CheckboxProps<TValue = boolean> {
   /**
    * Whether HTML5 validation should be disabled for this checkbox.
    */
-  disableHtmlValidation?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
+  disableHtmlValidation?: Boolean;
 }
 
 export interface CheckboxDomInputProps extends AriaLabelableProps, InputBaseAttributes {

--- a/packages/core/src/useCheckbox/useCheckboxGroup.ts
+++ b/packages/core/src/useCheckbox/useCheckboxGroup.ts
@@ -107,7 +107,8 @@ export interface CheckboxGroupProps<TCheckbox = unknown> {
   /**
    * Whether HTML5 validation should be disabled for this checkbox group.
    */
-  disableHtmlValidation?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
+  disableHtmlValidation?: Boolean;
 }
 
 interface CheckboxGroupDomProps extends AriaLabelableProps, AriaDescribableProps, AriaValidatableProps {

--- a/packages/core/src/useComboBox/useComboBox.ts
+++ b/packages/core/src/useComboBox/useComboBox.ts
@@ -80,7 +80,8 @@ export interface ComboBoxProps<TOption, TValue = TOption> {
   /**
    * Whether to disable HTML5 validation.
    */
-  disableHtmlValidation?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
+  disableHtmlValidation?: Boolean;
 
   /**
    * Whether to open the popup when the input is focused.

--- a/packages/core/src/useForm/useForm.ts
+++ b/packages/core/src/useForm/useForm.ts
@@ -48,7 +48,8 @@ interface _FormProps<TInput extends FormObject> {
   /**
    * Whether HTML5 validation should be disabled for this form.
    */
-  disableHtmlValidation?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
+  disableHtmlValidation?: Boolean;
 
   /**
    * Whether the form is disabled.

--- a/packages/core/src/useFormGroup/useFormGroup.ts
+++ b/packages/core/src/useFormGroup/useFormGroup.ts
@@ -42,7 +42,8 @@ export interface FormGroupProps<TInput extends FormObject = FormObject, TOutput 
   /**
    * Whether HTML5 validation should be disabled for this form group.
    */
-  disableHtmlValidation?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
+  disableHtmlValidation?: Boolean;
 }
 
 interface GroupProps extends AriaLabelableProps {
@@ -83,7 +84,9 @@ export function useFormGroup<TInput extends FormObject = FormObject, TOutput ext
   const parentGroup = inject(FormGroupKey, null);
   const isDisabled = createDisabledContext(props.disabled);
   const isHtmlValidationDisabled = () =>
-    toValue(props.disableHtmlValidation) ?? form?.isHtmlValidationDisabled() ?? getConfig().disableHtmlValidation;
+    (toValue(props.disableHtmlValidation) as boolean) ??
+    form?.isHtmlValidationDisabled() ??
+    getConfig().disableHtmlValidation;
   const { validate, onValidationDispatch, defineValidationRequest, onValidationDone, dispatchValidateDone } =
     useValidationProvider({
       getValues: () => getValue(),

--- a/packages/core/src/useNumberField/useNumberField.ts
+++ b/packages/core/src/useNumberField/useNumberField.ts
@@ -135,7 +135,8 @@ export interface NumberFieldProps {
   /**
    * Whether to disable HTML5 form validation.
    */
-  disableHtmlValidation?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
+  disableHtmlValidation?: Boolean;
 }
 
 export function useNumberField(_props: Reactivify<NumberFieldProps, 'schema'>) {

--- a/packages/core/src/useOtpField/useOtpField.ts
+++ b/packages/core/src/useOtpField/useOtpField.ts
@@ -75,7 +75,8 @@ export interface OtpFieldProps {
   /**
    * Whether to disable HTML validation.
    */
-  disableHtmlValidation?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
+  disableHtmlValidation?: Boolean;
 
   /**
    * The prefix of the OTP field. If you prefix your codes with a character, you can set it here (e.g "G-").

--- a/packages/core/src/useRadio/useRadioGroup.ts
+++ b/packages/core/src/useRadio/useRadioGroup.ts
@@ -101,7 +101,8 @@ export interface RadioGroupProps<TValue = string> {
   /**
    * Whether to disable HTML5 form validation.
    */
-  disableHtmlValidation?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
+  disableHtmlValidation?: Boolean;
 }
 
 interface RadioGroupDomProps extends AriaLabelableProps, AriaDescribableProps, AriaValidatableProps {

--- a/packages/core/src/useSearchField/useSearchField.ts
+++ b/packages/core/src/useSearchField/useSearchField.ts
@@ -115,7 +115,8 @@ export interface SearchFieldProps {
   /**
    * Whether to disable HTML5 form validation.
    */
-  disableHtmlValidation?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
+  disableHtmlValidation?: Boolean;
 }
 
 export function useSearchField(_props: Reactivify<SearchFieldProps, 'onSubmit' | 'schema'>) {

--- a/packages/core/src/useSwitch/useSwitch.ts
+++ b/packages/core/src/useSwitch/useSwitch.ts
@@ -92,7 +92,8 @@ export type SwitchProps<TValue = boolean> = {
   /**
    * Whether to disable HTML5 validation.
    */
-  disableHtmlValidation?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
+  disableHtmlValidation?: Boolean;
 };
 
 export function useSwitch<TValue = boolean>(_props: Reactivify<SwitchProps<TValue>, 'schema'>) {

--- a/packages/core/src/useTextField/useTextField.ts
+++ b/packages/core/src/useTextField/useTextField.ts
@@ -110,7 +110,8 @@ export interface TextFieldProps {
   /**
    * Whether to disable HTML5 validation.
    */
-  disableHtmlValidation?: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
+  disableHtmlValidation?: Boolean;
 }
 
 export function useTextField(_props: Reactivify<TextFieldProps, 'schema'>) {

--- a/packages/core/src/validation/useInputValidity.ts
+++ b/packages/core/src/validation/useInputValidity.ts
@@ -12,7 +12,8 @@ type ElementReference = Ref<Arrayable<Maybe<HTMLElement>>>;
 
 interface InputValidityOptions {
   inputEl?: ElementReference;
-  disableHtmlValidation?: MaybeRefOrGetter<boolean | undefined>;
+  // eslint-disable-next-line @typescript-eslint/no-wrapper-object-types
+  disableHtmlValidation?: MaybeRefOrGetter<Boolean | undefined>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   field: FormField<any>;
   events?: EventExpression[];

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -42,7 +42,7 @@ async function createConfig(pkg: keyof typeof pkgNameMap, format: ModuleFormat) 
     bundleName: `${pkgNameMap[pkg]}.${formatExt[format] ?? 'js'}`,
     input: {
       resolve: {
-        tsconfigFilename: normalizePath(path.resolve(__dirname, `../tsconfig.lib.json`)),
+        tsconfigFilename: slashes(path.resolve(__dirname, `../tsconfig.lib.json`)),
       },
       define: {
         __VERSION__: JSON.stringify(version),


### PR DESCRIPTION
This fixes the global/form-wide HTML validation disable configuration, by making sure that Vue treats non-explicit & optional booleans as undefined instead of casting to false. 
Previously the most fine-grained control (i.e. setting it via `useTextField` props) would always overwrite the more global control, even if the boolean was never explicitly provided at that level.
It now uses the wrapper type `Boolean` instead of `boolean`, so that Vue correctly uses undefined for booleans that are not provided. 

The change in [scripts/config.ts](https://github.com/formwerkjs/formwerk/compare/main...KammererTob:formwerk:fix/global-disable-html-validation?expand=1#diff-5b9d59df63c11e72bcc6f7f9df237a90c7fa429dac6f9f22d5c72b5adec672e0) was needed because otherwise i was not able to build on windows. This might have been an oversight when migrating to rolldown.