### PR TITLE
refactor: rename `isValidated` to `isUserValidated`

### DIFF
--- a/.changeset/rename-isvalidated-to-isuservalidated.md
+++ b/.changeset/rename-isvalidated-to-isuservalidated.md
@@ -1,0 +1,5 @@
+---
+'@formwerk/core': minor
+---
+
+refactor: rename `isValidated` to `isUserValidated` to clarify that it tracks user-initiated validation

--- a/packages/core/src/useFormField/useFieldState.ts
+++ b/packages/core/src/useFormField/useFieldState.ts
@@ -43,7 +43,7 @@ export type FieldState<TValue> = {
   isDirty: Ref<boolean>;
   isBlurred: Ref<boolean>;
   isValid: Ref<boolean>;
-  isValidated: Ref<boolean>;
+  isUserValidated: Ref<boolean>;
   isDisabled: Ref<boolean>;
   errors: Ref<string[]>;
   errorMessage: Ref<string>;
@@ -57,7 +57,7 @@ export type FieldState<TValue> = {
   setTouched: (touched: boolean) => void;
   setBlurred: (blurred: boolean) => void;
   setErrors: (messages: Arrayable<string>) => void;
-  setIsValidated: (isValidated: boolean) => void;
+  setIsUserValidated: (isUserValidated: boolean) => void;
   form?: FormContext | null;
 };
 
@@ -75,7 +75,7 @@ export function useFieldState<TValue = unknown>(opts?: Partial<FieldStateInit<TV
   const { fieldValue, pathlessValue, setValue } = useFieldValue(getPath, form, initialValue);
   const { isTouched, pathlessTouched, setTouched } = useFieldTouched(getPath, form);
   const { isBlurred, pathlessBlurred, setBlurred } = useFieldBlurred(getPath, form);
-  const { isValidated, setIsValidated } = useFieldIsValidated();
+  const { isUserValidated, setIsUserValidated } = useFieldIsValidated();
 
   const { errors, setErrors, isValid, errorMessage, pathlessValidity, submitErrors, submitErrorMessage } =
     useFieldValidity(getPath, isDisabled, form);
@@ -136,7 +136,7 @@ export function useFieldState<TValue = unknown>(opts?: Partial<FieldStateInit<TV
     isBlurred: readonly(isBlurred) as Ref<boolean>,
     isDirty,
     isValid,
-    isValidated,
+    isUserValidated,
     errors,
     errorMessage,
     isDisabled,
@@ -148,7 +148,7 @@ export function useFieldState<TValue = unknown>(opts?: Partial<FieldStateInit<TV
     setTouched,
     setBlurred,
     setErrors,
-    setIsValidated,
+    setIsUserValidated,
     submitErrors,
     submitErrorMessage,
   };
@@ -171,7 +171,7 @@ export function useFieldState<TValue = unknown>(opts?: Partial<FieldStateInit<TV
   });
 
   form.onSubmitDone(() => {
-    setIsValidated(true);
+    setIsUserValidated(true);
   });
 
   tryOnScopeDispose(() => {
@@ -503,19 +503,19 @@ export function resolveFieldState<TValue = unknown, TInitialValue = TValue>(
 }
 
 /**
- * Tracks whether the field has been validated.
+ * Tracks whether the field has been validated by user interaction.
  * This is useful for determining whether to show validation errors or not.
  */
 export function useFieldIsValidated() {
   // Right now, there is no need to track it in a form.
-  const isValidated = ref(false);
+  const isUserValidated = ref(false);
 
-  function setIsValidated(value: boolean) {
-    isValidated.value = value;
+  function setIsUserValidated(value: boolean) {
+    isUserValidated.value = value;
   }
 
   return {
-    isValidated,
-    setIsValidated,
+    isUserValidated,
+    setIsUserValidated,
   };
 }

--- a/packages/core/src/useFormField/useFormField.spec.ts
+++ b/packages/core/src/useFormField/useFormField.spec.ts
@@ -295,27 +295,27 @@ test('validate warns and skips validation on a disabled field', async () => {
   consoleWarnSpy.mockRestore();
 });
 
-describe('isValidated state', () => {
-  test('field starts with isValidated as false', async () => {
-    const { isValidated } = renderSetup(() => {
+describe('isUserValidated state', () => {
+  test('field starts with isUserValidated as false', async () => {
+    const { isUserValidated } = renderSetup(() => {
       return useFormField({ label: 'Field', initialValue: 'bar' }).state;
     });
 
-    expect(isValidated.value).toBe(false);
+    expect(isUserValidated.value).toBe(false);
   });
 
-  test('isValidated remains false after programmatic validation without schema', async () => {
-    const { isValidated, validate } = renderSetup(() => {
+  test('isUserValidated remains false after programmatic validation without schema', async () => {
+    const { isUserValidated, validate } = renderSetup(() => {
       return useFormField({ label: 'Field', initialValue: 'bar' }).state;
     });
 
-    expect(isValidated.value).toBe(false);
+    expect(isUserValidated.value).toBe(false);
     await validate();
-    expect(isValidated.value).toBe(false); // Should remain false - programmatic validation
+    expect(isUserValidated.value).toBe(false); // Should remain false - programmatic validation
   });
 
-  test('isValidated remains false after programmatic validation with schema', async () => {
-    const { isValidated, validate } = renderSetup(() => {
+  test('isUserValidated remains false after programmatic validation with schema', async () => {
+    const { isUserValidated, validate } = renderSetup(() => {
       return useFormField({
         label: 'Field',
         initialValue: 'bar',
@@ -325,13 +325,13 @@ describe('isValidated state', () => {
       }).state;
     });
 
-    expect(isValidated.value).toBe(false);
+    expect(isUserValidated.value).toBe(false);
     await validate();
-    expect(isValidated.value).toBe(false); // Should remain false - programmatic validation
+    expect(isUserValidated.value).toBe(false); // Should remain false - programmatic validation
   });
 
-  test('isValidated remains false after programmatic validation with errors', async () => {
-    const { isValidated, validate } = renderSetup(() => {
+  test('isUserValidated remains false after programmatic validation with errors', async () => {
+    const { isUserValidated, validate } = renderSetup(() => {
       return useFormField({
         label: 'Field',
         initialValue: '',
@@ -341,24 +341,24 @@ describe('isValidated state', () => {
       }).state;
     });
 
-    expect(isValidated.value).toBe(false);
+    expect(isUserValidated.value).toBe(false);
     await validate(true);
-    expect(isValidated.value).toBe(false); // Should remain false - programmatic validation
+    expect(isUserValidated.value).toBe(false); // Should remain false - programmatic validation
   });
 
-  test('isValidated can be set manually', async () => {
-    const { isValidated, setIsValidated } = renderSetup(() => {
+  test('isUserValidated can be set manually', async () => {
+    const { isUserValidated, setIsUserValidated } = renderSetup(() => {
       return useFormField({ label: 'Field', initialValue: 'bar' }).state;
     });
 
-    expect(isValidated.value).toBe(false);
-    setIsValidated(true);
-    expect(isValidated.value).toBe(true);
-    setIsValidated(false);
-    expect(isValidated.value).toBe(false);
+    expect(isUserValidated.value).toBe(false);
+    setIsUserValidated(true);
+    expect(isUserValidated.value).toBe(true);
+    setIsUserValidated(false);
+    expect(isUserValidated.value).toBe(false);
   });
 
-  test('isValidated becomes true after form submit attempt', async () => {
+  test('isUserValidated becomes true after form submit attempt', async () => {
     const { form, field } = renderSetup(
       () => {
         const form = useForm({
@@ -380,32 +380,32 @@ describe('isValidated state', () => {
       },
     );
 
-    expect(field.state.isValidated.value).toBe(false);
+    expect(field.state.isUserValidated.value).toBe(false);
 
     // Submit attempt is a user interaction
     const handleSubmit = form.handleSubmit(async () => {});
     await handleSubmit();
 
-    expect(field.state.isValidated.value).toBe(true);
+    expect(field.state.isUserValidated.value).toBe(true);
   });
 
-  test('isValidated is independent for pathless fields', async () => {
+  test('isUserValidated is independent for pathless fields', async () => {
     const { field1, field2 } = renderSetup(() => {
       const field1 = useFormField({ label: 'Field1', initialValue: 'bar' });
       const field2 = useFormField({ label: 'Field2', initialValue: 'baz' });
       return { field1, field2 };
     });
 
-    expect(field1.state.isValidated.value).toBe(false);
-    expect(field2.state.isValidated.value).toBe(false);
+    expect(field1.state.isUserValidated.value).toBe(false);
+    expect(field2.state.isUserValidated.value).toBe(false);
 
-    // Manually set isValidated (simulating user interaction)
-    field1.state.setIsValidated(true);
-    expect(field1.state.isValidated.value).toBe(true);
-    expect(field2.state.isValidated.value).toBe(false);
+    // Manually set isUserValidated (simulating user interaction)
+    field1.state.setIsUserValidated(true);
+    expect(field1.state.isUserValidated.value).toBe(true);
+    expect(field2.state.isUserValidated.value).toBe(false);
 
-    field2.state.setIsValidated(true);
-    expect(field1.state.isValidated.value).toBe(true);
-    expect(field2.state.isValidated.value).toBe(true);
+    field2.state.setIsUserValidated(true);
+    expect(field1.state.isUserValidated.value).toBe(true);
+    expect(field2.state.isUserValidated.value).toBe(true);
   });
 });

--- a/packages/core/src/useFormField/useFormField.ts
+++ b/packages/core/src/useFormField/useFormField.ts
@@ -116,9 +116,9 @@ export type ExposedField<TValue> = {
   isValid: Ref<boolean>;
 
   /**
-   * Whether the field is validated, used to determine whether to show validation errors or not.
+   * Whether the field has been validated by user interaction (blur, change, or submit), used to determine whether to show validation errors or not.
    */
-  isValidated: Ref<boolean>;
+  isUserValidated: Ref<boolean>;
 
   /**
    * Whether the field is disabled.
@@ -141,9 +141,9 @@ export type ExposedField<TValue> = {
   setBlurred: (blurred: boolean) => void;
 
   /**
-   * Sets the validated state for the field.
+   * Sets the user-validated state for the field.
    */
-  setIsValidated: (isValidated: boolean) => void;
+  setIsUserValidated: (isUserValidated: boolean) => void;
 
   /**
    * Sets the value for the field.
@@ -186,7 +186,7 @@ export function exposeField<TReturns extends object, TValue>(
     isTouched: field.state.isTouched,
     isBlurred: field.state.isBlurred,
     isValid: field.state.isValid,
-    isValidated: field.state.isValidated,
+    isUserValidated: field.state.isUserValidated,
     isDisabled: field.state.isDisabled,
     labelProps: field.labelProps,
     descriptionProps: field.descriptionProps,
@@ -202,7 +202,7 @@ export function exposeField<TReturns extends object, TValue>(
       : field.state.setErrors,
     setTouched: field.state.setTouched,
     setBlurred: field.state.setBlurred,
-    setIsValidated: field.state.setIsValidated,
+    setIsUserValidated: field.state.setIsUserValidated,
     setValue: field.state.setValue,
     validate: (mutate = true) => field.state.validate(mutate),
     ...obj,

--- a/packages/core/src/validation/useInputValidity.spec.ts
+++ b/packages/core/src/validation/useInputValidity.spec.ts
@@ -148,7 +148,7 @@ test('events can be reactive', async () => {
   await expect.element(page.getByTestId('err')).toHaveTextContent('');
 });
 
-describe('isValidated tracking', () => {
+describe('isUserValidated tracking', () => {
   test('does not flash error on blur when field becomes valid (issue #203)', async () => {
     const input = ref<HTMLInputElement>();
     let field!: FieldState<any>;
@@ -161,7 +161,7 @@ describe('isValidated tracking', () => {
         // This mimics the user pattern: only show errors after validation AND blur
         const displayError = computed(() => {
           // Don't show error until validated (prevents initial mount validation from showing)
-          if (!field.isValidated.value) return '';
+          if (!field.isUserValidated.value) return '';
           // Don't show error until blurred (prevents showing while typing)
           if (!field.isBlurred.value) return '';
           return field.errorMessage.value;
@@ -186,8 +186,8 @@ describe('isValidated tracking', () => {
       .element(page.getByTestId('raw-err'))
       .toHaveTextContent(/Constraints not satisfied|Please fill out this field\.?/);
 
-    // isValidated should still be false after mount (not user interaction)
-    expect(field.isValidated.value).toBe(false);
+    // isUserValidated should still be false after mount (not user interaction)
+    expect(field.isUserValidated.value).toBe(false);
 
     // User types a valid value
     await page.getByTestId('input').fill('valid value');
@@ -202,11 +202,11 @@ describe('isValidated tracking', () => {
     await expect.element(page.getByTestId('display-err')).toHaveTextContent('');
     await expect.element(page.getByTestId('raw-err')).toHaveTextContent('');
 
-    // Now isValidated should be true (user interaction)
-    expect(field.isValidated.value).toBe(true);
+    // Now isUserValidated should be true (user interaction)
+    expect(field.isUserValidated.value).toBe(true);
   });
 
-  test('isValidated remains false after mount validation', async () => {
+  test('isUserValidated remains false after mount validation', async () => {
     const input = ref<HTMLInputElement>();
     let field!: FieldState<any>;
 
@@ -215,22 +215,22 @@ describe('isValidated tracking', () => {
         field = useFormField().state;
         useInputValidity({ inputEl: input, field });
 
-        return { input, isValidated: field.isValidated };
+        return { input, isUserValidated: field.isUserValidated };
       },
       template: `
         <form>
           <input ref="input" data-testid="input" required />
-          <span data-testid="validated">{{ isValidated }}</span>
+          <span data-testid="validated">{{ isUserValidated }}</span>
         </form>
       `,
     });
 
-    // After mount, validation runs but isValidated should remain false
+    // After mount, validation runs but isUserValidated should remain false
     await expect.element(page.getByTestId('validated')).toHaveTextContent('false');
-    expect(field.isValidated.value).toBe(false);
+    expect(field.isUserValidated.value).toBe(false);
   });
 
-  test('isValidated becomes true after blur event triggers validation', async () => {
+  test('isUserValidated becomes true after blur event triggers validation', async () => {
     const input = ref<HTMLInputElement>();
     let field!: FieldState<any>;
 
@@ -239,29 +239,29 @@ describe('isValidated tracking', () => {
         field = useFormField().state;
         useInputValidity({ inputEl: input, field });
 
-        return { input, isValidated: field.isValidated };
+        return { input, isUserValidated: field.isUserValidated };
       },
       template: `
         <form>
           <input ref="input" data-testid="input" required />
-          <span data-testid="validated">{{ isValidated }}</span>
+          <span data-testid="validated">{{ isUserValidated }}</span>
         </form>
       `,
     });
 
     // Initially false
-    expect(field.isValidated.value).toBe(false);
+    expect(field.isUserValidated.value).toBe(false);
 
     // User blurs the field (user interaction)
     await page.getByTestId('input').click();
     await userEvent.tab();
     await expect.element(page.getByTestId('validated')).toHaveTextContent('true');
 
-    // Now isValidated should be true
-    expect(field.isValidated.value).toBe(true);
+    // Now isUserValidated should be true
+    expect(field.isUserValidated.value).toBe(true);
   });
 
-  test('isValidated is set to true after change event triggers validation', async () => {
+  test('isUserValidated is set to true after change event triggers validation', async () => {
     const input = ref<HTMLInputElement>();
     let field!: FieldState<any>;
 
@@ -270,35 +270,35 @@ describe('isValidated tracking', () => {
         field = useFormField().state;
         useInputValidity({ inputEl: input, field });
 
-        return { input, isValidated: field.isValidated };
+        return { input, isUserValidated: field.isUserValidated };
       },
       template: `
         <form>
           <input ref="input" data-testid="input" required />
-          <span data-testid="validated">{{ isValidated }}</span>
+          <span data-testid="validated">{{ isUserValidated }}</span>
         </form>
       `,
     });
 
     // Initially false even after mount
-    await expect.poll(() => field.isValidated.value).toBe(false);
+    await expect.poll(() => field.isUserValidated.value).toBe(false);
 
     // User triggers change event (user interaction)
     await page.getByTestId('input').fill('test');
     await userEvent.tab();
-    await expect.poll(() => field.isValidated.value).toBe(true);
+    await expect.poll(() => field.isUserValidated.value).toBe(true);
 
     // Can be manually reset
-    field.setIsValidated(false);
-    await expect.poll(() => field.isValidated.value).toBe(false);
+    field.setIsUserValidated(false);
+    await expect.poll(() => field.isUserValidated.value).toBe(false);
 
     // And set again by user interaction
     await page.getByTestId('input').fill('test2');
     await userEvent.tab();
-    await expect.poll(() => field.isValidated.value).toBe(true);
+    await expect.poll(() => field.isUserValidated.value).toBe(true);
   });
 
-  test('isValidated helps prevent displaying initial validation errors', async () => {
+  test('isUserValidated helps prevent displaying initial validation errors', async () => {
     const input = ref<HTMLInputElement>();
     let field!: FieldState<any>;
 
@@ -309,7 +309,7 @@ describe('isValidated tracking', () => {
 
         // Computed that mimics user code for conditional error display
         const displayError = computed(() => {
-          return field.isValidated.value ? field.errorMessage.value : '';
+          return field.isUserValidated.value ? field.errorMessage.value : '';
         });
 
         return { input, displayError, errorMessage: field.errorMessage };
@@ -328,25 +328,25 @@ describe('isValidated tracking', () => {
       .element(page.getByTestId('raw-err'))
       .toHaveTextContent(/Constraints not satisfied|Please fill out this field\.?/);
 
-    // But displayError should NOT show because isValidated is still false (mount is not user interaction)
+    // But displayError should NOT show because isUserValidated is still false (mount is not user interaction)
     await expect.element(page.getByTestId('err')).toHaveTextContent('');
-    await expect.poll(() => field.isValidated.value).toBe(false);
+    await expect.poll(() => field.isUserValidated.value).toBe(false);
 
-    // User interaction (blur) sets isValidated to true (field is still empty/invalid)
+    // User interaction (blur) sets isUserValidated to true (field is still empty/invalid)
     await page.getByTestId('input').click();
     await userEvent.tab();
     await expect
       .element(page.getByTestId('err'))
       .toHaveTextContent(/Constraints not satisfied|Please fill out this field\.?/);
 
-    // Now errors should show because isValidated is true
-    await expect.poll(() => field.isValidated.value).toBe(true);
+    // Now errors should show because isUserValidated is true
+    await expect.poll(() => field.isUserValidated.value).toBe(true);
     await expect
       .element(page.getByTestId('err'))
       .toHaveTextContent(/Constraints not satisfied|Please fill out this field\.?/);
   });
 
-  test('isValidated with blur event allows showing errors after user interaction', async () => {
+  test('isUserValidated with blur event allows showing errors after user interaction', async () => {
     const input = ref<HTMLInputElement>();
     let field!: FieldState<any>;
 
@@ -355,9 +355,9 @@ describe('isValidated tracking', () => {
         field = useFormField().state;
         useInputValidity({ inputEl: input, field, events: ['blur'] });
 
-        // Computed that only shows errors after blur (isValidated)
+        // Computed that only shows errors after blur (isUserValidated)
         const displayError = computed(() => {
-          return field.isValidated.value && field.isBlurred.value ? field.errorMessage.value : '';
+          return field.isUserValidated.value && field.isBlurred.value ? field.errorMessage.value : '';
         });
 
         return { input, displayError };
@@ -380,8 +380,8 @@ describe('isValidated tracking', () => {
     // Manually set blurred state (in real usage, this would be done by the field's blur handler)
     field.setBlurred(true);
 
-    // The displayError computed requires both isValidated AND isBlurred to be true
-    await expect.poll(() => field.isValidated.value).toBe(true);
+    // The displayError computed requires both isUserValidated AND isBlurred to be true
+    await expect.poll(() => field.isUserValidated.value).toBe(true);
     await expect.poll(() => field.isBlurred.value).toBe(true);
     await expect
       .element(page.getByTestId('err'))

--- a/packages/core/src/validation/useInputValidity.ts
+++ b/packages/core/src/validation/useInputValidity.ts
@@ -105,7 +105,7 @@ export function useInputValidity(opts: InputValidityOptions) {
     await nextTick();
     await _updateValidity();
     nextTick(() => {
-      opts.field.setIsValidated(true);
+      opts.field.setIsUserValidated(true);
     });
   }
 
@@ -134,7 +134,7 @@ export function useInputValidity(opts: InputValidityOptions) {
       validateNative(true);
       if (!isHtmlValidationDisabled()) {
         nextTick(() => {
-          opts.field.setIsValidated(true);
+          opts.field.setIsUserValidated(true);
         });
       }
     });
@@ -146,7 +146,7 @@ export function useInputValidity(opts: InputValidityOptions) {
       await updateValidity();
       // Field value change is user interaction - mark as validated
       nextTick(() => {
-        opts.field.setIsValidated(true);
+        opts.field.setIsUserValidated(true);
       });
     });
   }


### PR DESCRIPTION
## Summary
- Renames `isValidated` to `isUserValidated` and `setIsValidated` to `setIsUserValidated` across the field state API
- Clarifies that this state tracks **user-initiated validation** (blur, change, or submit), not programmatic `validate()` calls
- Includes changeset for minor version bump

Closes #243

## Test plan
- [x] All existing tests updated and passing (lint-staged ran them on commit)
- [x] Build succeeds
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)