### PR TITLE
fix: DateTimeSegment backspace/delete handling

### DIFF
--- a/.changeset/polite-bees-drive.md
+++ b/.changeset/polite-bees-drive.md
@@ -1,0 +1,5 @@
+---
+'@formwerk/core': patch
+---
+
+Make backspace/delete more untuitive for date/time segments in DateField

--- a/packages/core/src/useDateTime/useDateTimeSegment.ts
+++ b/packages/core/src/useDateTime/useDateTimeSegment.ts
@@ -5,7 +5,7 @@ import { DateTimeSegmentGroupKey } from './useDateTimeSegmentGroup';
 import { FieldTypePrefixes } from '../constants';
 import { blockEvent } from '../utils/events';
 import { DateTimeSegmentType } from './types';
-import { isEditableSegmentType } from './constants';
+import { getSegmentTypePlaceholder, isEditableSegmentType } from './constants';
 import { createDisabledContext } from '../helpers/createDisabledContext';
 import { isFirefox } from '../utils/platform';
 
@@ -205,7 +205,16 @@ export function useDateTimeSegment(_props: Reactivify<DateTimeSegmentProps>) {
       if (hasKeyCode(evt, 'Backspace') || hasKeyCode(evt, 'Delete')) {
         blockEvent(evt);
         if (!isNonMutable()) {
-          clear();
+          if (currentInput.length > 1) {
+            currentInput = currentInput.slice(0, -1);
+          } else {
+            clear();
+            currentInput = '';
+          }
+
+          if (segmentEl.value) {
+            segmentEl.value.textContent = currentInput || (getSegmentTypePlaceholder(toValue(props.type)) ?? '');
+          }
         }
       }
     },


### PR DESCRIPTION
Closes: https://github.com/formwerkjs/formwerk/issues/212

This emulates correct backspace handling when typing into the segment and it also returns back to the default state when the input ends up empty.
The last part (about returning to the initial state) especially wasn't working when filling the segments initially, since the placeholder is set through the `value` and the `value` only changes when a segment was completely set first. Thus if you deleted input before that happened Vue did not detect any changes and thus did not rerender.

So the new behavour would be:
1. You can delete single digits while typing
2. When you delete the last digit it returns back to the initial state of this segment type
3. When you initially focus a segment (without typing in it) and press delete/backspace it behaves as before (i.e. resetting to the default value/placeholder).