### PR TITLE
fix: set field to touched on date select in calendar

### DIFF
--- a/.changeset/hip-bikes-visit.md
+++ b/.changeset/hip-bikes-visit.md
@@ -1,0 +1,5 @@
+---
+'@formwerk/core': patch
+---
+
+Sets the field to touched when selecting a date in the Calendar

--- a/packages/core/src/useCalendar/useCalendar.ts
+++ b/packages/core/src/useCalendar/useCalendar.ts
@@ -228,6 +228,8 @@ export function useCalendar(_props: Reactivify<CalendarProps, 'field' | 'schema'
       // Automatically close the calendar when a day is selected
       pickerContext?.close();
     }
+
+    field.setTouched(true);
   }
 
   const handleKeyDown = useCalendarKeyboard(context, currentView);


### PR DESCRIPTION
When using `Calendar` in a DateField i would expect the field to be set to touched when a date was selected, and thus the value of the field changed. This PR fixes this issue by setting it to touched when the Date is set.

Closes: https://github.com/formwerkjs/formwerk/issues/216