### PR TITLE
fix: fixes windows build in rolldown

### DIFF
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -42,7 +42,7 @@ async function createConfig(pkg: keyof typeof pkgNameMap, format: ModuleFormat) 
     bundleName: `${pkgNameMap[pkg]}.${formatExt[format] ?? 'js'}`,
     input: {
       resolve: {
-        tsconfigFilename: normalizePath(path.resolve(__dirname, `../tsconfig.lib.json`)),
+        tsconfigFilename: slashes(path.resolve(__dirname, `../tsconfig.lib.json`)),
       },
       define: {
         __VERSION__: JSON.stringify(version),


### PR DESCRIPTION
This fixes the build process for Windows (tested on 10 and 11). I am not sure what the reason for `normalizePath` was before, but maybe it was an issue in rollup. It seems to work fine without it for rolldown.

The actual issue was that the path then looked something like: 
tsconfigFilename: 'file:///C:/Users/User/Documents/formwerk/tsconfig.lib.json'

which obviously does not work.