### PR TITLE
feat: update useEventListener to accept reactive event expressions

### DIFF
--- a/packages/core/src/validation/useInputValidity.spec.ts
+++ b/packages/core/src/validation/useInputValidity.spec.ts
@@ -2,6 +2,7 @@ import { nextTick, ref } from 'vue';
 import { useInputValidity } from './useInputValidity';
 import { fireEvent, render, screen } from '@testing-library/vue';
 import { FormField, useFormField } from '../useFormField';
+import { EventExpression } from '../helpers/useEventListener';
 
 test('updates the validity state on blur events', async () => {
   const input = ref<HTMLInputElement>();
@@ -96,4 +97,33 @@ test('updates the input native validity with custom validity errors', async () =
   await nextTick();
   expect(screen.getByTestId('err').textContent).toBe('Custom error');
   expect(input.value?.validationMessage).toBe('Custom error');
+});
+
+test('events can be reactive', async () => {
+  const input = ref<HTMLInputElement>();
+  const events = ref<EventExpression[]>(['test']);
+
+  await render({
+    setup: () => {
+      const field = useFormField();
+      useInputValidity({ inputEl: input, field, events });
+
+      return { input, errorMessage: field.errorMessage };
+    },
+    template: `
+      <form>
+        <input ref="input" data-testid="input" required />
+        <span data-testid="err">{{ errorMessage }}</span>
+      </form>
+    `,
+  });
+
+  await fireEvent.blur(screen.getByTestId('input'));
+  // mounted validation
+  expect(screen.getByTestId('err').textContent).toBe('Constraints not satisfied');
+  events.value = ['blur'];
+  await fireEvent.update(screen.getByTestId('input'), '12');
+  expect(screen.getByTestId('err').textContent).toBe('Constraints not satisfied');
+  await fireEvent.blur(screen.getByTestId('input'));
+  expect(screen.getByTestId('err').textContent).toBe('');
 });

--- a/packages/core/src/validation/useInputValidity.ts
+++ b/packages/core/src/validation/useInputValidity.ts
@@ -16,7 +16,7 @@ interface InputValidityOptions {
   disableHtmlValidation?: MaybeRefOrGetter<TransparentWrapper<boolean> | undefined>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   field: FormField<any>;
-  events?: EventExpression[];
+  events?: MaybeRefOrGetter<Arrayable<EventExpression>>;
   groupValidityBehavior?: 'some' | 'every';
 }
 


### PR DESCRIPTION
# What

Adds the ability to customize validation events by making it reactive and exposing `validateOn` prop, we will need to do it for all fields.

closes #193 