### PR TITLE
poc: fix errors displayed before validation finished

### DIFF
--- a/packages/core/src/useTextField/useTextField.ts
+++ b/packages/core/src/useTextField/useTextField.ts
@@ -126,7 +126,7 @@ export function useTextField(_props: Reactivify<TextFieldProps, 'schema'>) {
   });
 
   const { validityDetails } = useInputValidity({ inputEl, field, disableHtmlValidation: props.disableHtmlValidation });
-  const { fieldValue, setValue, setTouched, errorMessage, isDisabled } = field;
+  const { fieldValue, setValue, errorMessage, isDisabled } = field;
   const { labelProps, labelledByProps } = useLabel({
     for: inputId,
     label: props.label,
@@ -150,9 +150,7 @@ export function useTextField(_props: Reactivify<TextFieldProps, 'schema'>) {
     onChange(evt) {
       setValue((evt.target as HTMLInputElement).value);
     },
-    onBlur() {
-      setTouched(true);
-    },
+    onBlur() {},
   };
 
   const inputProps = useCaptureProps(() => {

--- a/packages/core/src/validation/useInputValidity.ts
+++ b/packages/core/src/validation/useInputValidity.ts
@@ -87,7 +87,7 @@ export function useInputValidity(opts: InputValidityOptions) {
     };
   }
 
-  async function _updateValidity() {
+  async function _updateValidity(initialValidation?: boolean) {
     let result = validateNative(true);
     if (schema && result.isValid) {
       result = await validateField(true);
@@ -98,6 +98,12 @@ export function useInputValidity(opts: InputValidityOptions) {
     }
 
     (formGroup || form)?.requestValidation();
+
+    if (!initialValidation) {
+      (formGroup || form)?.onValidationDone(() => {
+        opts.field.setTouched(true);
+      });
+    }
   }
 
   async function updateValidity() {
@@ -138,7 +144,7 @@ export function useInputValidity(opts: InputValidityOptions) {
    * Validity is always updated on mount.
    */
   onMounted(() => {
-    nextTick(() => _updateValidity());
+    nextTick(() => _updateValidity(true));
   });
 
   return {

--- a/packages/core/src/validation/useValidationProvider.ts
+++ b/packages/core/src/validation/useValidationProvider.ts
@@ -75,8 +75,6 @@ export function useValidationProvider<
     const allErrors = combineIssues([...errors, ...fieldIssues]);
     const output = 'value' in result ? result.value : undefined;
 
-    dispatchValidateDone();
-
     return createValidationResult({
       isValid: !allErrors.length,
       errors: allErrors,


### PR DESCRIPTION
This PR is meant as a proof of concept and maybe helper for a discussion on how to approach or fix this [issue](https://github.com/formwerkjs/formwerk/issues/203). 
I think the main issue is that for most fields (but especially the Text Field) `isTouched` is set to true independent of the validation. It is set `onBlur` (as a event on the input), but the validation can happen async (especially for Schema providers) and thus might not have finished yet.
There also is a initial validation on mount that already sets potential/initial errors in the background.
Since `isTouched` and the existence of an error are the two conditions to display errors with `displayError()`, it can show the initial (outdated) errors before the error message gets updated through the async validation.

The PR now tries to "fix" this by setting touched to true *after* the validation is done (expect on initial validation since no fields were touched at that point).
This has two potential issues i can see:
1. We cannot use `setTouched` on the native events (or custom events for checkbox, radio - i.e. arrow select, space, click), but have to rely on it being set after validation. This also is not really in line with what the documentation describes for touched (although that already is not 100% accurate), since the validation also occurs when the value is changed etc.
2. I had to remove one `dispatchValidateDone();` from `validate` inside the useValidationProviders.ts file because it was emitting this event "too soon" (i.e. before any errors where set), but i could not see any issue with that, since it seems to be called after setting the errors anyways in different places.

One test also now fails (the one checking for isTouched) since it relies on it currently being immediatly set to true on blur instead of after the validation/async.

Let me know what you think or if you need more information or a better explanation.