### PR TITLE
feat: added clearBtnProps for useComboBox and useSelect

### DIFF
--- a/.changeset/clear-rice-smash.md
+++ b/.changeset/clear-rice-smash.md
@@ -1,0 +1,5 @@
+---
+"@formwerk/core": minor
+---
+
+Added clearBtnProps for useComboBox and useSelect using new clearSelection of useListBox

--- a/packages/core/src/useComboBox/useComboBox.spec.ts
+++ b/packages/core/src/useComboBox/useComboBox.spec.ts
@@ -40,6 +40,7 @@ function createComboBox(fixedProps: Partial<ComboBoxProps<any, any>> = {}) {
         inputValue,
         errorMessage,
         selectedOption,
+        clearBtnProps,
       } = useComboBox(all, {
         filter: useDefaultFilter({ caseSensitive: false }).contains,
       });
@@ -63,6 +64,7 @@ function createComboBox(fixedProps: Partial<ComboBoxProps<any, any>> = {}) {
         errorMessage,
         options,
         selectedOption,
+        clearBtnProps,
       };
     },
     template: `
@@ -71,7 +73,8 @@ function createComboBox(fixedProps: Partial<ComboBoxProps<any, any>> = {}) {
 
           <div>
             <input v-bind="inputProps" />
-            <button v-bind="buttonProps">Toggle</button>
+            <button v-bind="buttonProps">toggle</button>
+            <button v-bind="clearBtnProps">clear</button>
           </div>
 
           <div v-bind="listBoxProps" popover>
@@ -109,12 +112,16 @@ function getInput() {
   return page.getByRole('combobox');
 }
 
-function getButton() {
-  return page.getByRole('button');
+function getToggleButton() {
+  return page.getByRole('button', { name: 'toggle' });
+}
+
+function getClearButton() {
+  return page.getByRole('button', { name: 'clear' });
 }
 
 describe('reset', () => {
-  test('should set inputValue on reset with values', async () => {
+  async function renderComboBox() {
     const MyComboBox = createComboBox();
     const options = [{ label: 'One' }, { label: 'Two' }, { label: 'Three' }];
 
@@ -139,7 +146,27 @@ describe('reset', () => {
       `,
     });
 
+    return MyComboBox;
+  }
+
+  test('should set inputValue on reset with values', async () => {
+    const MyComboBox = await renderComboBox();
+
     expect(MyComboBox.getExposedState().inputValue).toEqual('Two');
+  });
+
+  test('should be able to clear with button', async () => {
+    const MyComboBox = await renderComboBox();
+
+    expect(MyComboBox.getExposedState().inputValue).toEqual('Two');
+    expect(MyComboBox.getExposedState().selectedOption).toEqual({
+      id: expect.any(String),
+      label: 'Two',
+      value: { label: 'Two' },
+    });
+    await getClearButton().click();
+    expect(MyComboBox.getExposedState().inputValue).toEqual('');
+    expect(MyComboBox.getExposedState().selectedOption).toEqual(undefined);
   });
 });
 
@@ -164,7 +191,7 @@ describe('keyboard features', () => {
 
     return {
       async open() {
-        await getButton().click();
+        await getToggleButton().click();
         await expect.element(getInput()).toHaveAttribute('aria-expanded', 'true');
       },
     };
@@ -189,10 +216,10 @@ describe('keyboard features', () => {
   test('Clicking the button should toggle the listbox', async () => {
     await renderComboBox();
 
-    await getButton().click();
+    await getToggleButton().click();
     await expect.element(getInput()).toHaveAttribute('aria-expanded', 'true');
 
-    await getButton().click();
+    await getToggleButton().click();
     await expect.element(getInput()).toHaveAttribute('aria-expanded', 'false');
   });
 
@@ -450,7 +477,7 @@ describe('selection state', () => {
       `,
     });
 
-    await getButton().click();
+    await getToggleButton().click();
     await page.getByRole('option').nth(1).click();
 
     await expect
@@ -591,12 +618,12 @@ test('Should not accept new value on Enter when readonly', async () => {
   const input = getInput();
 
   // First select an option
-  await getButton().click();
+  await getToggleButton().click();
   await page.getByRole('option').nth(1).click();
   await expect.element(input).toHaveValue('Two');
 
   // Enable readonly
-  await getButton().click();
+  await getToggleButton().click();
 
   // Try to type something new
   await input.fill('Something new');

--- a/packages/core/src/useComboBox/useComboBoxControl.ts
+++ b/packages/core/src/useComboBox/useComboBoxControl.ts
@@ -46,6 +46,11 @@ export interface ComboBoxControlProps<TOption, TValue = TOption> extends Control
   openOnFocus?: boolean;
 
   /**
+   * The label text for the clear button.
+   */
+  clearButtonLabel?: string;
+
+  /**
    * Function to create a new option from the user input.
    */
   onNewValue?(value: string): Maybe<{ label: string; value: TValue }>;
@@ -90,6 +95,7 @@ export function useComboBoxControl<TOption, TValue = TOption>(
     focusNext,
     focusPrev,
     findFocusedOption,
+    clearSelection,
     renderedOptions,
     isEmpty,
     focusFirst: focusFirstOption,
@@ -322,6 +328,21 @@ export function useComboBoxControl<TOption, TValue = TOption>(
     watch(inputValue, debounce(filter.debounceMs, updateHiddenState));
   }
 
+  const clearBtnProps = computed(() => {
+    return {
+      tabindex: '-1',
+      type: 'button' as const,
+      ariaLabel: toValue(props.clearButtonLabel) ?? 'Clear search',
+      onClick() {
+        if (isReadOnly() || isDisabled.value) return;
+
+        clearSelection();
+        inputValue.value = '';
+        setModelValue(undefined);
+      },
+    };
+  });
+
   return {
     /**
      * The id of the input element.
@@ -370,6 +391,10 @@ export function useComboBoxControl<TOption, TValue = TOption>(
      * Whether the listbox is empty, i.e. no options are visible.
      */
     isListEmpty: isEmpty,
+    /**
+     * Props for the button element that clears the input and selection
+     */
+    clearBtnProps,
 
     /**
      * The field state.

--- a/packages/core/src/useListBox/useListBox.ts
+++ b/packages/core/src/useListBox/useListBox.ts
@@ -253,6 +253,10 @@ export function useListBox<TOption, TValue = TOption>(
     }
   }
 
+  function clearSelection() {
+    renderedOptions.value.filter(opt => opt.isSelected()).forEach(opt => opt.toggleSelected());
+  }
+
   const listBoxProps = useCaptureProps<ListBoxDomProps>(() => {
     const isMultiple = toValue(props.multiple);
     const labeledBy = toValue(props.labeledBy);
@@ -324,5 +328,6 @@ export function useListBox<TOption, TValue = TOption>(
     focusFirst,
     focusLast,
     findFocusedOption,
+    clearSelection,
   };
 }

--- a/packages/core/src/useSelect/useSelect.spec.ts
+++ b/packages/core/src/useSelect/useSelect.spec.ts
@@ -82,6 +82,7 @@ function createSelect() {
         selectedOptions,
         selectedOption,
         errorMessage,
+        clearBtnProps,
       } = useSelect(all);
 
       exposedSelectedOptions = selectedOptions;
@@ -106,6 +107,7 @@ function createSelect() {
         selectedOptions,
         selectedOption,
         errorMessage,
+        clearBtnProps,
       };
     },
     template: `
@@ -115,6 +117,8 @@ function createSelect() {
           <div v-bind="triggerProps">
             {{ fieldValue || 'Select here' }}
           </div>
+
+          <button v-bind="clearBtnProps">clear</button>
 
           <div v-bind="listBoxProps" popover>
             <slot>
@@ -563,6 +567,25 @@ describe('selection state', () => {
           value: { label: 'Three' },
         },
       ]);
+  });
+
+  test('clicking clear button should reset selected option', async () => {
+    const MySelect = createSelect();
+    const options = [{ label: 'One' }, { label: 'Two' }, { label: 'Three' }];
+
+    const sl = renderSelect(MySelect, options);
+
+    // Select first and third options
+    await sl.open();
+    await sl.select(0);
+
+    expect(MySelect.getExposedState().selectedOption).toEqual({
+      id: expect.any(String),
+      label: 'One',
+      value: { label: 'One' },
+    });
+    await page.getByRole('button', { name: 'clear' }).click();
+    expect(MySelect.getExposedState().selectedOption).toEqual(undefined);
   });
 });
 

--- a/packages/core/src/useSelect/useSelectControl.ts
+++ b/packages/core/src/useSelect/useSelectControl.ts
@@ -36,6 +36,11 @@ export interface SelectControlProps<TValue> extends ControlProps<Arrayable<TValu
    * The orientation of the listbox popup (vertical or horizontal).
    */
   orientation?: Orientation;
+
+  /**
+   * The label text for the clear button.
+   */
+  clearButtonLabel?: string;
 }
 
 export interface SelectTriggerDomProps extends AriaLabelableProps {
@@ -72,6 +77,7 @@ export function useSelectControl<TOption, TValue = TOption>(
     selectedOptions,
     listBoxId,
     findFocusedOption,
+    clearSelection,
   } = useListBox<TOption, TValue>({
     labeledBy: () => controller?.labelledByProps.value['aria-labelledby'],
     autofocusOnOpen: true,
@@ -241,6 +247,20 @@ export function useSelectControl<TOption, TValue = TOption>(
     };
   }, triggerEl);
 
+  const clearBtnProps = computed(() => {
+    return {
+      tabindex: '-1',
+      type: 'button' as const,
+      ariaLabel: toValue(props.clearButtonLabel) ?? 'Clear search',
+      onClick() {
+        if (!isMutable()) return;
+
+        clearSelection();
+        setModelValue(undefined);
+      },
+    };
+  });
+
   return {
     /**
      * The id of the input element.
@@ -278,6 +298,10 @@ export function useSelectControl<TOption, TValue = TOption>(
      * The currently selected options.
      */
     selectedOptions,
+    /**
+     * Props for the button element that clears the input and selection
+     */
+    clearBtnProps,
 
     /**
      * The field state.


### PR DESCRIPTION
There currently is no way to reset the modelValue for select and combo box fields. 

This PR adds `clearBtnProps` which can be used to build/provide a clear button. It is build upon a newly added `clearSelection` function provided by `useListBox`. This is also why i've only added this for `useSelect` and `useComboBox`.

My use-case: I was building a searchable combo box with async option items (i.e. not the traditional way where the popover is immediately opened by a click of a button on the side). After having selected an option there then was no way to "unselect" this option. Even when completely removing the value of the input element, the underlying option would still be selected. `selectedOption`  also is a dead-end since it is a `computed` (OT: it is marked as `Ref` in the documentation still).