### PR TITLE
fix(repeater): prevent value corruption when resetting form

### DIFF
--- a/.changeset/goofy-ears-repair.md
+++ b/.changeset/goofy-ears-repair.md
@@ -1,0 +1,5 @@
+---
+'@formwerk/core': patch
+---
+
+fix(repeater): prevent value corruption when resetting form after item removal

--- a/packages/core/src/useFormRepeater/useFormRepeater.ts
+++ b/packages/core/src/useFormRepeater/useFormRepeater.ts
@@ -380,6 +380,13 @@ export function useFormRepeater<TItem = unknown>(_props: Reactivify<FormRepeater
     onMounted(() => {
       watch(getPathValue, value => {
         if (!isEqual(value, lastControlledValueSnapshot)) {
+          // Queue ARRAY_MUT to protect against stale DESTROY_PATH transactions
+          // from unmounting field components when records are rebuilt
+          form.transaction((_, { ARRAY_MUT }) => ({
+            kind: ARRAY_MUT,
+            path: getPath(),
+            value: value,
+          }));
           records.value = buildRecords();
         }
       });


### PR DESCRIPTION
When resetting a form after removing an item from a repeater, values would become corrupted with duplicates.

To fix it, whenever an external array change (via reset or whatever) is detected, an `ARRAY_MUT` transaction is scheduled to protect the new value from corruption by subsequent `UNSET` and `DESTORY` transactions.

We already implemented `ARRAY_MUT` to fix #230, so we can just re-use it here.