### PR TITLE
fix(otp): trigger onCompleted when setValue() fills all slots

### DIFF
--- a/.changeset/fix-otp-setvalue-oncompleted.md
+++ b/.changeset/fix-otp-setvalue-oncompleted.md
@@ -1,0 +1,5 @@
+---
+'@formwerk/core': patch
+---
+
+fix(otp): trigger onCompleted when setValue() fills all slots

--- a/packages/core/src/useOtpField/useOtpControl.ts
+++ b/packages/core/src/useOtpField/useOtpControl.ts
@@ -171,6 +171,7 @@ export function useOtpControl(_props: Reactivify<OtpControlProps, ExcludedProps>
   watch(model, value => {
     if (!value) {
       inputsState.value = withPrefix('', props.prefix).split('');
+      updateFieldValue();
       return;
     }
 
@@ -180,6 +181,7 @@ export function useOtpControl(_props: Reactivify<OtpControlProps, ExcludedProps>
     }
 
     inputsState.value = value.split('');
+    updateFieldValue();
   });
 
   function onPaste(event: ClipboardEvent) {

--- a/packages/core/src/useOtpField/useOtpField.spec.ts
+++ b/packages/core/src/useOtpField/useOtpField.spec.ts
@@ -1,6 +1,6 @@
 import { OtpFieldProps, useOtpField, OtpCell } from '.';
 import { DEFAULT_MASK, isValueAccepted } from './utils';
-import { Component, defineComponent } from 'vue';
+import { Component, defineComponent, nextTick } from 'vue';
 import { renderSetup, expectNoA11yViolations, appRender } from '@test-utils/index';
 import { page } from 'vitest/browser';
 
@@ -320,7 +320,8 @@ describe('useOtpField', () => {
       });
 
       setValue('12');
-      await expect.poll(() => onCompleted).not.toHaveBeenCalled();
+      await nextTick();
+      expect(onCompleted).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/useOtpField/useOtpField.spec.ts
+++ b/packages/core/src/useOtpField/useOtpField.spec.ts
@@ -302,6 +302,26 @@ describe('useOtpField', () => {
 
       await expect.poll(() => onCompleted.mock.calls[0]?.[0]).toBe('1234');
     });
+
+    test('calls onCompleted when setValue fills all slots', async () => {
+      const onCompleted = vi.fn();
+      const { setValue } = renderSetup(() => {
+        return useOtpField({ label: 'OTP Code', length: 4, onCompleted });
+      });
+
+      setValue('1234');
+      await expect.poll(() => onCompleted.mock.calls[0]?.[0]).toBe('1234');
+    });
+
+    test('does not call onCompleted when setValue partially fills slots', async () => {
+      const onCompleted = vi.fn();
+      const { setValue } = renderSetup(() => {
+        return useOtpField({ label: 'OTP Code', length: 4, onCompleted });
+      });
+
+      setValue('12');
+      await expect.poll(() => onCompleted).not.toHaveBeenCalled();
+    });
   });
 
   describe('keyboard navigation', () => {


### PR DESCRIPTION
## Summary

`setValue()` on an OTP field fills slots visually but never triggers `onCompleted`.

**Root cause**: The `watch(model)` handler in `useOtpControl.ts` updates `inputsState` but skips `updateFieldValue()` — the only function that checks completion and calls `props.onCompleted`.

**Fix**: Add `updateFieldValue()` calls after `inputsState.value` assignments in the watch handler, matching the existing pattern in `fillCells()`.

**Use case**: WebOTP API integration — `navigator.credentials.get({ otp: { transport: ['sms'] } })` resolves with a code that needs to fill slots AND trigger completion for auto-submit.

## Changes

- `packages/core/src/useOtpField/useOtpControl.ts` — Add `updateFieldValue()` in watch handler (2 lines)
- `packages/core/src/useOtpField/useOtpField.spec.ts` — Regression tests for setValue + onCompleted

## Test plan

- [x] New test: `setValue('1234')` on 4-slot field triggers `onCompleted('1234')`
- [x] New test: `setValue('12')` on 4-slot field does NOT trigger `onCompleted`
- [x] Existing tests pass (38/38)
- [x] Build, lint, format, typecheck pass

Closes #241